### PR TITLE
Changed game.CleanUpMap()

### DIFF
--- a/lilia/gamemode/init.lua
+++ b/lilia/gamemode/init.lua
@@ -34,7 +34,7 @@ end)
 cvars.AddChangeCallback("sbox_persist", function(_, old, new)
     timer.Create("sbox_persist_change_timer", 1, 1, function()
         hook.Run("PersistenceSave", old)
-        game.CleanUpMap()
+        game.CleanUpMap( false, nil, function() end )
         if new == "" then return end
         hook.Run("PersistenceLoad", new)
     end)


### PR DESCRIPTION
Helps when resetting heavy maps.

From my experience when resetting maps on SCPRP it tends to have issues recreating all entities.

-\/ ChatGPT explaining better cause my brain hurts.
Using game.CleanUpMap(false, nil, function() end) can help fix the "too many edicts" error by performing a comprehensive cleanup of the map, removing a wide range of non-essential entities. This reduces the total number of active entities (edicts) in the game, which can alleviate the issue of exceeding the maximum allowed edicts and improve server performance.