### PR TITLE
Revise library docs

### DIFF
--- a/docs/lua/libraries/menu.lua
+++ b/docs/lua/libraries/menu.lua
@@ -1,0 +1,72 @@
+--[[
+    lia.menu.add(opts, pos, onRemove)
+
+    Description:
+        Creates a new world or entity menu using the entries provided in 'opts'.
+        Keys are display text and values are callback functions executed when
+        selected. The menu may be positioned at a world Vector or anchored to
+        an entity.
+
+    Parameters:
+        opts (table) – Table of label/callback pairs.
+        pos (Vector|Entity|nil) – World position or entity to attach the menu to.
+        onRemove (function|nil) – Called when the menu is removed.
+
+    Realm:
+        Client
+
+    Returns:
+        number – Identifier for the created menu entry.
+]]
+
+--[[
+    lia.menu.drawAll()
+
+    Description:
+        Draws all active menus on the player's screen. Typically called from
+        HUDPaint.
+
+    Parameters:
+        None
+
+    Realm:
+        Client
+
+    Returns:
+        nil
+]]
+
+--[[
+    lia.menu.getActiveMenu()
+
+    Description:
+        Returns the ID and callback of the menu item currently being hovered
+        or selected by the player.
+
+    Parameters:
+        None
+
+    Realm:
+        Client
+
+    Returns:
+        id (number|nil) – Index of the active menu.
+        callback (function|nil) – Callback for the hovered item.
+]]
+
+--[[
+    lia.menu.onButtonPressed(id, callback)
+
+    Description:
+        Removes the specified menu and runs its callback if provided.
+
+    Parameters:
+        id (number) – Identifier returned by lia.menu.add.
+        callback (function|nil) – Function to execute after removal.
+
+    Realm:
+        Client
+
+    Returns:
+        boolean – True if a callback was executed.
+]]

--- a/docs/lua/libraries/networking.lua
+++ b/docs/lua/libraries/networking.lua
@@ -1,0 +1,36 @@
+--[[
+    setNetVar(key, value, receiver)
+
+    Description:
+        Stores a global networked variable and broadcasts it to clients. When a
+        receiver is specified the update is only sent to those players.
+
+    Parameters:
+        key (string) – Name of the variable.
+        value (any) – Value to store.
+        receiver (Player|table|nil) – Optional receiver(s) for the update.
+
+    Realm:
+        Server
+
+    Returns:
+        nil
+]]
+
+--[[
+    getNetVar(key, default)
+
+    Description:
+        Retrieves a global networked variable previously set by setNetVar.
+
+    Parameters:
+        key (string) – Variable name.
+        default (any) – Fallback value if the variable is not set.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Stored value or default.
+]]
+

--- a/docs/lua/libraries/webimage.lua
+++ b/docs/lua/libraries/webimage.lua
@@ -1,0 +1,38 @@
+--[[
+    lia.webimage.register(name, url, callback, flags)
+
+    Description:
+        Downloads an image from the specified URL and caches it within the
+        data folder. Once available, the provided callback receives the
+        resulting Material.
+
+    Parameters:
+        name (string) – Unique file name including extension.
+        url (string) – HTTP address of the image.
+        callback (function|nil) – Called with (Material, fromCache, err).
+        flags (string|nil) – Optional material flags for Material().
+
+    Realm:
+        Client
+
+    Returns:
+        nil
+]]
+
+--[[
+    lia.webimage.get(name, flags)
+
+    Description:
+        Retrieves a Material for a previously registered image if it exists in
+        the cache.
+
+    Parameters:
+        name (string) – File name used during registration.
+        flags (string|nil) – Optional material flags.
+
+    Realm:
+        Client
+
+    Returns:
+        Material|nil – The image material or nil if missing.
+]]


### PR DESCRIPTION
## Summary
- document networking helpers
- keep docs for menu and webimage libraries

## Testing
- `luacheck . --no-redefined --no-global --no-self --no-max-line-length --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e19be543c8327b9e5c2c9b4eca832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation for menu management functions, including creating, drawing, and interacting with menus.
  * Introduced documentation for networking functions to set and get global networked variables.
  * Provided documentation for web image functions, detailing how to register and retrieve cached images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->