### PR TITLE
Generate def docs

### DIFF
--- a/docs/docs/framework/definitions/attribute.md
+++ b/docs/docs/framework/definitions/attribute.md
@@ -132,4 +132,225 @@ end
     ```
     *Displays a chat message to the player if their Strength attribute exceeds 5.*
     
+------
+
+### **Example**
+
+```lua
+ATTRIBUTE.name = "Strength"
+```
+
 ---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE.name`                                  | Specifies the display name of the attribute. | `Unknown`    | `ATTRIBUTE.name = "Strength"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE.name`
+
+- **Purpose:**  
+    Specifies the display name of the attribute.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ATTRIBUTE.name = "Strength"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ATTRIBUTE.desc = "Strength Skill."
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE.desc`                                  | Provides a short description of the attribute. | `Unknown`    | `ATTRIBUTE.desc = "Strength Skill."` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE.desc`
+
+- **Purpose:**  
+    Provides a short description of the attribute.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ATTRIBUTE.desc = "Strength Skill."
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ATTRIBUTE.noStartBonus = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE.noStartBonus`                                  | Determines whether the attribute can receive a bonus at the start of the game. | `Unknown`    | `ATTRIBUTE.noStartBonus = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE.noStartBonus`
+
+- **Purpose:**  
+    Determines whether the attribute can receive a bonus at the start of the game.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ATTRIBUTE.noStartBonus = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ATTRIBUTE.maxValue = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE.maxValue`                                  | Specifies the maximum value the attribute can reach. | `Unknown`    | `ATTRIBUTE.maxValue = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE.maxValue`
+
+- **Purpose:**  
+    Specifies the maximum value the attribute can reach.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ATTRIBUTE.maxValue = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ATTRIBUTE.startingMax = 15
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE.startingMax`                                  | Defines the maximum value the attribute can start with. | `Unknown`    | `ATTRIBUTE.startingMax = 15` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE.startingMax`
+
+- **Purpose:**  
+    Defines the maximum value the attribute can start with.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ATTRIBUTE.startingMax = 15
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+function ATTRIBUTE:OnSetup(client, value)
+if value > 5 then
+client:ChatPrint("You are very Strong!")
+end
+end
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ATTRIBUTE:OnSetup(client, value)`                                  | Executes custom logic when the attribute is set up for a player, such as notifications or additional effects. | `Function`    | `function ATTRIBUTE:OnSetup(client, value)
+if value > 5 then
+client:ChatPrint("You are very Strong!")
+end
+end` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ATTRIBUTE:OnSetup(client, value)`
+
+- **Purpose:**  
+    Executes custom logic when the attribute is set up for a player, such as notifications or additional effects.
+
+- **Type:**  
+    `Function`
+
+- **Example Usage:
+    ```lua
+function ATTRIBUTE:OnSetup(client, value)
+if value > 5 then
+client:ChatPrint("You are very Strong!")
+end
+end
+    ```
+
+---
+

--- a/docs/docs/framework/definitions/class.md
+++ b/docs/docs/framework/definitions/class.md
@@ -1,0 +1,840 @@
+---
+
+### **Example**
+
+```lua
+CLASS.name = "Engineer"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `name`                                  | The displayed name of the class. | `Unknown`    | `CLASS.name = "Engineer"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `name`
+
+- **Purpose:**  
+    The displayed name of the class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.name = "Engineer"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.desc = "Technicians who maintain equipment."
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `desc`                                  | The description or lore of the class. | `Unknown`    | `CLASS.desc = "Technicians who maintain equipment."` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `desc`
+
+- **Purpose:**  
+    The description or lore of the class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.desc = "Technicians who maintain equipment."
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.isDefault = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `isDefault`                                  | Determines if the class is available by default. | `Unknown`    | `CLASS.isDefault = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `isDefault`
+
+- **Purpose:**  
+    Determines if the class is available by default.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.isDefault = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.isWhitelisted = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `isWhitelisted`                                  | Indicates if the class requires whitelisting. | `Unknown`    | `CLASS.isWhitelisted = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `isWhitelisted`
+
+- **Purpose:**  
+    Indicates if the class requires whitelisting.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.isWhitelisted = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.faction = FACTION_CITIZEN
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `faction`                                  | Links the class to a specific faction. | `Unknown`    | `CLASS.faction = FACTION_CITIZEN` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `faction`
+
+- **Purpose:**  
+    Links the class to a specific faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.faction = FACTION_CITIZEN
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.color = Color(255, 0, 0)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `color`                                  | The color associated with the class. | `Color`    | `CLASS.color = Color(255, 0, 0)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `color`
+
+- **Purpose:**  
+    The color associated with the class.
+
+- **Type:**  
+    `Color`
+
+- **Example Usage:
+    ```lua
+CLASS.color = Color(255, 0, 0)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `weapons`                                  | Weapons available to class members. | `Unknown`    | `CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `weapons`
+
+- **Purpose:**  
+    Weapons available to class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.pay = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `pay`                                  | Payment amount for class members. | `Unknown`    | `CLASS.pay = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `pay`
+
+- **Purpose:**  
+    Payment amount for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.pay = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.payLimit = 1000
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `payLimit`                                  | Maximum accumulated pay for class members. | `Unknown`    | `CLASS.payLimit = 1000` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `payLimit`
+
+- **Purpose:**  
+    Maximum accumulated pay for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.payLimit = 1000
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.payTimer = 3600
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `payTimer`                                  | Interval in seconds for issuing pay. | `Unknown`    | `CLASS.payTimer = 3600` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `payTimer`
+
+- **Purpose:**  
+    Interval in seconds for issuing pay.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.payTimer = 3600
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.limit = 10
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `limit`                                  | Maximum number of players allowed in the class. | `Unknown`    | `CLASS.limit = 10` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `limit`
+
+- **Purpose:**  
+    Maximum number of players allowed in the class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.limit = 10
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.health = 150
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `health`                                  | Default health for class members. | `Unknown`    | `CLASS.health = 150` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `health`
+
+- **Purpose:**  
+    Default health for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.health = 150
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.armor = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `armor`                                  | Default armor for class members. | `Unknown`    | `CLASS.armor = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `armor`
+
+- **Purpose:**  
+    Default armor for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.armor = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.scale = 1.2
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `scale`                                  | Adjusts the player model's size. | `Unknown`    | `CLASS.scale = 1.2` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `scale`
+
+- **Purpose:**  
+    Adjusts the player model's size.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.scale = 1.2
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.runSpeed = 250
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `runSpeed`                                  | Default running speed for class members. | `Unknown`    | `CLASS.runSpeed = 250` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `runSpeed`
+
+- **Purpose:**  
+    Default running speed for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.runSpeed = 250
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.runSpeedMultiplier = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `runSpeedMultiplier`                                  | If true, multiplies runSpeed by the base speed; otherwise sets it directly. | `Unknown`    | `CLASS.runSpeedMultiplier = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `runSpeedMultiplier`
+
+- **Purpose:**  
+    If true, multiplies runSpeed by the base speed; otherwise sets it directly.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.runSpeedMultiplier = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.walkSpeed = 200
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `walkSpeed`                                  | Default walking speed for class members. | `Unknown`    | `CLASS.walkSpeed = 200` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `walkSpeed`
+
+- **Purpose:**  
+    Default walking speed for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.walkSpeed = 200
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.walkSpeedMultiplier = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `walkSpeedMultiplier`                                  | If true, multiplies walkSpeed by the base speed; otherwise sets it directly. | `Unknown`    | `CLASS.walkSpeedMultiplier = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `walkSpeedMultiplier`
+
+- **Purpose:**  
+    If true, multiplies walkSpeed by the base speed; otherwise sets it directly.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.walkSpeedMultiplier = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.jumpPower = 200
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `jumpPower`                                  | Default jump power for class members. | `Unknown`    | `CLASS.jumpPower = 200` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `jumpPower`
+
+- **Purpose:**  
+    Default jump power for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.jumpPower = 200
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.jumpPowerMultiplier = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `jumpPowerMultiplier`                                  | If true, multiplies jumpPower by the base jump power; otherwise sets it directly. | `Unknown`    | `CLASS.jumpPowerMultiplier = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `jumpPowerMultiplier`
+
+- **Purpose:**  
+    If true, multiplies jumpPower by the base jump power; otherwise sets it directly.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.jumpPowerMultiplier = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.bloodcolor = BLOOD_COLOR_RED
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `bloodcolor`                                  | Sets the blood color for class members. | `Unknown`    | `CLASS.bloodcolor = BLOOD_COLOR_RED` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `bloodcolor`
+
+- **Purpose:**  
+    Sets the blood color for class members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.bloodcolor = BLOOD_COLOR_RED
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.bodyGroups = { [1] = 2, [3] = 1 }
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `bodyGroups`                                  | Assigns bodygroup values on spawn. | `Unknown`    | `CLASS.bodyGroups = { [1] = 2, [3] = 1 }` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `bodyGroups`
+
+- **Purpose:**  
+    Assigns bodygroup values on spawn.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.bodyGroups = { [1] = 2, [3] = 1 }
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.model = "models/player/alyx.mdl"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `model`                                  | Model or models assigned to the class. | `Unknown`    | `CLASS.model = "models/player/alyx.mdl"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `model`
+
+- **Purpose:**  
+    Model or models assigned to the class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.model = "models/player/alyx.mdl"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+CLASS.index = CLASS_ENGINEER
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `index`                                  | Unique ID (team index) identifying the class. | `Unknown`    | `CLASS.index = CLASS_ENGINEER` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `index`
+
+- **Purpose:**  
+    Unique ID (team index) identifying the class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+CLASS.index = CLASS_ENGINEER
+    ```
+
+---
+

--- a/docs/docs/framework/definitions/command.md
+++ b/docs/docs/framework/definitions/command.md
@@ -1,0 +1,351 @@
+---
+
+### **Example**
+
+```lua
+alias = {"chargiveflag", "giveflag"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `alias`                                  | Alternative command names that also trigger the same command.
+Can be a single string or a table of strings. | `Unknown`    | `alias = {"chargiveflag", "giveflag"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `alias`
+
+- **Purpose:**  
+    Alternative command names that also trigger the same command.
+Can be a single string or a table of strings.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+alias = {"chargiveflag", "giveflag"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+adminOnly = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `adminOnly`                                  | When true only players with admin privileges (or higher)
+may run the command. A CAMI privilege is registered
+automatically. | `Unknown`    | `adminOnly = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `adminOnly`
+
+- **Purpose:**  
+    When true only players with admin privileges (or higher)
+may run the command. A CAMI privilege is registered
+automatically.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+adminOnly = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+superAdminOnly = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `superAdminOnly`                                  | Restricts usage to super administrators. Like adminOnly this
+registers a CAMI privilege if needed. | `Unknown`    | `superAdminOnly = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `superAdminOnly`
+
+- **Purpose:**  
+    Restricts usage to super administrators. Like adminOnly this
+registers a CAMI privilege if needed.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+superAdminOnly = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+privilege = "Manage Doors"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `privilege`                                  | Name of the CAMI privilege checked when running the command.
+If omitted, the command name itself is used as the privilege. | `Unknown`    | `privilege = "Manage Doors"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `privilege`
+
+- **Purpose:**  
+    Name of the CAMI privilege checked when running the command.
+If omitted, the command name itself is used as the privilege.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+privilege = "Manage Doors"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+syntax = "[string target] [number amount]"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `syntax`                                  | Human readable syntax string shown in help menus. This has
+no effect on parsing but informs players how to format
+the arguments. | `Unknown`    | `syntax = "[string target] [number amount]"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `syntax`
+
+- **Purpose:**  
+    Human readable syntax string shown in help menus. This has
+no effect on parsing but informs players how to format
+the arguments.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+syntax = "[string target] [number amount]"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+desc = L("doorbuyDesc")
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `desc`                                  | Short description of what the command does. Displayed in
+command lists and menus. | `Unknown`    | `desc = L("doorbuyDesc")` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `desc`
+
+- **Purpose:**  
+    Short description of what the command does. Displayed in
+command lists and menus.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+desc = L("doorbuyDesc")
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+AdminStick = {
+Name = "Set Character Skin",
+Category = "Player Informations",
+SubCategory = "Set Informations",
+Icon = "icon16/user_gray.png",
+ExtraFields = {
+["skin"] = "number"
+}
+}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `AdminStick`                                  | Table describing how the command should appear in admin
+utilities. Common keys include:
+Name        - display text in the menu.
+Category    - top level grouping.
+SubCategory - secondary grouping.
+Icon        - 16x16 icon path.
+ExtraFields - additional field definitions. | `Unknown`    | `AdminStick = {
+Name = "Set Character Skin",
+Category = "Player Informations",
+SubCategory = "Set Informations",
+Icon = "icon16/user_gray.png",
+ExtraFields = {
+["skin"] = "number"
+}
+}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `AdminStick`
+
+- **Purpose:**  
+    Table describing how the command should appear in admin
+utilities. Common keys include:
+Name        - display text in the menu.
+Category    - top level grouping.
+SubCategory - secondary grouping.
+Icon        - 16x16 icon path.
+ExtraFields - additional field definitions.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+AdminStick = {
+Name = "Set Character Skin",
+Category = "Player Informations",
+SubCategory = "Set Informations",
+Icon = "icon16/user_gray.png",
+ExtraFields = {
+["skin"] = "number"
+}
+}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+onRun = function(client, arguments)
+local target = lia.util.findPlayer(client, arguments[1])
+if target then
+target:Kill()
+end
+end
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `onRun(client, arguments)`                                  | Function executed when the command is run. Arguments are
+already parsed and provided as a table.
+Return a string to notify the caller or nothing to stay silent. | `Unknown`    | `onRun = function(client, arguments)
+local target = lia.util.findPlayer(client, arguments[1])
+if target then
+target:Kill()
+end
+end` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `onRun(client, arguments)`
+
+- **Purpose:**  
+    Function executed when the command is run. Arguments are
+already parsed and provided as a table.
+Return a string to notify the caller or nothing to stay silent.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+onRun = function(client, arguments)
+local target = lia.util.findPlayer(client, arguments[1])
+if target then
+target:Kill()
+end
+end
+    ```
+
+---
+

--- a/docs/docs/framework/definitions/faction.md
+++ b/docs/docs/framework/definitions/faction.md
@@ -1,0 +1,1039 @@
+---
+
+### **Example**
+
+```lua
+FACTION.name = "Minecrafters"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `name`                                  | Display name shown for members of this faction. | `Unknown`    | `FACTION.name = "Minecrafters"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `name`
+
+- **Purpose:**  
+    Display name shown for members of this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.name = "Minecrafters"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.desc = "Surviving and crafting in the blocky world."
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `desc`                                  | Lore or descriptive text about the faction. | `Unknown`    | `FACTION.desc = "Surviving and crafting in the blocky world."` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `desc`
+
+- **Purpose:**  
+    Lore or descriptive text about the faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.desc = "Surviving and crafting in the blocky world."
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.isDefault = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `isDefault`                                  | Set to true if players may select this faction without a whitelist. | `Unknown`    | `FACTION.isDefault = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `isDefault`
+
+- **Purpose:**  
+    Set to true if players may select this faction without a whitelist.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.isDefault = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.color = Color(255, 56, 252)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `color`                                  | Color used to represent the faction in UI elements. | `Color`    | `FACTION.color = Color(255, 56, 252)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `color`
+
+- **Purpose:**  
+    Color used to represent the faction in UI elements.
+
+- **Type:**  
+    `Color`
+
+- **Example Usage:
+    ```lua
+FACTION.color = Color(255, 56, 252)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.models = {"models/Humans/Group02/male_07.mdl"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `models`                                  | Table of player models available to faction members. | `Unknown`    | `FACTION.models = {"models/Humans/Group02/male_07.mdl"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `models`
+
+- **Purpose:**  
+    Table of player models available to faction members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.models = {"models/Humans/Group02/male_07.mdl"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.uniqueID = "staff"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `uniqueID`                                  | String identifier used internally to reference the faction. | `Unknown`    | `FACTION.uniqueID = "staff"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `uniqueID`
+
+- **Purpose:**  
+    String identifier used internally to reference the faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.uniqueID = "staff"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.weapons = {"weapon_physgun", "gmod_tool"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `weapons`                                  | Weapons automatically granted to players in this faction. | `Unknown`    | `FACTION.weapons = {"weapon_physgun", "gmod_tool"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `weapons`
+
+- **Purpose:**  
+    Weapons automatically granted to players in this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.weapons = {"weapon_physgun", "gmod_tool"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.items = {"radio", "handcuffs"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `items`                                  | Table of item uniqueIDs automatically granted when a character is created. | `Unknown`    | `FACTION.items = {"radio", "handcuffs"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `items`
+
+- **Purpose:**  
+    Table of item uniqueIDs automatically granted when a character is created.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.items = {"radio", "handcuffs"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION_STAFF = FACTION.index
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `index`                                  | Numeric identifier assigned during faction registration. | `Unknown`    | `FACTION_STAFF = FACTION.index` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `index`
+
+- **Purpose:**  
+    Numeric identifier assigned during faction registration.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION_STAFF = FACTION.index
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.pay = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `pay`                                  | Payment amount for members of this faction. | `Unknown`    | `FACTION.pay = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `pay`
+
+- **Purpose:**  
+    Payment amount for members of this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.pay = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.payLimit = 1000
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `payLimit`                                  | Maximum pay a member can accumulate. | `Unknown`    | `FACTION.payLimit = 1000` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `payLimit`
+
+- **Purpose:**  
+    Maximum pay a member can accumulate.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.payLimit = 1000
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.payTimer = 3600
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `payTimer`                                  | Interval in seconds between salary payouts. | `Unknown`    | `FACTION.payTimer = 3600` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `payTimer`
+
+- **Purpose:**  
+    Interval in seconds between salary payouts.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.payTimer = 3600
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.limit = 20
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `limit`                                  | Maximum number of players allowed in this faction. | `Unknown`    | `FACTION.limit = 20` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `limit`
+
+- **Purpose:**  
+    Maximum number of players allowed in this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.limit = 20
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.oneCharOnly = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `oneCharOnly`                                  | If true, players may only create one character in this faction. | `Unknown`    | `FACTION.oneCharOnly = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `oneCharOnly`
+
+- **Purpose:**  
+    If true, players may only create one character in this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.oneCharOnly = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.health = 150
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `health`                                  | Starting health for faction members. | `Unknown`    | `FACTION.health = 150` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `health`
+
+- **Purpose:**  
+    Starting health for faction members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.health = 150
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.armor = 25
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `armor`                                  | Starting armor for faction members. | `Unknown`    | `FACTION.armor = 25` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `armor`
+
+- **Purpose:**  
+    Starting armor for faction members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.armor = 25
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.scale = 1.1
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `scale`                                  | Player model scale multiplier for this faction. | `Unknown`    | `FACTION.scale = 1.1` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `scale`
+
+- **Purpose:**  
+    Player model scale multiplier for this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.scale = 1.1
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.runSpeed = 250
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `runSpeed`                                  | Base running speed for members of this faction. | `Unknown`    | `FACTION.runSpeed = 250` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `runSpeed`
+
+- **Purpose:**  
+    Base running speed for members of this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.runSpeed = 250
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.runSpeedMultiplier = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `runSpeedMultiplier`                                  | If true, runSpeed multiplies the base speed instead of replacing it. | `Unknown`    | `FACTION.runSpeedMultiplier = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `runSpeedMultiplier`
+
+- **Purpose:**  
+    If true, runSpeed multiplies the base speed instead of replacing it.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.runSpeedMultiplier = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.walkSpeed = 200
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `walkSpeed`                                  | Base walking speed for members of this faction. | `Unknown`    | `FACTION.walkSpeed = 200` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `walkSpeed`
+
+- **Purpose:**  
+    Base walking speed for members of this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.walkSpeed = 200
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.walkSpeedMultiplier = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `walkSpeedMultiplier`                                  | If true, walkSpeed multiplies the base speed instead of replacing it. | `Unknown`    | `FACTION.walkSpeedMultiplier = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `walkSpeedMultiplier`
+
+- **Purpose:**  
+    If true, walkSpeed multiplies the base speed instead of replacing it.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.walkSpeedMultiplier = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.jumpPower = 200
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `jumpPower`                                  | Base jump power for members of this faction. | `Unknown`    | `FACTION.jumpPower = 200` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `jumpPower`
+
+- **Purpose:**  
+    Base jump power for members of this faction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.jumpPower = 200
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.jumpPowerMultiplier = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `jumpPowerMultiplier`                                  | If true, jumpPower multiplies the base jump power instead of replacing it. | `Unknown`    | `FACTION.jumpPowerMultiplier = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `jumpPowerMultiplier`
+
+- **Purpose:**  
+    If true, jumpPower multiplies the base jump power instead of replacing it.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.jumpPowerMultiplier = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.MemberToMemberAutoRecognition = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `MemberToMemberAutoRecognition`                                  | Whether members automatically recognize each other. | `Unknown`    | `FACTION.MemberToMemberAutoRecognition = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `MemberToMemberAutoRecognition`
+
+- **Purpose:**  
+    Whether members automatically recognize each other.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.MemberToMemberAutoRecognition = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.bloodcolor = BLOOD_COLOR_RED
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `bloodcolor`                                  | Blood color enumeration for faction members. | `Unknown`    | `FACTION.bloodcolor = BLOOD_COLOR_RED` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `bloodcolor`
+
+- **Purpose:**  
+    Blood color enumeration for faction members.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.bloodcolor = BLOOD_COLOR_RED
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.bodyGroups = {
+hands = 1,
+torso = 3
+}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `bodyGroups`                                  | Table mapping bodygroup names to the index value each should use.
+These are applied whenever a faction member spawns. | `Unknown`    | `FACTION.bodyGroups = {
+hands = 1,
+torso = 3
+}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `bodyGroups`
+
+- **Purpose:**  
+    Table mapping bodygroup names to the index value each should use.
+These are applied whenever a faction member spawns.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.bodyGroups = {
+hands = 1,
+torso = 3
+}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.NPCRelations = {
+["npc_combine_s"] = D_HT,
+["npc_citizen"] = D_LI
+}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `NPCRelations`                                  | Table mapping NPC class names to disposition constants such as
+D_HT (hate) or D_LI (like). Each NPC is updated with these
+relationships when the player spawns or the NPC is created. | `Unknown`    | `FACTION.NPCRelations = {
+["npc_combine_s"] = D_HT,
+["npc_citizen"] = D_LI
+}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `NPCRelations`
+
+- **Purpose:**  
+    Table mapping NPC class names to disposition constants such as
+D_HT (hate) or D_LI (like). Each NPC is updated with these
+relationships when the player spawns or the NPC is created.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.NPCRelations = {
+["npc_combine_s"] = D_HT,
+["npc_citizen"] = D_LI
+}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.RecognizesGlobally = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `RecognizesGlobally`                                  | If true, members of this faction recognize all players globally. | `Unknown`    | `FACTION.RecognizesGlobally = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `RecognizesGlobally`
+
+- **Purpose:**  
+    If true, members of this faction recognize all players globally.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.RecognizesGlobally = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+FACTION.ScoreboardHidden = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ScoreboardHidden`                                  | If true, members of this faction are hidden from the scoreboard. | `Unknown`    | `FACTION.ScoreboardHidden = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ScoreboardHidden`
+
+- **Purpose:**  
+    If true, members of this faction are hidden from the scoreboard.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+FACTION.ScoreboardHidden = false
+    ```
+
+---
+

--- a/docs/docs/framework/definitions/items.md
+++ b/docs/docs/framework/definitions/items.md
@@ -1,0 +1,1750 @@
+---
+
+### **Example**
+
+```lua
+ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.BagSound`                                  | Sound played when moving items to/from the bag. | `Unknown`    | `ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.BagSound`
+
+- **Purpose:**  
+    Sound played when moving items to/from the bag.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.DropOnDeath = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.DropOnDeath`                                  | Deletes the item upon player death. | `Unknown`    | `ITEM.DropOnDeath = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.DropOnDeath`
+
+- **Purpose:**  
+    Deletes the item upon player death.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.DropOnDeath = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.FactionWhitelist = {FACTION_CITIZEN}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.FactionWhitelist`                                  | Allowed factions for vendor interaction. | `Unknown`    | `ITEM.FactionWhitelist = {FACTION_CITIZEN}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.FactionWhitelist`
+
+- **Purpose:**  
+    Allowed factions for vendor interaction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.FactionWhitelist = {FACTION_CITIZEN}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.RequiredSkillLevels = {Strength = 5}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.RequiredSkillLevels`                                  | Skill requirements needed to use the item. | `Unknown`    | `ITEM.RequiredSkillLevels = {Strength = 5}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.RequiredSkillLevels`
+
+- **Purpose:**  
+    Skill requirements needed to use the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.RequiredSkillLevels = {Strength = 5}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.SteamIDWhitelist`                                  | Allowed Steam IDs for vendor interaction. | `Unknown`    | `ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.SteamIDWhitelist`
+
+- **Purpose:**  
+    Allowed Steam IDs for vendor interaction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.UsergroupWhitelist = {"admin"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.UsergroupWhitelist`                                  | Allowed user groups for vendor interaction. | `Unknown`    | `ITEM.UsergroupWhitelist = {"admin"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.UsergroupWhitelist`
+
+- **Purpose:**  
+    Allowed user groups for vendor interaction.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.UsergroupWhitelist = {"admin"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.VIPWhitelist = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.VIPWhitelist`                                  | Restricts usage to VIP players. | `Unknown`    | `ITEM.VIPWhitelist = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.VIPWhitelist`
+
+- **Purpose:**  
+    Restricts usage to VIP players.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.VIPWhitelist = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.VManipDisabled = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.VManipDisabled`                                  | Disables VManip grabbing for the item. | `Unknown`    | `ITEM.VManipDisabled = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.VManipDisabled`
+
+- **Purpose:**  
+    Disables VManip grabbing for the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.VManipDisabled = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.ammo = "pistol"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.ammo`                                  | Ammo type provided. | `Unknown`    | `ITEM.ammo = "pistol"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.ammo`
+
+- **Purpose:**  
+    Ammo type provided.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.ammo = "pistol"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.ammoAmount = 30
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.ammoAmount`                                  | Amount of ammo contained. | `Unknown`    | `ITEM.ammoAmount = 30` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.ammoAmount`
+
+- **Purpose:**  
+    Amount of ammo contained.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.ammoAmount = 30
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.armor = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.armor`                                  | Armor value granted when equipped. | `Unknown`    | `ITEM.armor = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.armor`
+
+- **Purpose:**  
+    Armor value granted when equipped.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.armor = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.attribBoosts = {strength = 5}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.attribBoosts`                                  | Attribute boosts applied on equip. | `Unknown`    | `ITEM.attribBoosts = {strength = 5}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.attribBoosts`
+
+- **Purpose:**  
+    Attribute boosts applied on equip.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.attribBoosts = {strength = 5}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.base = "weapon"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.base`                                  | Base item this item derives from. | `Unknown`    | `ITEM.base = "weapon"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.base`
+
+- **Purpose:**  
+    Base item this item derives from.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.base = "weapon"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.canSplit = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.canSplit`                                  | Whether the item stack can be divided. | `Unknown`    | `ITEM.canSplit = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.canSplit`
+
+- **Purpose:**  
+    Whether the item stack can be divided.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.canSplit = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.category = "Storage"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.category`                                  | Inventory grouping category. | `Unknown`    | `ITEM.category = "Storage"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.category`
+
+- **Purpose:**  
+    Inventory grouping category.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.category = "Storage"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.class = "weapon_pistol"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.class`                                  | Weapon entity class. | `Unknown`    | `ITEM.class = "weapon_pistol"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.class`
+
+- **Purpose:**  
+    Weapon entity class.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.class = "weapon_pistol"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.contents = "<h1>Book</h1>"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.contents`                                  | HTML contents of a readable book. | `Unknown`    | `ITEM.contents = "<h1>Book</h1>"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.contents`
+
+- **Purpose:**  
+    HTML contents of a readable book.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.contents = "<h1>Book</h1>"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.desc = "An example item"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.desc`                                  | Short description shown to players. | `Unknown`    | `ITEM.desc = "An example item"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.desc`
+
+- **Purpose:**  
+    Short description shown to players.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.desc = "An example item"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.entityid = "item_suit"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.entityid`                                  | Entity class spawned by the item. | `Unknown`    | `ITEM.entityid = "item_suit"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.entityid`
+
+- **Purpose:**  
+    Entity class spawned by the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.entityid = "item_suit"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.equipSound = "items/ammo_pickup.wav"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.equipSound`                                  | Sound played when equipping. | `Unknown`    | `ITEM.equipSound = "items/ammo_pickup.wav"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.equipSound`
+
+- **Purpose:**  
+    Sound played when equipping.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.equipSound = "items/ammo_pickup.wav"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.flag = "Y"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.flag`                                  | Flag required to purchase the item. | `Unknown`    | `ITEM.flag = "Y"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.flag`
+
+- **Purpose:**  
+    Flag required to purchase the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.flag = "Y"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.functions = {}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.functions`                                  | Table of interaction functions. | `Unknown`    | `ITEM.functions = {}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.functions`
+
+- **Purpose:**  
+    Table of interaction functions.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.functions = {}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.grenadeClass = "weapon_frag"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.grenadeClass`                                  | Class name used when spawning a grenade. | `Unknown`    | `ITEM.grenadeClass = "weapon_frag"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.grenadeClass`
+
+- **Purpose:**  
+    Class name used when spawning a grenade.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.grenadeClass = "weapon_frag"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.health = 50
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.health`                                  | Amount of health restored when used. | `Unknown`    | `ITEM.health = 50` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.health`
+
+- **Purpose:**  
+    Amount of health restored when used.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.health = 50
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.height = 1
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.height`                                  | Height in inventory grid. | `Unknown`    | `ITEM.height = 1` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.height`
+
+- **Purpose:**  
+    Height in inventory grid.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.height = 1
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+print(item.id)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.id`                                  | Database identifier. | `Unknown`    | `print(item.id)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.id`
+
+- **Purpose:**  
+    Database identifier.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+print(item.id)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.invHeight = 2
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.invHeight`                                  | Internal bag inventory height. | `Unknown`    | `ITEM.invHeight = 2` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.invHeight`
+
+- **Purpose:**  
+    Internal bag inventory height.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.invHeight = 2
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.invWidth = 2
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.invWidth`                                  | Internal bag inventory width. | `Unknown`    | `ITEM.invWidth = 2` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.invWidth`
+
+- **Purpose:**  
+    Internal bag inventory width.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.invWidth = 2
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.isBag = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.isBag`                                  | Marks the item as a bag providing extra inventory. | `Unknown`    | `ITEM.isBag = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.isBag`
+
+- **Purpose:**  
+    Marks the item as a bag providing extra inventory.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.isBag = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.isBase = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.isBase`                                  | Indicates the table is a base item. | `Unknown`    | `ITEM.isBase = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.isBase`
+
+- **Purpose:**  
+    Indicates the table is a base item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.isBase = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.isOutfit = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.isOutfit`                                  | Marks the item as an outfit. | `Unknown`    | `ITEM.isOutfit = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.isOutfit`
+
+- **Purpose:**  
+    Marks the item as an outfit.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.isOutfit = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.isStackable = false
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.isStackable`                                  | Allows stacking multiple quantities. | `Unknown`    | `ITEM.isStackable = false` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.isStackable`
+
+- **Purpose:**  
+    Allows stacking multiple quantities.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.isStackable = false
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.isWeapon = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.isWeapon`                                  | Marks the item as a weapon. | `Unknown`    | `ITEM.isWeapon = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.isWeapon`
+
+- **Purpose:**  
+    Marks the item as a weapon.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.isWeapon = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.maxQuantity = 10
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.maxQuantity`                                  | Maximum stack size. | `Unknown`    | `ITEM.maxQuantity = 10` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.maxQuantity`
+
+- **Purpose:**  
+    Maximum stack size.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.maxQuantity = 10
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.model = "models/props_c17/oildrum001.mdl"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.model`                                  | 3D model path for the item. | `Unknown`    | `ITEM.model = "models/props_c17/oildrum001.mdl"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.model`
+
+- **Purpose:**  
+    3D model path for the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.model = "models/props_c17/oildrum001.mdl"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.name = "Example Item"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.name`                                  | Displayed name of the item. | `Unknown`    | `ITEM.name = "Example Item"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.name`
+
+- **Purpose:**  
+    Displayed name of the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.name = "Example Item"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.newSkin = 1
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.newSkin`                                  | Skin index applied to the player model. | `Unknown`    | `ITEM.newSkin = 1` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.newSkin`
+
+- **Purpose:**  
+    Skin index applied to the player model.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.newSkin = 1
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.outfitCategory = "body"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.outfitCategory`                                  | Slot or category for the outfit. | `Unknown`    | `ITEM.outfitCategory = "body"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.outfitCategory`
+
+- **Purpose:**  
+    Slot or category for the outfit.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.outfitCategory = "body"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.pacData = {}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.pacData`                                  | PAC3 customization information. | `Unknown`    | `ITEM.pacData = {}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.pacData`
+
+- **Purpose:**  
+    PAC3 customization information.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.pacData = {}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.postHooks = {}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.postHooks`                                  | Table of post-hook callbacks. | `Unknown`    | `ITEM.postHooks = {}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.postHooks`
+
+- **Purpose:**  
+    Table of post-hook callbacks.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.postHooks = {}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.price = 100
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.price`                                  | Item cost for trading or selling. | `Unknown`    | `ITEM.price = 100` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.price`
+
+- **Purpose:**  
+    Item cost for trading or selling.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.price = 100
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+item:getQuantity()
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.quantity`                                  | Current amount in the item stack. | `Unknown`    | `item:getQuantity()` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.quantity`
+
+- **Purpose:**  
+    Current amount in the item stack.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+item:getQuantity()
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.rarity = "Legendary"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.rarity`                                  | Rarity level affecting vendor color. | `Unknown`    | `ITEM.rarity = "Legendary"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.rarity`
+
+- **Purpose:**  
+    Rarity level affecting vendor color.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.rarity = "Legendary"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.replacements = "models/player/combine_soldier.mdl"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.replacements`                                  | Model replacements when equipped. | `Unknown`    | `ITEM.replacements = "models/player/combine_soldier.mdl"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.replacements`
+
+- **Purpose:**  
+    Model replacements when equipped.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.replacements = "models/player/combine_soldier.mdl"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.unequipSound = "items/ammo_pickup.wav"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.unequipSound`                                  | Sound played when unequipping. | `Unknown`    | `ITEM.unequipSound = "items/ammo_pickup.wav"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.unequipSound`
+
+- **Purpose:**  
+    Sound played when unequipping.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.unequipSound = "items/ammo_pickup.wav"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.uniqueID = "custom_unique_id"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.uniqueID`                                  | Overrides the automatically generated unique identifier. | `Unknown`    | `ITEM.uniqueID = "custom_unique_id"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.uniqueID`
+
+- **Purpose:**  
+    Overrides the automatically generated unique identifier.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.uniqueID = "custom_unique_id"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.url = "https://example.com"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.url`                                  | Web address opened when using the item. | `Unknown`    | `ITEM.url = "https://example.com"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.url`
+
+- **Purpose:**  
+    Web address opened when using the item.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.url = "https://example.com"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.visualData = {}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.visualData`                                  | Table storing outfit visual information. | `Unknown`    | `ITEM.visualData = {}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.visualData`
+
+- **Purpose:**  
+    Table storing outfit visual information.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.visualData = {}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.weaponCategory = "sidearm"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.weaponCategory`                                  | Slot category for the weapon. | `Unknown`    | `ITEM.weaponCategory = "sidearm"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.weaponCategory`
+
+- **Purpose:**  
+    Slot category for the weapon.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.weaponCategory = "sidearm"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+ITEM.width = 2
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ITEM.width`                                  | Width in inventory grid. | `Unknown`    | `ITEM.width = 2` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ITEM.width`
+
+- **Purpose:**  
+    Width in inventory grid.
+
+- **Type:**  
+    `Unknown`
+
+- **Example Usage:
+    ```lua
+ITEM.width = 2
+    ```
+
+---
+

--- a/docs/docs/framework/definitions/module.md
+++ b/docs/docs/framework/definitions/module.md
@@ -1,0 +1,613 @@
+---
+
+### **Example**
+
+```lua
+MODULE.name = "My Module"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `name`                                  | Identifies the module in logs and UI elements. | `string`    | `MODULE.name = "My Module"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `name`
+
+- **Purpose:**  
+    Identifies the module in logs and UI elements.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.name = "My Module"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.author = "Samael"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `author`                                  | Name or SteamID64 of the module's author. | `string`    | `MODULE.author = "Samael"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `author`
+
+- **Purpose:**  
+    Name or SteamID64 of the module's author.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.author = "Samael"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.discord = "@liliaplayer"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `discord`                                  | Discord tag or support channel for the module. | `string`    | `MODULE.discord = "@liliaplayer"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `discord`
+
+- **Purpose:**  
+    Discord tag or support channel for the module.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.discord = "@liliaplayer"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.version = "1.0"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `version`                                  | Version string used for compatibility checks. | `string`    | `MODULE.version = "1.0"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `version`
+
+- **Purpose:**  
+    Version string used for compatibility checks.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.version = "1.0"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.desc = "Adds a Chatbox"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `desc`                                  | Short description of what the module provides. | `string`    | `MODULE.desc = "Adds a Chatbox"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `desc`
+
+- **Purpose:**  
+    Short description of what the module provides.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.desc = "Adds a Chatbox"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.identifier = "example_mod"
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `identifier`                                  | Unique key used to reference this module globally. | `string`    | `MODULE.identifier = "example_mod"` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `identifier`
+
+- **Purpose:**  
+    Unique key used to reference this module globally.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+MODULE.identifier = "example_mod"
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.CAMIPrivileges = {
+{Name = "Staff Permissions - Admin Chat", MinAccess = "admin"}
+}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `CAMIPrivileges`                                  | Table defining CAMI privileges required or provided by the module. | `table`    | `MODULE.CAMIPrivileges = {
+{Name = "Staff Permissions - Admin Chat", MinAccess = "admin"}
+}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `CAMIPrivileges`
+
+- **Purpose:**  
+    Table defining CAMI privileges required or provided by the module.
+
+- **Type:**  
+    `table`
+
+- **Example Usage:
+    ```lua
+MODULE.CAMIPrivileges = {
+{Name = "Staff Permissions - Admin Chat", MinAccess = "admin"}
+}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.WorkshopContent = {"2959728255"}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `WorkshopContent`                                  | Steam Workshop add-on IDs required by this module. | `table`    | `MODULE.WorkshopContent = {"2959728255"}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `WorkshopContent`
+
+- **Purpose:**  
+    Steam Workshop add-on IDs required by this module.
+
+- **Type:**  
+    `table`
+
+- **Example Usage:
+    ```lua
+MODULE.WorkshopContent = {"2959728255"}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.enabled = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `enabled`                                  | Boolean or function that controls whether the module loads. | `boolean or function`    | `MODULE.enabled = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `enabled`
+
+- **Purpose:**  
+    Boolean or function that controls whether the module loads.
+
+- **Type:**  
+    `boolean or function`
+
+- **Example Usage:
+    ```lua
+MODULE.enabled = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.Dependencies = {
+{File = "logs.lua", Realm = "server"}
+}
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `Dependencies`                                  | Files or folders that this module requires to run. | `table`    | `MODULE.Dependencies = {
+{File = "logs.lua", Realm = "server"}
+}` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `Dependencies`
+
+- **Purpose:**  
+    Files or folders that this module requires to run.
+
+- **Type:**  
+    `table`
+
+- **Example Usage:
+    ```lua
+MODULE.Dependencies = {
+{File = "logs.lua", Realm = "server"}
+}
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+print(MODULE.folder)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `folder`                                  | Filesystem path where the module is located. | `string`    | `print(MODULE.folder)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `folder`
+
+- **Purpose:**  
+    Filesystem path where the module is located.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+print(MODULE.folder)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+print(MODULE.path)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `path`                                  | Absolute path to the module's root directory. | `string`    | `print(MODULE.path)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `path`
+
+- **Purpose:**  
+    Absolute path to the module's root directory.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+print(MODULE.path)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+print(MODULE.uniqueID)
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `uniqueID`                                  | Identifier used internally for the module list. | `string`    | `print(MODULE.uniqueID)` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `uniqueID`
+
+- **Purpose:**  
+    Identifier used internally for the module list.
+
+- **Type:**  
+    `string`
+
+- **Example Usage:
+    ```lua
+print(MODULE.uniqueID)
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+if MODULE.loading then return end
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `loading`                                  | True while the module is in the process of loading. | `boolean`    | `if MODULE.loading then return end` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `loading`
+
+- **Purpose:**  
+    True while the module is in the process of loading.
+
+- **Type:**  
+    `boolean`
+
+- **Example Usage:
+    ```lua
+if MODULE.loading then return end
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+function MODULE:ModuleLoaded()
+print("Module fully initialized")
+end
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `ModuleLoaded`                                  | Optional callback run after the module finishes loading. | `function`    | `function MODULE:ModuleLoaded()
+print("Module fully initialized")
+end` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `ModuleLoaded`
+
+- **Purpose:**  
+    Optional callback run after the module finishes loading.
+
+- **Type:**  
+    `function`
+
+- **Example Usage:
+    ```lua
+function MODULE:ModuleLoaded()
+print("Module fully initialized")
+end
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.Public = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `Public`                                  | When true, the module participates in public version checks. | `boolean`    | `MODULE.Public = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `Public`
+
+- **Purpose:**  
+    When true, the module participates in public version checks.
+
+- **Type:**  
+    `boolean`
+
+- **Example Usage:
+    ```lua
+MODULE.Public = true
+    ```
+
+---
+
+---
+
+### **Example**
+
+```lua
+MODULE.Private = true
+```
+
+---
+
+### **Key Variables Explained**
+
+| **Variable**                                 | **Purpose**                                                                                                     | **Type**   | **Example**                           |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|
+| `Private`                                  | When true, the module uses private version checking. | `boolean`    | `MODULE.Private = true` |
+
+---
+
+### **Detailed Descriptions**
+
+#### 1. `Private`
+
+- **Purpose:**  
+    When true, the module uses private version checking.
+
+- **Type:**  
+    `boolean`
+
+- **Example Usage:
+    ```lua
+MODULE.Private = true
+    ```
+
+---
+

--- a/parse_definition_docs.py
+++ b/parse_definition_docs.py
@@ -1,0 +1,119 @@
+import os
+import re
+from pathlib import Path
+
+
+def guess_type(example: str) -> str:
+    example = example.strip()
+    if not example:
+        return "Unknown"
+    if example.startswith("function"):
+        return "Function"
+    if example.startswith("{") and example.endswith("}"):
+        return "Table"
+    if example.lower() in {"true", "false"}:
+        return "Boolean"
+    if re.fullmatch(r"[-+]?[0-9]+", example):
+        return "Number"
+    if re.fullmatch(r"[-+]?[0-9]*\.[0-9]+", example):
+        return "Number"
+    if example.startswith("\"") or example.startswith("'"):
+        return "String"
+    if "Color(" in example:
+        return "Color"
+    return "Unknown"
+
+
+def parse_blocks(text: str):
+    pattern = r"--\[\[(.*?)\]\]"
+    blocks = re.findall(pattern, text, flags=re.S)
+    results = []
+    for block in blocks:
+        lines = [l.rstrip() for l in block.splitlines()]
+        # trim empty lines
+        while lines and lines[0].strip() == "":
+            lines.pop(0)
+        while lines and lines[-1].strip() == "":
+            lines.pop()
+        if not lines:
+            continue
+        if not any("Example Usage:" in l for l in lines):
+            continue  # skip non-field blocks
+        name = lines[0].strip()
+        current = None
+        fields = {}
+        buf = []
+        for line in lines[1:]:
+            m = re.match(r"\s*([A-Za-z ]+):\s*$", line)
+            if m:
+                if current:
+                    fields[current] = "\n".join(buf).strip()
+                    buf = []
+                current = m.group(1)
+            else:
+                buf.append(line.strip())
+        if current:
+            fields[current] = "\n".join(buf).strip()
+        results.append({"name": name, "fields": fields})
+    return results
+
+
+def build_section(entry):
+    name = entry["name"]
+    fields = entry["fields"]
+    example = fields.get("Example Usage", "").strip()
+    desc = fields.get("Description", "").strip()
+    var_type = fields.get("Type", "").strip()
+    if not var_type:
+        var_type = guess_type(example.splitlines()[0] if example else "")
+    table = (
+        "| **Variable**                                 | **Purpose**" +
+        "                                                                                                     | **Type**   | **Example**                           |\n" +
+        "|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|------------|---------------------------------------|\n" +
+        f"| `{name}`                                  | {desc} | `{var_type}`    | `{example}` |"
+    )
+    detailed = (
+        f"#### 1. `{name}`\n\n" +
+        "- **Purpose:**  \n" +
+        f"    {desc}\n\n" +
+        "- **Type:**  \n" +
+        f"    `{var_type}`\n\n" +
+        "- **Example Usage:" +
+        "\n    ```lua\n" +
+        "\n".join(f"{line}" for line in example.splitlines()) +
+        "\n    ```\n"
+    )
+    section = (
+        "---\n\n" +
+        "### **Example**\n\n" +
+        "```lua\n" +
+        "\n".join(example.splitlines()) +
+        "\n```\n\n" +
+        "---\n\n" +
+        "### **Key Variables Explained**\n\n" +
+        table +
+        "\n\n---\n\n" +
+        "### **Detailed Descriptions**\n\n" +
+        detailed +
+        "\n---\n"
+    )
+    return section
+
+
+def main():
+    definitions_dir = Path("docs/definitions")
+    out_base = Path("docs/docs/framework/definitions")
+    out_base.mkdir(parents=True, exist_ok=True)
+    for file in definitions_dir.glob("*.lua"):
+        basename = file.stem
+        prefix = basename.split("_")[0]
+        out_path = out_base / f"{prefix}.md"
+        text = file.read_text(encoding="utf-8")
+        entries = parse_blocks(text)
+        with open(out_path, "a", encoding="utf-8") as f:
+            for entry in entries:
+                section = build_section(entry)
+                f.write(section + "\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to parse definition docs
- auto-generate markdown docs for definitions

## Testing
- `python3 parse_definition_docs.py`
- `python3 -m py_compile parse_definition_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_685c992b3d688327bf2a679e6e431864