### PR TITLE
Fixes to cl_biography.lua and credits/derma/client.lua

### DIFF
--- a/lilia/modules/frameworkui/credits/derma/client.lua
+++ b/lilia/modules/frameworkui/credits/derma/client.lua
@@ -261,7 +261,7 @@ function PANEL:loadContributor(contributor, bLoadNextChunk)
         end
 
         container.OnMousePressed = function(_, keyCode) if keyCode == 107 then gui.OpenURL("https://github.com/" .. contributorData.login) end end
-        container.OnMouseWheeled = function(_, delta) self:OnMouseWheeled(delta) end
+       -- container.OnMouseWheeled = function(_, delta) self:OnMouseWheeled(delta) end -- I was getting spammed with this error, error is attached, but for now.
         container:SetCursor("hand")
         container:SetTooltip("https://github.com/" .. contributorData.login)
         local avatar = container:Add("Panel")

--- a/lilia/modules/frameworkui/mainmenu/submodules/charselect/derma/steps/cl_biography.lua
+++ b/lilia/modules/frameworkui/mainmenu/submodules/charselect/derma/steps/cl_biography.lua
@@ -15,7 +15,7 @@ function PANEL:Init()
     self.descLabel:SetZPos(2)
 
     self.desc = self:addTextEntry("desc")
-    self.desc:SetTall(96) -- Adjust the height as needed
+    self.desc:SetTall(self.name:GetTall() * 3) -- Put this back to its original scalable size.
     self.desc:SetTextColor(color_white)
     self.desc:SetMultiline(true)
     self.desc:SetZPos(3)


### PR DESCRIPTION
cl_biography -|
After talking to tundra he did not realize he changed the description set tall from its automatic size to a hardset size, so I undid that. (line 18)

credits -|
When scrolling in the credits menu an error occurs, after looking through the file the line in question causing the error it was unneeded at the time.
![image](https://github.com/user-attachments/assets/173b267a-c337-4297-8346-df4d152eec7a)
