### PR TITLE
Fix missing localization entry

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -814,4 +814,7 @@ LANGUAGE = {
     noPreviousSitroomPos = "No previous sitroom position found.",
     sitroomReturnSuccess = "Returned %s to their previous position.",
     sitroomReturned = "Returned to your previous position.",
+    TogglePropBlacklist = "Toggle Prop Blacklist",
+    addedToBlacklist = "Added to blacklist: %s",
+    removedFromBlacklist = "Removed from blacklist: %s",
 }

--- a/modules/core/administration/libraries/shared.lua
+++ b/modules/core/administration/libraries/shared.lua
@@ -19,11 +19,11 @@ properties.Add("TogglePropBlacklist", {
         if table.HasValue(list, model) then
             table.RemoveByValue(list, model)
             lia.data.set("blacklist", list, true, true)
-            ply:ChatPrint("Removed from blacklist: " .. model)
+            ply:notifyLocalized("removedFromBlacklist", model)
         else
             table.insert(list, model)
             lia.data.set("blacklist", list, true, true)
-            ply:ChatPrint("Added to blacklist: " .. model)
+            ply:notifyLocalized("addedToBlacklist", model)
         end
     end
 })


### PR DESCRIPTION
## Summary
- add new localization strings for prop blacklist management
- localize blacklist notifications
- add newline at EOF for touched files

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e14955c048327a7574b1c210b8d4e