### PR TITLE
Inventory QoL and Fix to lia.keybind.add

### DIFF
--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -113,6 +113,8 @@ local KeybindKeys = {
 }
 
 function lia.keybind.add( k, d, cb, rcb )
+	if not IsFirstTimePredicted() then return end
+
 	local c = isstring( k ) and KeybindKeys[ string.lower( k ) ] or k
 	if not c then return end
 	lia.keybind.stored[ d ] = lia.keybind.stored[ d ] or {}

--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -113,8 +113,6 @@ local KeybindKeys = {
 }
 
 function lia.keybind.add( k, d, cb, rcb )
-	if not IsFirstTimePredicted() then return end
-
 	local c = isstring( k ) and KeybindKeys[ string.lower( k ) ] or k
 	if not c then return end
 	lia.keybind.stored[ d ] = lia.keybind.stored[ d ] or {}

--- a/modules/core/administration/libraries/client.lua
+++ b/modules/core/administration/libraries/client.lua
@@ -169,4 +169,4 @@ function MODULE:LoadFonts( font )
 	} )
 end
 
-lia.keybind.add( KEY_NONE, "Admin Mode", function() lia.command.send( "adminmode" ) end )
+lia.keybind.add( KEY_NONE, "Admin Mode", function() if not IsFirstTimePredicted() then return end lia.command.send( "adminmode" ) end )

--- a/modules/core/interactionmenu/libraries/client.lua
+++ b/modules/core/interactionmenu/libraries/client.lua
@@ -169,8 +169,10 @@ function MODULE:OpenLocalPIM()
 end
 
 lia.keybind.add( KEY_TAB, "Interaction Menu", function()
+	if not IsFirstTimePredicted() then return end
+
 	local client = LocalPlayer()
 	if client:getChar() and MODULE:CheckPossibilities() then MODULE:OpenPIM() end
 end )
 
-lia.keybind.add( KEY_G, "Personal Actions", function() MODULE:OpenLocalPIM() end )
+lia.keybind.add( KEY_G, "Personal Actions", function() if not IsFirstTimePredicted() then return end MODULE:OpenLocalPIM() end )

--- a/modules/frameworkui/f1menu/derma/cl_menu.lua
+++ b/modules/frameworkui/f1menu/derma/cl_menu.lua
@@ -111,8 +111,10 @@ function PANEL:Init()
 end
 
 function PANEL:OnKeyCodePressed( key )
+	local invkey = lia.keybind.get( "Open Inventory", KEY_I )
 	self.noAnchor = CurTime() + 0.5
 	if key == KEY_F1 then self:remove() end
+	if key == invkey then self:remove() end
 end
 
 function PANEL:Update()

--- a/modules/frameworkui/f1menu/libraries/client.lua
+++ b/modules/frameworkui/f1menu/libraries/client.lua
@@ -133,6 +133,8 @@ function MODULE:CanDisplayCharInfo( name )
 end
 
 lia.keybind.add( KEY_I, "Open Inventory", function()
+	if not IsFirstTimePredicted() then return end
+	
 	local f1Menu = vgui.Create( "liaMenu" )
 	f1Menu:setActiveTab( "inv" )
 end )


### PR DESCRIPTION
Inventory QoL and Fix to lia.keybind.add

QoL: Inventory Key Opens and Closes the F1 Menu
Bug Fix: lia.keybind.add runs 5 times per key press; made a IsFirstTimePredicted() hook for each keybind