### PR TITLE
Add ATTRIBUTE field docs

### DIFF
--- a/docs/attribute_fields.lua
+++ b/docs/attribute_fields.lua
@@ -1,0 +1,69 @@
+--[[
+    This file documents ATTRIBUTE fields defined within the codebase.
+
+    Generated automatically.
+]]
+
+--[[
+        ATTRIBUTE.name
+
+        Description:
+            Specifies the display name of the attribute.
+
+        Example Usage:
+            ATTRIBUTE.name = "Strength"
+]]
+
+--[[
+        ATTRIBUTE.desc
+
+        Description:
+            Provides a short description of the attribute.
+
+        Example Usage:
+            ATTRIBUTE.desc = "Strength Skill."
+]]
+
+--[[
+        ATTRIBUTE.noStartBonus
+
+        Description:
+            Determines whether the attribute can receive a bonus at the start of the game.
+
+        Example Usage:
+            ATTRIBUTE.noStartBonus = false
+]]
+
+--[[
+        ATTRIBUTE.maxValue
+
+        Description:
+            Specifies the maximum value the attribute can reach.
+
+        Example Usage:
+            ATTRIBUTE.maxValue = 50
+]]
+
+--[[
+        ATTRIBUTE.startingMax
+
+        Description:
+            Defines the maximum value the attribute can start with.
+
+        Example Usage:
+            ATTRIBUTE.startingMax = 15
+]]
+
+--[[
+        ATTRIBUTE:OnSetup(client, value)
+
+        Description:
+            Executes custom logic when the attribute is set up for a player, such as notifications or additional effects.
+
+        Example Usage:
+            function ATTRIBUTE:OnSetup(client, value)
+                if value > 5 then
+                    client:ChatPrint("You are very Strong!")
+                end
+            end
+]]


### PR DESCRIPTION
## Summary
- document `ATTRIBUTE` fields used in the framework

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b311bf25c8327ad28075fff3bd7a0