### PR TITLE
Fix hook docs

### DIFF
--- a/docs/hooks.lua
+++ b/docs/hooks.lua
@@ -1703,24 +1703,6 @@
             end)
 ]]
 --[[
-        CanDisplayCharInfo(client, id)
-
-        Description:
-            Replacement for deprecated CanDisplayCharacterInfo.
-            Determines if a character can be shown.
-
-        Parameters:
-            client (Player) – Local player.
-            id (number) – Character ID.
-
-        Realm:
-            Client
-        Example Usage:
-            hook.Add("CanDisplayCharInfo", "AllowAll", function()
-                return true
-            end)
-]]
---[[
         CharListLoaded(newCharList)
 
         Description:
@@ -1768,8 +1750,73 @@
         Realm:
             Shared
         Example Usage:
-            hook.Add("getCharMaxStamina", "Double", function(char)
-                return 200
+        hook.Add("getCharMaxStamina", "Double", function(char)
+            return 200
+        end)
+]]
+--[[
+        AdjustStaminaOffsetRunning(client, runCost)
+
+        Description:
+            Alters the stamina offset applied each tick while sprinting.
+            Return a new cost to modify how quickly stamina drains when running.
+
+        Parameters:
+            client (Player) – Player that is sprinting.
+            runCost (number) – Proposed stamina cost.
+
+        Realm:
+            Shared
+
+        Returns:
+            number – Modified stamina cost.
+        Example Usage:
+            hook.Add("AdjustStaminaOffsetRunning", "EnduranceBonus", function(ply, cost)
+                return cost + ply:getChar():getAttrib("stm", 0) * -0.01
+            end)
+]]
+--[[
+        AdjustStaminaRegeneration(client, regen)
+
+        Description:
+            Allows changing how quickly stamina regenerates when not sprinting.
+            Return a new amount to modify regeneration speed.
+
+        Parameters:
+            client (Player) – Player recovering stamina.
+            regen (number) – Default regeneration per tick.
+
+        Realm:
+            Shared
+
+        Returns:
+            number – Modified regeneration amount.
+        Example Usage:
+            hook.Add("AdjustStaminaRegeneration", "RestAreaBoost", function(ply, amount)
+                if ply:isInSafeZone() then
+                    return amount * 2
+                end
+            end)
+]]
+--[[
+        AdjustStaminaOffset(client, offset)
+
+        Description:
+            Final hook for tweaking the calculated stamina offset.
+            Return the modified offset value to apply each tick.
+
+        Parameters:
+            client (Player) – Player whose stamina is updating.
+            offset (number) – Current offset after other adjustments.
+
+        Realm:
+            Shared
+
+        Returns:
+            number – New offset to apply.
+        Example Usage:
+            hook.Add("AdjustStaminaOffset", "MinimumDrain", function(ply, off)
+                return math.max(off, -1)
             end)
 ]]
 --[[
@@ -3234,7 +3281,7 @@
         Example Usage:
             hook.Add("CreateDefaultInventory", "InitializeStarterInventory", function(character)
                 local d = deferred.new()
-            
+
                 someInventoryCreationFunction(character)
                     :next(function(inventory)
                         -- Add starter items
@@ -3245,7 +3292,7 @@
                         print("Failed to create inventory:", err)
                         d:reject(err)
                     end)
-            
+
                 return d
             end)
 ]]
@@ -3268,10 +3315,10 @@
                 panel.Paint = function(self, w, h)
                     draw.RoundedBox(8, 0, 0, w, h, Color(30, 30, 30, 200))
                 end
-            
+
                 local itemList = vgui.Create("DScrollPanel", panel)
                 itemList:Dock(FILL)
-            
+
                 for _, item in ipairs(inventory:getItems()) do
                     local itemPanel = vgui.Create("DButton", itemList)
                     itemPanel:SetText(item.name)
@@ -3281,7 +3328,7 @@
                         print("Selected item:", item.name)
                     end
                 end
-            
+
                 return panel
             end)
 ]]

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -1,5 +1,5 @@
 GM.Name = "Lilia"
-GM.version = "4.8.50"
+GM.version = "4.8.53"
 GM.Author = "Samael"
 GM.Website = "https://discord.gg/esCRH5ckbQ"
 include("core/loader.lua")


### PR DESCRIPTION
## Summary
- remove `CanDisplayCharInfo` block from hook docs
- document stamina adjustment hooks
- clean up trailing whitespace in docs

## Testing
- `python3 - <<'EOF'
import os,re
pattern_run=re.compile(r'hook\.Run\(\s*["\']([^"\']+)')
pattern_hookrun=re.compile(r'hookRun\(\s*["\']([^"\']+)')
code_hooks=set()
for root, dirs, files in os.walk('gamemode'):
    for file in files:
        if file.endswith('.lua'):
            with open(os.path.join(root,file), errors='ignore') as f:
                for line in f:
                    for m in pattern_run.finditer(line):
                        code_hooks.add(m.group(1))
                    for m in pattern_hookrun.finditer(line):
                        code_hooks.add(m.group(1))
for root, dirs, files in os.walk('modules'):
    for file in files:
        if file.endswith('.lua'):
            with open(os.path.join(root,file), errors='ignore') as f:
                for line in f:
                    for m in pattern_run.finditer(line):
                        code_hooks.add(m.group(1))
                    for m in pattern_hookrun.finditer(line):
                        code_hooks.add(m.group(1))

doc_hooks=set()
lines=open('docs/hooks.lua').read().splitlines()
for i,line in enumerate(lines):
    if line.startswith('--[['):
        j=i+1
        while j<len(lines) and lines[j].strip()=='' :
            j+=1
        if j<len(lines):
            m=re.match(r'\s*([A-Za-z0-9_.]+)\(', lines[j])
            if m:
                doc_hooks.add(m.group(1))
print('Hooks in code:', len(code_hooks))
print('Hooks in docs:', len(doc_hooks))
print('Missing docs:', code_hooks-doc_hooks)
print('Extra docs:', doc_hooks-code_hooks)
EOF`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859e64e81d08327ab269eaa2f3cac0e