### PR TITLE
Add pac library docs

### DIFF
--- a/gamemode/core/libraries/notice.lua
+++ b/gamemode/core/libraries/notice.lua
@@ -1,4 +1,20 @@
-﻿if SERVER then
+if SERVER then
+    --[[
+        lia.notices.notify(message, recipient)
+
+        Description:
+            Sends a notification message to a specific player or all players.
+
+        Parameters:
+            message (string) – Message text to send.
+            recipient (Player|nil) – Target player, or nil to broadcast.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function lia.notices.notify(message, recipient)
         net.Start("liaNotify")
         net.WriteString(message)
@@ -9,6 +25,23 @@
         end
     end
 
+    --[[
+        lia.notices.notifyLocalized(key, recipient, ...)
+
+        Description:
+            Sends a localized notification to a player or all players.
+
+        Parameters:
+            key (string) – Localization key.
+            recipient (Player|nil) – Target player or nil to broadcast.
+            ... (any) – Formatting arguments for the localization string.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function lia.notices.notifyLocalized(key, recipient, ...)
         local args = {...}
         if recipient and type(recipient) ~= "Player" then
@@ -37,6 +70,21 @@ else
         end
     end
 
+    --[[
+        lia.notices.notify(message)
+
+        Description:
+            Creates a visual notification panel on the client's screen.
+
+        Parameters:
+            message (string) – Message text to display.
+
+        Realm:
+            Client
+
+        Returns:
+            None
+    ]]
     function lia.notices.notify(message)
         local notice = vgui.Create("liaNotice")
         local i = table.insert(lia.notices, notice)
@@ -66,10 +114,41 @@ else
         MsgN(message)
     end
 
+    --[[
+        lia.notices.notifyLocalized(key, ...)
+
+        Description:
+            Displays a localized notification on the client's screen.
+
+        Parameters:
+            key (string) – Localization key.
+            ... (any) – Formatting arguments for the localization string.
+
+        Realm:
+            Client
+
+        Returns:
+            None
+    ]]
     function lia.notices.notifyLocalized(key, ...)
         lia.notices.notify(L(key, ...))
     end
 
+    --[[
+        notification.AddLegacy(text)
+
+        Description:
+            Overrides Garry's Mod legacy notification to use lia.notices.
+
+        Parameters:
+            text (string) – Message text to display.
+
+        Realm:
+            Client
+
+        Returns:
+            None
+    ]]
     function notification.AddLegacy(text)
         lia.notices.notify(tostring(text))
     end

--- a/gamemode/core/libraries/pac.lua
+++ b/gamemode/core/libraries/pac.lua
@@ -1,14 +1,59 @@
-﻿local playerMeta = FindMetaTable("Entity")
+local playerMeta = FindMetaTable("Entity")
+--[[
+    Entity:getParts()
+
+    Description:
+        Retrieves the PAC3 parts currently equipped on this player.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        parts (table) – Table of equipped part IDs.
+]]
 function playerMeta:getParts()
     return self:getNetVar("parts", {})
 end
 
 if SERVER then
+    --[[
+        Entity:syncParts()
+
+        Description:
+            Sends the player's equipped PAC3 parts to the client.
+
+        Parameters:
+            None
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function playerMeta:syncParts()
         net.Start("liaPACSync")
         net.Send(self)
     end
 
+    --[[
+        Entity:addPart(partID)
+
+        Description:
+            Adds a PAC3 part to the player and broadcasts the change.
+
+        Parameters:
+            partID (string) – Identifier of the part to add.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function playerMeta:addPart(partID)
         if self:getParts()[partID] then return end
         net.Start("liaPACPartAdd")
@@ -20,6 +65,21 @@ if SERVER then
         self:setNetVar("parts", parts)
     end
 
+    --[[
+        Entity:removePart(partID)
+
+        Description:
+            Removes a PAC3 part from the player and broadcasts the change.
+
+        Parameters:
+            partID (string) – Identifier of the part to remove.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function playerMeta:removePart(partID)
         net.Start("liaPACPartRemove")
         net.WriteEntity(self)
@@ -30,6 +90,21 @@ if SERVER then
         self:setNetVar("parts", parts)
     end
 
+    --[[
+        Entity:resetParts()
+
+        Description:
+            Clears all PAC3 parts from the player and notifies clients.
+
+        Parameters:
+            None
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     function playerMeta:resetParts()
         net.Start("liaPACPartReset")
         net.WriteEntity(self)
@@ -161,6 +236,19 @@ else
     end)
 end
 
+--[[
+    net.Receive("liaPACSync")
+
+    Description:
+        Attaches all currently equipped PAC3 parts from every player when
+        the local client requests synchronization.
+
+    Realm:
+        Client
+
+    Returns:
+        None
+]]
 net.Receive("liaPACSync", function()
     for _, client in player.Iterator() do
         for id in pairs(client:getParts()) do
@@ -169,6 +257,18 @@ net.Receive("liaPACSync", function()
     end
 end)
 
+--[[
+    net.Receive("liaPACPartAdd")
+
+    Description:
+        Receives a part addition for a player and attaches it locally.
+
+    Realm:
+        Client
+
+    Returns:
+        None
+]]
 net.Receive("liaPACPartAdd", function()
     local client = net.ReadEntity()
     local id = net.ReadString()
@@ -176,6 +276,18 @@ net.Receive("liaPACPartAdd", function()
     hook.Run("attachPart", client, id)
 end)
 
+--[[
+    net.Receive("liaPACPartRemove")
+
+    Description:
+        Handles the removal of a PAC3 part from a player on the client.
+
+    Realm:
+        Client
+
+    Returns:
+        None
+]]
 net.Receive("liaPACPartRemove", function()
     local client = net.ReadEntity()
     local id = net.ReadString()
@@ -183,6 +295,18 @@ net.Receive("liaPACPartRemove", function()
     hook.Run("removePart", client, id)
 end)
 
+--[[
+    net.Receive("liaPACPartReset")
+
+    Description:
+        Clears all PAC3 parts from a player on the client side.
+
+    Realm:
+        Client
+
+    Returns:
+        None
+]]
 net.Receive("liaPACPartReset", function()
     local client = net.ReadEntity()
     if not IsValid(client) or not client.RemovePACPart then return end
@@ -195,6 +319,15 @@ net.Receive("liaPACPartReset", function()
     end
 end)
 
+--[[
+    fixpac command
+
+    Description:
+        Clears cached PAC3 data on the client to resolve issues.
+
+    Realm:
+        Server
+]]
 lia.command.add("fixpac", {
     adminOnly = false,
     desc = L("pacFixCommandDesc"),
@@ -212,6 +345,15 @@ lia.command.add("fixpac", {
     end
 })
 
+--[[
+    pacenable command
+
+    Description:
+        Enables PAC3 for the calling player.
+
+    Realm:
+        Server
+]]
 lia.command.add("pacenable", {
     adminOnly = false,
     desc = L("pacEnableCommandDesc"),
@@ -221,6 +363,15 @@ lia.command.add("pacenable", {
     end
 })
 
+--[[
+    pacdisable command
+
+    Description:
+        Disables PAC3 for the calling player.
+
+    Realm:
+        Server
+]]
 lia.command.add("pacdisable", {
     adminOnly = false,
     desc = L("pacDisableCommandDesc"),

--- a/gamemode/core/libraries/prone.lua
+++ b/gamemode/core/libraries/prone.lua
@@ -1,2 +1,41 @@
-﻿hook.Add("DoPlayerDeath", "PRONE_DoPlayerDeath", function(client) if client:IsProne() then prone.Exit(client) end end)
-hook.Add("PlayerLoadedChar", "PRONE_PlayerLoadedChar", function(client) if client:IsProne() then prone.Exit(client) end end)
+--[[
+    DoPlayerDeath hook
+
+    Description:
+        Exits the player's prone state when they die.
+
+    Parameters:
+        client (Player) – Player entity that died.
+
+    Realm:
+        Server
+
+    Returns:
+        None
+]]
+hook.Add("DoPlayerDeath", "PRONE_DoPlayerDeath", function(client)
+    if client:IsProne() then
+        prone.Exit(client)
+    end
+end)
+
+--[[
+    PlayerLoadedChar hook
+
+    Description:
+        Ensures the player is no longer prone when their character loads.
+
+    Parameters:
+        client (Player) – Player entity whose character finished loading.
+
+    Realm:
+        Server
+
+    Returns:
+        None
+]]
+hook.Add("PlayerLoadedChar", "PRONE_PlayerLoadedChar", function(client)
+    if client:IsProne() then
+        prone.Exit(client)
+    end
+end)

--- a/gamemode/core/libraries/sam.lua
+++ b/gamemode/core/libraries/sam.lua
@@ -1,4 +1,4 @@
-﻿hook.Add("InitializedModules", "SAM_InitializedModules", function()
+hook.Add("InitializedModules", "SAM_InitializedModules", function()
     for _, commandInfo in ipairs(sam.command.get_commands()) do
         local customSyntax = ""
         for _, argInfo in ipairs(commandInfo.args) do
@@ -18,6 +18,25 @@
     end
 end)
 
+--[[
+    hook.Add("SAM.CanRunCommand")
+
+    Description:
+        Prevents players without the proper staff permissions from
+        running SAM commands.
+
+    Parameters:
+        client (Player) – The player executing the command.
+        _ (any) – Unused.
+        _ (any) – Unused.
+        cmd (table) – SAM command table with permission info.
+
+    Realm:
+        Server
+
+    Returns:
+        allowed (boolean) – True if the player is permitted to run the command.
+]]
 hook.Add("SAM.CanRunCommand", "Check4Staff", function(client, _, _, cmd)
     if type(client) ~= "Player" then return true end
     if lia.config.get("SAMEnforceStaff", false) then
@@ -36,6 +55,22 @@ hook.Add("SAM.CanRunCommand", "Check4Staff", function(client, _, _, cmd)
 end)
 
 if SERVER then
+    --[[
+        sam.command.new("blind")
+
+        Description:
+            Temporarily blinds the specified target players.
+
+        Parameters:
+            client (Player) – Command executor.
+            targets (table) – Players to blind.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     sam.command.new("blind"):SetPermission("blind", "superadmin"):AddArg("player"):Help("Blinds the Players"):OnExecute(function(client, targets)
         for i = 1, #targets do
             local target = targets[i]
@@ -52,6 +87,22 @@ if SERVER then
         end
     end):End()
 
+    --[[
+        sam.command.new("unblind")
+
+        Description:
+            Removes the blind effect from the specified target players.
+
+        Parameters:
+            client (Player) – Command executor.
+            targets (table) – Players to unblind.
+
+        Realm:
+            Server
+
+        Returns:
+            None
+    ]]
     sam.command.new("unblind"):SetPermission("blind", "superadmin"):AddArg("player"):Help("Unblinds the Players"):OnExecute(function(client, targets)
         for i = 1, #targets do
             local target = targets[i]
@@ -70,6 +121,16 @@ if SERVER then
 
     hook.Add("InitializedModules", "SAM_InitializedModules", function() hook.Remove("PlayerSay", "SAM.Chat.Asay") end)
 else
+    --[[
+        net.Receive("sam_blind")
+
+        Description:
+            Displays or removes a fullscreen black overlay when a player
+            is blinded by the SAM command.
+
+        Realm:
+            Client
+    ]]
     net.Receive("sam_blind", function()
         local enabled = net.ReadBool()
         if enabled then
@@ -85,6 +146,23 @@ local function CanReadNotifications(client)
     return client:hasPrivilege("Staff Permissions - Can See SAM Notifications") or client:isStaffOnDuty()
 end
 
+--[[
+    sam.player.send_message(client, msg, tbl)
+
+    Description:
+        Sends a formatted SAM chat message to the given player or the console.
+
+    Parameters:
+        client (Player|nil) – Target player or nil to print in the server console.
+        msg (string) – Message template.
+        tbl (table|nil) – Formatting arguments.
+
+    Realm:
+        Shared
+
+    Returns:
+        None
+]]
 function sam.player.send_message(client, msg, tbl)
     if SERVER then
         if sam.isconsole(client) then
@@ -103,6 +181,15 @@ function sam.player.send_message(client, msg, tbl)
     end
 end
 
+--[[
+    cleardecals command
+
+    Description:
+        Clears all decals from every connected player's screen.
+
+    Realm:
+        Server
+]]
 lia.command.add("cleardecals", {
     adminOnly = true,
     privilege = "Clear Decals",
@@ -114,6 +201,15 @@ lia.command.add("cleardecals", {
     end
 })
 
+--[[
+    playtime command
+
+    Description:
+        Prints the calling player's accumulated playtime.
+
+    Realm:
+        Server
+]]
 lia.command.add("playtime", {
     adminOnly = false,
     privilege = "View Own Playtime",
@@ -133,6 +229,15 @@ lia.command.add("playtime", {
     end
 })
 
+--[[
+    plygetplaytime command
+
+    Description:
+        Displays the playtime of another player specified by name.
+
+    Realm:
+        Server
+]]
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = "View Playtime",

--- a/gamemode/core/libraries/serverguard.lua
+++ b/gamemode/core/libraries/serverguard.lua
@@ -1,1 +1,17 @@
-﻿serverguard.plugin:Toggle("restrictions", false)
+--[[
+    serverguard.plugin:Toggle("restrictions", false)
+
+    Description:
+        Disables ServerGuard's restrictions plugin to avoid conflicts with Lilia.
+
+    Parameters:
+        identifier (string) – Plugin identifier.
+        state (boolean) – Whether to enable the plugin.
+
+    Realm:
+        Server
+
+    Returns:
+        None
+]]
+serverguard.plugin:Toggle("restrictions", false)

--- a/gamemode/core/libraries/simfphys.lua
+++ b/gamemode/core/libraries/simfphys.lua
@@ -1,4 +1,18 @@
-﻿if SERVER then
+if SERVER then
+    --[[
+        hook.Add("EntityTakeDamage")
+
+        Description:
+            Transfers a portion of vehicle damage to the driver when a
+            simfphys seat is hit near the player.
+
+        Parameters:
+            seat (Entity) – Vehicle seat entity receiving damage.
+            dmgInfo (CTakeDamageInfo) – Damage information.
+
+        Realm:
+            Server
+    ]]
     hook.Add("EntityTakeDamage", "SIMFPHYS_EntityTakeDamage", function(seat, dmgInfo)
         if seat:IsVehicle() and seat:GetClass() == "gmod_sent_vehicle_fphysics_base" then
             local player = seat:GetDriver()
@@ -18,6 +32,22 @@
         end
     end)
 
+    --[[
+        hook.Add("simfphysUse")
+
+        Description:
+            Adds a configurable delay before entering a Simfphys vehicle.
+
+        Parameters:
+            entity (Entity) – Vehicle being used.
+            client (Player) – Player attempting to enter.
+
+        Realm:
+            Server
+
+        Returns:
+            alwaysTrue (boolean) – Always returns true to override default behavior.
+    ]]
     hook.Add("simfphysUse", "SIMFPHYS_simfphysUse", function(entity, client)
         if entity.IsBeingEntered then
             client:notifyLocalized("carOccupiedNotice")
@@ -44,6 +74,22 @@ else
     hook.Remove("HUDPaint", "simfphys_HUD")
 end
 
+--[[
+    hook.Add("CheckValidSit")
+
+    Description:
+        Prevents players from sitting on Simfphys vehicles when using
+        the Sit Anywhere module.
+
+    Parameters:
+        client (Player) – Player attempting to sit.
+
+    Realm:
+        Shared
+
+    Returns:
+        false if the traced entity is a Simfphys vehicle.
+]]
 hook.Add("CheckValidSit", "SIMFPHYS_CheckValidSit", function(client)
     local vehicle = client:getTracedEntity()
     if IsValid(vehicle) and vehicle:isSimfphysCar() then return false end
@@ -75,6 +121,31 @@ CAMI.RegisterPrivilege({
     Description = "Allows access to Editting Simfphys Cars"
 })
 
+--[[
+    hook.Add("simfphysPhysicsCollide")
+
+    Description:
+        Always allows physics collisions for Simfphys vehicles.
+]]
 hook.Add("simfphysPhysicsCollide", "SIMFPHYS_simfphysPhysicsCollide", function() return true end)
+
+--[[
+    hook.Add("IsSuitableForTrunk")
+
+    Description:
+        Marks Simfphys vehicles as valid targets for trunk storage.
+]]
 hook.Add("IsSuitableForTrunk", "SIMFPHYS_IsSuitableForTrunk", function(vehicle) if IsValid(vehicle) and vehicle:isSimfphysCar() then return true end end)
+
+--[[
+    hook.Add("CanProperty")
+
+    Description:
+        Restricts the "editentity" property to staff with the appropriate privilege.
+
+    Parameters:
+        client (Player) – Player using the property tool.
+        property (string) – Property name.
+        ent (Entity) – Target entity.
+]]
 hook.Add("CanProperty", "SIMFPHYS_CanProperty", function(client, property, ent) if property == "editentity" and ent:isSimfphysCar() then return client:hasPrivilege("Staff Permissions - Can Edit Simfphys Cars") end end)

--- a/gamemode/core/libraries/sitanywhere.lua
+++ b/gamemode/core/libraries/sitanywhere.lua
@@ -1,10 +1,35 @@
-﻿local commands = {{"sitting_can_sit_on_players", "1"}, {"sitting_can_sit_on_player_ent", "1"}, {"sitting_can_damage_players_sitting", "1"}, {"sitting_allow_weapons_in_seat", "0"}, {"sitting_admin_only", "0"}, {"sitting_anti_prop_surf", "1"}, {"sitting_anti_tool_abuse", "1"}}
+local commands = {{"sitting_can_sit_on_players", "1"}, {"sitting_can_sit_on_player_ent", "1"}, {"sitting_can_damage_players_sitting", "1"}, {"sitting_allow_weapons_in_seat", "0"}, {"sitting_admin_only", "0"}, {"sitting_anti_prop_surf", "1"}, {"sitting_anti_tool_abuse", "1"}}
+--[[
+    hook.Add("InitializedModules")
+
+    Description:
+        Sets recommended Sit Anywhere console variables when modules are
+        initialized.
+
+    Realm:
+        Server
+]]
 hook.Add("InitializedModules", "SITANYWHERE_InitializedModules", function()
     for _, cmd in ipairs(commands) do
         RunConsoleCommand(cmd[1], cmd[2])
     end
 end)
 
+--[[
+    hook.Add("CheckValidSit")
+
+    Description:
+        Disallows sitting on players or vehicles when using Sit Anywhere.
+
+    Parameters:
+        client (Player) – Player attempting to sit.
+
+    Realm:
+        Shared
+
+    Returns:
+        false if the traced entity is unsuitable for sitting.
+]]
 hook.Add("CheckValidSit", "SITANYWHERE_CheckValidSit", function(client)
     local entity = client:getTracedEntity()
     if entity:IsVehicle() or entity:IsPlayer() then return false end


### PR DESCRIPTION
## Summary
- document the PAC library
- document prone exit hooks
- add documentation for serverguard library
- document additional modules and network hooks

## Testing
- `grep -R "test" -n | head`
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e856daa08327913d74013a801768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced PAC3 part management and synchronization, allowing players and admins to add, remove, reset, and sync PAC3 parts. Includes new commands for controlling PAC3 functionality and a configuration option to block loading PAC3 packs from URLs.
  - Added new staff commands for blinding/unblinding players, clearing decals, and viewing playtime information. Enhanced staff permission checks for command execution.
  - Added a new hook to restrict staff command execution based on configuration.

- **Documentation**
  - Added comprehensive documentation comments to notification, prone, vehicle, Sit Anywhere, workshop, and admin modules, improving clarity and maintainability for all major systems.

- **Chores**
  - Improved codebase readability by expanding and annotating existing hooks and functions without modifying their logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->