### PR TITLE
Fix markup parse doc

### DIFF
--- a/gamemode/core/libraries/thirdparty/cl_markup.lua
+++ b/gamemode/core/libraries/thirdparty/cl_markup.lua
@@ -324,6 +324,27 @@ function MarkupObject:draw(xOffset, yOffset, halign, valign, alphaoverride)
     end
 end
 
+--[[
+    lia.markup.parse(text, maxwidth)
+
+    Description:
+        Parses the provided markup text and returns a markup object
+        representing the formatted content. When maxwidth is provided,
+        the text will automatically wrap at that width.
+
+    Parameters:
+        text (string) – String containing markup to be parsed.
+        maxwidth (number|nil) – Optional maximum width for wrapping.
+
+    Realm:
+        Client
+
+    Returns:
+        MarkupObject – The parsed markup object with size information.
+
+    Example Usage:
+        local object = lia.markup.parse("<color=255,0,0>Hello</color>", 200)
+]]
 function parse(ml, maxwidth)
     colour_stack = {
         {


### PR DESCRIPTION
## Summary
- document `lia.markup.parse` in `cl_markup.lua`

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597af3b5848327af4248903c8ea0ee