### PR TITLE
Improve meta docs formatting

### DIFF
--- a/docs/lua/meta/character.lua
+++ b/docs/lua/meta/character.lua
@@ -1,0 +1,343 @@
+--[[
+    tostring()
+
+    Description:
+        Returns a printable identifier for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Format "character[id]".
+
+    Example Usage:
+        local result = char:tostring()
+]]
+--[[
+    eq(other)
+
+    Description:
+        Compares two characters by ID for equality.
+
+    Parameters:
+        other (Character) – Character to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both share the same ID.
+
+    Example Usage:
+        local result = char:eq(other)
+]]
+--[[
+    getID()
+
+    Description:
+        Returns the unique database ID for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Character identifier.
+
+    Example Usage:
+        local result = char:getID()
+]]
+--[[
+    getPlayer()
+
+    Description:
+        Returns the player entity currently controlling this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|nil – Owning player or nil.
+
+    Example Usage:
+        local result = char:getPlayer()
+]]
+--[[
+    getDisplayedName(client)
+
+    Description:
+        Returns the character's name as it should be shown to the given player.
+
+    Parameters:
+        client (Player) – Player requesting the name.
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Localized or recognized character name.
+
+    Example Usage:
+        local result = char:getDisplayedName(client)
+]]
+--[[
+    hasMoney(amount)
+
+    Description:
+        Checks if the character has at least the given amount of money.
+
+    Parameters:
+        amount (number) – Amount to check for.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the character's funds are sufficient.
+
+    Example Usage:
+        local result = char:hasMoney(amount)
+]]
+--[[
+    getFlags()
+
+    Description:
+        Retrieves the string of permission flags for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Concatenated flag characters.
+
+    Example Usage:
+        local result = char:getFlags()
+]]
+--[[
+    hasFlags(flags)
+
+    Description:
+        Checks if the character possesses any of the specified flags.
+
+    Parameters:
+        flags (string) – String of flag characters to check.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if at least one flag is present.
+
+    Example Usage:
+        local result = char:hasFlags(flags)
+]]
+--[[
+    getItemWeapon(requireEquip)
+
+    Description:
+        Checks the player's active weapon against items in the inventory.
+
+    Parameters:
+        requireEquip (boolean) – Only match equipped items if true.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the active weapon corresponds to an item.
+
+    Example Usage:
+        local result = char:getItemWeapon(requireEquip)
+]]
+--[[
+    getMaxStamina()
+
+    Description:
+        Returns the maximum stamina value for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Maximum stamina points.
+
+    Example Usage:
+        local result = char:getMaxStamina()
+]]
+--[[
+    getStamina()
+
+    Description:
+        Retrieves the character's current stamina value.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Current stamina.
+
+    Example Usage:
+        local result = char:getStamina()
+]]
+--[[
+    hasClassWhitelist(class)
+
+    Description:
+        Checks if the character has whitelisted the given class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the class is whitelisted.
+
+    Example Usage:
+        local result = char:hasClassWhitelist(class)
+]]
+--[[
+    isFaction(faction)
+
+    Description:
+        Returns true if the character's faction matches.
+
+    Parameters:
+        faction (number) – Faction index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the faction matches.
+
+    Example Usage:
+        local result = char:isFaction(faction)
+]]
+--[[
+    isClass(class)
+
+    Description:
+        Returns true if the character's class equals the specified class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the classes match.
+
+    Example Usage:
+        local result = char:isClass(class)
+]]
+--[[
+    getAttrib(key, default)
+
+    Description:
+        Retrieves the value of an attribute including boosts.
+
+    Parameters:
+        key (string) – Attribute identifier.
+        default (number) – Default value when attribute is missing.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Final attribute value.
+
+    Example Usage:
+        local result = char:getAttrib(key, default)
+]]
+--[[
+    getBoost(attribID)
+
+    Description:
+        Returns the boost table for the given attribute.
+
+    Parameters:
+        attribID (string) – Attribute identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        table|nil – Table of boosts or nil.
+
+    Example Usage:
+        local result = char:getBoost(attribID)
+]]
+--[[
+    getBoosts()
+
+    Description:
+        Retrieves all attribute boosts for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Mapping of attribute IDs to boost tables.
+
+    Example Usage:
+        local result = char:getBoosts()
+]]
+--[[
+    doesRecognize(id)
+
+    Description:
+        Determines if this character recognizes another character.
+
+    Parameters:
+        id (number|Character) – Character ID or object to check.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if recognized.
+
+    Example Usage:
+        local result = char:doesRecognize(id)
+]]
+--[[
+    doesFakeRecognize(id)
+
+    Description:
+        Checks if the character has a fake recognition entry for another.
+
+    Parameters:
+        id (number|Character) – Character identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if fake recognized.
+
+    Example Usage:
+        local result = char:doesFakeRecognize(id)
+]]

--- a/docs/lua/meta/entity.lua
+++ b/docs/lua/meta/entity.lua
@@ -1,0 +1,470 @@
+--[[
+    isProp()
+
+    Description:
+        Returns true if the entity is a physics prop.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the entity is a physics prop.
+
+    Example Usage:
+        local result = ent:isProp()
+]]
+--[[
+    isItem()
+
+    Description:
+        Checks if the entity is an item entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the entity represents an item.
+
+    Example Usage:
+        local result = ent:isItem()
+]]
+--[[
+    isMoney()
+
+    Description:
+        Checks if the entity is a money entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the entity represents money.
+
+    Example Usage:
+        local result = ent:isMoney()
+]]
+--[[
+    isSimfphysCar()
+
+    Description:
+        Checks if the entity is a simfphys car.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if this is a simfphys vehicle.
+
+    Example Usage:
+        local result = ent:isSimfphysCar()
+]]
+--[[
+    isLiliaPersistent()
+
+    Description:
+        Determines if the entity is persistent in Lilia.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the entity should persist.
+
+    Example Usage:
+        local result = ent:isLiliaPersistent()
+]]
+--[[
+    checkDoorAccess(client, access)
+
+    Description:
+        Checks if a player has the given door access level.
+
+    Parameters:
+        client (Player) – The player to check.
+        access (number, optional) – Door permission level.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the player has access.
+
+    Example Usage:
+        local result = ent:checkDoorAccess(client, access)
+]]
+--[[
+    keysOwn(client)
+
+    Description:
+        Assigns the entity to the specified player.
+
+    Parameters:
+        client (Player) – Player to set as owner.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = ent:keysOwn(client)
+]]
+--[[
+    keysLock()
+
+    Description:
+        Locks the entity if it is a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = ent:keysLock()
+]]
+--[[
+    keysUnLock()
+
+    Description:
+        Unlocks the entity if it is a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = ent:keysUnLock()
+]]
+--[[
+    getDoorOwner()
+
+    Description:
+        Returns the player that owns this door if available.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|nil – Door owner or nil.
+
+    Example Usage:
+        local result = ent:getDoorOwner()
+]]
+--[[
+    isLocked()
+
+    Description:
+        Returns the locked state stored in net variables.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the door is locked.
+
+    Example Usage:
+        local result = ent:isLocked()
+]]
+--[[
+    isDoorLocked()
+
+    Description:
+        Checks the internal door locked state.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the door is locked.
+
+    Example Usage:
+        local result = ent:isDoorLocked()
+]]
+--[[
+    getEntItemDropPos(offset)
+
+    Description:
+        Calculates a drop position in front of the entity's eyes.
+
+    Parameters:
+        offset (number) – Distance from the player eye position.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – Drop position and angle.
+
+    Example Usage:
+        local result = ent:getEntItemDropPos(offset)
+]]
+--[[
+    isNearEntity(radius, otherEntity)
+
+    Description:
+        Checks for another entity of the same class nearby.
+
+    Parameters:
+        radius (number) – Sphere radius in units.
+        otherEntity (Entity, optional) – Specific entity to look for.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if another entity is within radius.
+
+    Example Usage:
+        local result = ent:isNearEntity(radius, otherEntity)
+]]
+--[[
+    GetCreator()
+
+    Description:
+        Returns the entity creator player.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|nil – Creator player if stored.
+
+    Example Usage:
+        local result = ent:GetCreator()
+]]
+--[[
+        SetCreator(client)
+
+        Description:
+            Stores the creator player on the entity.
+
+        Parameters:
+            client (Player) – Creator of the entity.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = ent:SetCreator(client)
+    ]]
+--[[
+        sendNetVar(key, receiver)
+
+        Description:
+            Sends a network variable to recipients.
+
+        Parameters:
+            key (string) – Identifier of the variable.
+            receiver (Player|nil) – Who to send to.
+
+        Realm:
+            Server
+
+        Internal:
+            Used by the networking system.
+
+    Example Usage:
+        local result = ent:sendNetVar(key, receiver)
+    ]]
+--[[
+        clearNetVars(receiver)
+
+        Description:
+            Clears all network variables on this entity.
+
+        Parameters:
+            receiver (Player|nil) – Receiver to notify.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = ent:clearNetVars(receiver)
+    ]]
+--[[
+        removeDoorAccessData()
+
+        Description:
+            Clears all stored door access information.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = ent:removeDoorAccessData()
+    ]]
+--[[
+        setLocked(state)
+
+        Description:
+            Stores the door locked state in network variables.
+
+        Parameters:
+            state (boolean) – New locked state.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = ent:setLocked(state)
+    ]]
+--[[
+        isDoor()
+
+        Description:
+            Returns true if the entity's class indicates a door.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+        Returns:
+            boolean – Whether the entity is a door.
+
+    Example Usage:
+        local result = ent:isDoor()
+    ]]
+--[[
+        getDoorPartner()
+
+        Description:
+            Returns the partner door linked with this entity.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+        Returns:
+            Entity|nil – The partnered door.
+
+    Example Usage:
+        local result = ent:getDoorPartner()
+    ]]
+--[[
+        setNetVar(key, value, receiver)
+
+        Description:
+            Updates a network variable and sends it to recipients.
+
+        Parameters:
+            key (string) – Variable name.
+            value (any) – Value to store.
+            receiver (Player|nil) – Who to send update to.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = ent:setNetVar(key, value, receiver)
+    ]]
+--[[
+        getNetVar(key, default)
+
+        Description:
+            Retrieves a stored network variable or a default value.
+
+        Parameters:
+            key (string) – Variable name.
+            default (any) – Value returned if variable is nil.
+
+        Realm:
+            Server
+            Client
+
+        Returns:
+            any – Stored value or default.
+
+    Example Usage:
+        local result = ent:getNetVar(key, default)
+    ]]
+--[[
+        isDoor()
+
+        Description:
+            Client-side door check using class name.
+
+    Parameters:
+        None
+
+        Realm:
+            Client
+
+        Returns:
+            boolean – True if entity class contains "door".
+
+    Example Usage:
+        local result = ent:isDoor()
+    ]]
+--[[
+        getDoorPartner()
+
+        Description:
+            Attempts to find the door partnered with this one.
+
+    Parameters:
+        None
+
+        Realm:
+            Client
+
+        Returns:
+            Entity|nil – The partner door entity.
+
+    Example Usage:
+        local result = ent:getDoorPartner()
+    ]]
+--[[
+        getNetVar(key, default)
+
+        Description:
+            Retrieves a network variable for this entity on the client.
+
+        Parameters:
+            key (string) – Variable name.
+            default (any) – Default if not set.
+
+        Realm:
+            Client
+
+        Returns:
+            any – Stored value or default.
+
+    Example Usage:
+        local result = ent:getNetVar(key, default)
+    ]]

--- a/docs/lua/meta/inventory.lua
+++ b/docs/lua/meta/inventory.lua
@@ -1,0 +1,393 @@
+--[[
+    getData(key, default)
+
+    Description:
+        Returns a stored data value for this inventory.
+
+    Parameters:
+        key (string) – Data field key.
+        default (any) – Value if the key does not exist.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Stored value or default.
+
+    Example Usage:
+        local result = inv:getData(key, default)
+]]
+--[[
+    extend(className)
+
+    Description:
+        Creates a subclass of the inventory meta table with a new class name.
+
+    Parameters:
+        className (string) – Name of the subclass meta table.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – The newly derived inventory table.
+
+    Example Usage:
+        local result = inv:extend(className)
+]]
+--[[
+    configure()
+
+    Description:
+        Stub for inventory configuration; meant to be overridden.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = inv:configure()
+]]
+--[[
+    addDataProxy(key, onChange)
+
+    Description:
+        Adds a proxy function that is called when a data field changes.
+
+    Parameters:
+        key (string) – Data field to watch.
+        onChange (function) – Callback receiving old and new values.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = inv:addDataProxy(key, onChange)
+]]
+--[[
+    getItemsByUniqueID(uniqueID, onlyMain)
+
+    Description:
+        Returns all items in the inventory matching the given unique ID.
+
+    Parameters:
+        uniqueID (string) – Item unique identifier.
+        onlyMain (boolean) – Search only the main item list.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Table of matching item objects.
+
+    Example Usage:
+        local result = inv:getItemsByUniqueID(uniqueID, onlyMain)
+]]
+--[[
+    register(typeID)
+
+    Description:
+        Registers this inventory type with the lia.inventory system.
+
+    Parameters:
+        typeID (string) – Unique identifier for this inventory type.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = inv:register(typeID)
+]]
+--[[
+    new()
+
+    Description:
+        Creates a new inventory of this type.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – New inventory instance.
+
+    Example Usage:
+        local result = inv:new()
+]]
+--[[
+    tostring()
+
+    Description:
+        Returns a printable representation of this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Formatted as "ClassName[id]".
+
+    Example Usage:
+        local result = inv:tostring()
+]]
+--[[
+    getType()
+
+    Description:
+        Retrieves the inventory type table from lia.inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Inventory type definition.
+
+    Example Usage:
+        local result = inv:getType()
+]]
+--[[
+    onDataChanged(key, oldValue, newValue)
+
+    Description:
+        Called when an inventory data field changes. Executes any
+        registered proxy callbacks for that field.
+
+    Parameters:
+        key (string) – Data field key.
+        oldValue (any) – Previous value.
+        newValue (any) – Updated value.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = inv:onDataChanged(key, oldValue, newValue)
+]]
+--[[
+    getItems()
+
+    Description:
+        Returns all items stored in this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Item instance table indexed by itemID.
+
+    Example Usage:
+        local result = inv:getItems()
+]]
+--[[
+    getItemsOfType(itemType)
+
+    Description:
+        Collects all items that match the given unique ID.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Array of matching items.
+
+    Example Usage:
+        local result = inv:getItemsOfType(itemType)
+]]
+--[[
+    getFirstItemOfType(itemType)
+
+    Description:
+        Retrieves the first item matching the given unique ID.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        Item|nil – The first matching item or nil.
+
+    Example Usage:
+        local result = inv:getFirstItemOfType(itemType)
+]]
+--[[
+    hasItem(itemType)
+
+    Description:
+        Determines whether the inventory contains an item type.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if an item is found.
+
+    Example Usage:
+        local result = inv:hasItem(itemType)
+]]
+--[[
+    getItemCount(itemType)
+
+    Description:
+        Counts the total quantity of a specific item type.
+
+    Parameters:
+        itemType (string|nil) – Item unique ID to count. Counts all if nil.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Sum of quantities.
+
+    Example Usage:
+        local result = inv:getItemCount(itemType)
+]]
+--[[
+    getID()
+
+    Description:
+        Returns the unique database ID of this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Inventory identifier.
+
+    Example Usage:
+        local result = inv:getID()
+]]
+--[[
+    eq(other)
+
+    Description:
+        Compares two inventories by ID for equality.
+
+    Parameters:
+        other (Inventory) – Other inventory to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both inventories share the same ID.
+
+    Example Usage:
+        local result = inv:eq(other)
+]]
+--[[
+        addItem(item, noReplicate)
+
+        Description:
+            Inserts an item instance into this inventory and persists it.
+
+        Parameters:
+            item (Item) – Item to add.
+            noReplicate (boolean) – Skip network replication when true.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:addItem(item, noReplicate)
+    ]]
+--[[
+        removeItem(itemID, preserveItem)
+
+        Description:
+            Removes an item by ID and optionally deletes it.
+
+        Parameters:
+            itemID (number) – Unique item identifier.
+            preserveItem (boolean) – Keep item in database when true.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:removeItem(itemID, preserveItem)
+    ]]
+--[[
+        syncData(key, recipients)
+
+        Description:
+            Sends a single data field to clients.
+
+        Parameters:
+            key (string) – Field to replicate.
+            recipients (table|nil) – Player recipients.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:syncData(key, recipients)
+    ]]
+--[[
+        sync(recipients)
+
+        Description:
+            Sends the entire inventory and its items to players.
+
+        Parameters:
+            recipients (table|nil) – Player recipients.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:sync(recipients)
+    ]]
+--[[
+        delete()
+
+        Description:
+            Removes this inventory record from the database.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:delete()
+    ]]
+--[[
+        destroy()
+
+        Description:
+            Destroys all items and removes network references.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = inv:destroy()
+    ]]

--- a/docs/lua/meta/item.lua
+++ b/docs/lua/meta/item.lua
@@ -1,0 +1,314 @@
+--[[
+    getQuantity()
+
+    Description:
+        Retrieves how many of this item the stack represents.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Quantity contained in this item instance.
+
+    Example Usage:
+        local result = item:getQuantity()
+]]
+--[[
+    eq(other)
+
+    Description:
+        Compares this item instance to another by ID.
+
+    Parameters:
+        other (Item) – The other item to compare with.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both items share the same ID.
+
+    Example Usage:
+        local result = item:eq(other)
+]]
+--[[
+    tostring()
+
+    Description:
+        Returns a printable representation of this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Identifier in the form "item[uniqueID][id]".
+
+    Example Usage:
+        local result = item:tostring()
+]]
+--[[
+    getID()
+
+    Description:
+        Retrieves the unique identifier of this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Item database ID.
+
+    Example Usage:
+        local result = item:getID()
+]]
+--[[
+    getModel()
+
+    Description:
+        Returns the model path associated with this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Model path.
+
+    Example Usage:
+        local result = item:getModel()
+]]
+--[[
+    getSkin()
+
+    Description:
+        Retrieves the skin index this item uses.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Skin ID applied to the model.
+
+    Example Usage:
+        local result = item:getSkin()
+]]
+--[[
+    getPrice()
+
+    Description:
+        Returns the calculated purchase price for the item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The price value.
+
+    Example Usage:
+        local result = item:getPrice()
+]]
+--[[
+    call(method, client, entity, ...)
+
+    Description:
+        Invokes an item method with the given player and entity context.
+
+    Parameters:
+        method (string) – Method name to run.
+        client (Player) – The player performing the action.
+        entity (Entity) – Entity representing this item.
+        ... – Additional arguments passed to the method.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Results returned by the called function.
+
+    Example Usage:
+        local result = item:call(method, client, entity, ...)
+]]
+--[[
+    getOwner()
+
+    Description:
+        Attempts to find the player currently owning this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|nil – The owner if available.
+
+    Example Usage:
+        local result = item:getOwner()
+]]
+--[[
+    getData(key, default)
+
+    Description:
+        Retrieves a piece of persistent data stored on the item.
+
+    Parameters:
+        key (string) – Data key to read.
+        default (any) – Value to return when the key is absent.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Stored value or default.
+
+    Example Usage:
+        local result = item:getData(key, default)
+]]
+--[[
+    getAllData()
+
+    Description:
+        Returns a merged table of this item's stored data and any
+        networked values on its entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Key/value table of all data fields.
+
+    Example Usage:
+        local result = item:getAllData()
+]]
+--[[
+    hook(name, func)
+
+    Description:
+        Registers a hook callback for this item instance.
+
+    Parameters:
+        name (string) – Hook identifier.
+        func (function) – Function to call.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = item:hook(name, func)
+]]
+--[[
+    postHook(name, func)
+
+    Description:
+        Registers a post-hook callback for this item.
+
+    Parameters:
+        name (string) – Hook identifier.
+        func (function) – Function invoked after the main hook.
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = item:postHook(name, func)
+]]
+--[[
+    onRegistered()
+
+    Description:
+        Called when the item table is first registered.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = item:onRegistered()
+]]
+--[[
+    print(detail)
+
+    Description:
+        Prints a simple representation of the item to the console.
+
+    Parameters:
+        detail (boolean) – Include position details when true.
+
+    Realm:
+        Server
+
+    Example Usage:
+        local result = item:print(detail)
+]]
+--[[
+    printData()
+
+    Description:
+        Debug helper that prints all stored item data.
+
+    Parameters:
+        None
+
+    Realm:
+        Server
+
+    Example Usage:
+        local result = item:printData()
+]]
+--[[
+        addQuantity(quantity, receivers, noCheckEntity)
+
+        Description:
+            Increases the stored quantity for this item instance.
+
+        Parameters:
+            quantity (number) – Amount to add.
+            receivers (Player|nil) – Who to network the change to.
+            noCheckEntity (boolean) – Skip entity network update.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = item:addQuantity(quantity, receivers, noCheckEntity)
+    ]]
+--[[
+        setQuantity(quantity, receivers, noCheckEntity)
+
+        Description:
+            Sets the current stack quantity and replicates the change.
+
+        Parameters:
+            quantity (number) – New amount to store.
+            receivers (Player|nil) – Recipients to send updates to.
+            noCheckEntity (boolean) – Skip entity updates when true.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = item:setQuantity(quantity, receivers, noCheckEntity)
+    ]]

--- a/docs/lua/meta/panel.lua
+++ b/docs/lua/meta/panel.lua
@@ -1,0 +1,22 @@
+--[[
+    Screen-scaling helper wrappers for Panel positioning functions.
+
+    Description:
+        These helpers apply ScreenScale and ScreenScaleH to common panel
+        positioning and sizing methods so that user interfaces remain
+        consistent across different resolutions.
+
+    Parameters:
+        None
+
+    Realm:
+        Client
+
+    Returns:
+        any – Whatever the wrapped Panel function returns.
+
+    Example Usage:
+        local frame = vgui.Create("DFrame")
+        frame:SetSize(200, 100)
+        frame:SetPos(25, 25)
+]]

--- a/docs/lua/meta/player.lua
+++ b/docs/lua/meta/player.lua
@@ -1,0 +1,596 @@
+--[[
+        getChar()
+
+        Description:
+            Returns the currently loaded character object for this player.
+
+    Parameters:
+        None
+
+        Realm:
+            Shared
+
+        Returns:
+            Character|nil – The player's active character.
+
+    Example Usage:
+        local result = player:getChar()
+    ]]
+--[[
+        Name()
+
+        Description:
+            Returns either the character's roleplay name or the player's Steam name.
+
+    Parameters:
+        None
+
+        Realm:
+            Shared
+
+        Returns:
+            string – Display name.
+
+    Example Usage:
+        local result = player:Name()
+    ]]
+--[[
+    hasPrivilege(privilegeName)
+
+    Description:
+        Wrapper for CAMI privilege checks.
+
+    Parameters:
+        privilegeName (string) – Privilege identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from CAMI.PlayerHasAccess.
+
+    Example Usage:
+        local result = player:hasPrivilege(privilegeName)
+]]
+--[[
+    getCurrentVehicle()
+
+    Description:
+        Safely returns the vehicle the player is currently using.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|nil – Vehicle entity or nil.
+
+    Example Usage:
+        local result = player:getCurrentVehicle()
+]]
+--[[
+    hasValidVehicle()
+
+    Description:
+        Determines if the player is currently inside a valid vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if a vehicle entity is valid.
+
+    Example Usage:
+        local result = player:hasValidVehicle()
+]]
+--[[
+    isNoClipping()
+
+    Description:
+        Returns true if the player is in noclip mode and not inside a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the player is noclipping.
+
+    Example Usage:
+        local result = player:isNoClipping()
+]]
+--[[
+    getItems()
+
+    Description:
+        Returns the player's inventory item list if a character is loaded.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table|nil – Table of items or nil if absent.
+
+    Example Usage:
+        local result = player:getItems()
+]]
+--[[
+    getTracedEntity(distance)
+
+    Description:
+        Performs a simple trace from the player's shoot position.
+
+    Parameters:
+        distance (number) – Trace length in units.
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|nil – The entity hit or nil.
+
+    Example Usage:
+        local result = player:getTracedEntity(distance)
+]]
+--[[
+    getTrace(distance)
+
+    Description:
+        Returns a hull trace in front of the player.
+
+    Parameters:
+        distance (number) – Hull length in units.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Trace result.
+
+    Example Usage:
+        local result = player:getTrace(distance)
+]]
+--[[
+    getEyeEnt(distance)
+
+    Description:
+        Returns the entity the player is looking at within a distance.
+
+    Parameters:
+        distance (number) – Maximum distance.
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|nil – The entity or nil if too far.
+
+    Example Usage:
+        local result = player:getEyeEnt(distance)
+]]
+--[[
+    notify(message)
+
+    Description:
+        Sends a plain notification message to the player.
+
+    Parameters:
+        message (string) – Text to display.
+
+    Realm:
+        Server
+
+    Example Usage:
+        local result = player:notify(message)
+]]
+--[[
+    notifyLocalized(message, ...)
+
+    Description:
+        Sends a localized notification to the player.
+
+    Parameters:
+        message (string) – Translation key.
+        ... – Additional parameters for localization.
+
+    Realm:
+        Server
+
+    Example Usage:
+        local result = player:notifyLocalized(message, ...)
+]]
+--[[
+    CanEditVendor(vendor)
+
+    Description:
+        Determines whether the player can edit the given vendor.
+
+    Parameters:
+        vendor (Entity) – Vendor entity to check.
+
+    Realm:
+        Server
+
+    Returns:
+        boolean – True if allowed to edit.
+
+    Example Usage:
+        local result = player:CanEditVendor(vendor)
+]]
+--[[
+    isUser()
+
+    Description:
+        Convenience wrapper to check if the player is in the "user" group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether usergroup is "user".
+
+    Example Usage:
+        local result = player:isUser()
+]]
+--[[
+    isStaff()
+
+    Description:
+        Returns true if the player belongs to a staff group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from the privilege check.
+
+    Example Usage:
+        local result = player:isStaff()
+]]
+--[[
+    isVIP()
+
+    Description:
+        Checks whether the player is in the VIP group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from privilege check.
+
+    Example Usage:
+        local result = player:isVIP()
+]]
+--[[
+    isStaffOnDuty()
+
+    Description:
+        Determines if the player is currently in the staff faction.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if staff faction is active.
+
+    Example Usage:
+        local result = player:isStaffOnDuty()
+]]
+--[[
+    isFaction(faction)
+
+    Description:
+        Checks if the player's character belongs to the given faction.
+
+    Parameters:
+        faction (number) – Faction index to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the factions match.
+
+    Example Usage:
+        local result = player:isFaction(faction)
+]]
+--[[
+    isClass(class)
+
+    Description:
+        Returns true if the player's character is of the given class.
+
+    Parameters:
+        class (number) – Class index to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the character matches the class.
+
+    Example Usage:
+        local result = player:isClass(class)
+]]
+--[[
+    hasWhitelist(faction)
+
+    Description:
+        Determines if the player has whitelist access for a faction.
+
+    Parameters:
+        faction (number) – Faction index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if whitelisted.
+
+    Example Usage:
+        local result = player:hasWhitelist(faction)
+]]
+--[[
+    getClass()
+
+    Description:
+        Retrieves the class index of the player's character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number|nil – Class index or nil.
+
+    Example Usage:
+        local result = player:getClass()
+]]
+--[[
+    hasClassWhitelist(class)
+
+    Description:
+        Checks if the player's character is whitelisted for a class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if class whitelist exists.
+
+    Example Usage:
+        local result = player:hasClassWhitelist(class)
+]]
+--[[
+    getClassData()
+
+    Description:
+        Returns the class table of the player's current class.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table|nil – Class definition table.
+
+    Example Usage:
+        local result = player:getClassData()
+]]
+--[[
+    getDarkRPVar(var)
+
+    Description:
+        Compatibility helper for retrieving money with DarkRP-style calls.
+
+    Parameters:
+        var (string) – Currently only supports "money".
+
+    Realm:
+        Shared
+
+    Returns:
+        number|nil – Money amount or nil.
+
+    Example Usage:
+        local result = player:getDarkRPVar(var)
+]]
+--[[
+    getMoney()
+
+    Description:
+        Convenience function to get the character's money amount.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Current funds or 0.
+
+    Example Usage:
+        local result = player:getMoney()
+]]
+--[[
+    canAfford(amount)
+
+    Description:
+        Checks if the player has enough money for a purchase.
+
+    Parameters:
+        amount (number) – Cost to test.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if funds are sufficient.
+
+    Example Usage:
+        local result = player:canAfford(amount)
+]]
+--[[
+    hasSkillLevel(skill, level)
+
+    Description:
+        Verifies the player's character meets an attribute level.
+
+    Parameters:
+        skill (string) – Attribute ID.
+        level (number) – Required level.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the character satisfies the requirement.
+
+    Example Usage:
+        local result = player:hasSkillLevel(skill, level)
+]]
+--[[
+    meetsRequiredSkills(requiredSkillLevels)
+
+    Description:
+        Checks a table of skill requirements against the player.
+
+    Parameters:
+        requiredSkillLevels (table) – Mapping of attribute IDs to levels.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if all requirements are met.
+
+    Example Usage:
+        local result = player:meetsRequiredSkills(requiredSkillLevels)
+]]
+--[[
+    forceSequence(sequenceName, callback, time, noFreeze)
+
+    Description:
+        Plays an animation sequence and optionally freezes the player.
+
+    Parameters:
+        sequenceName (string) – Sequence to play.
+        callback (function|nil) – Called when finished.
+        time (number|nil) – Duration override.
+        noFreeze (boolean) – Don't freeze movement when true.
+
+    Realm:
+        Shared
+
+    Returns:
+        number|boolean – Duration or false on failure.
+
+    Example Usage:
+        local result = player:forceSequence(sequenceName, callback, time, noFreeze)
+]]
+--[[
+    leaveSequence()
+
+    Description:
+        Stops any forced sequence and restores player movement.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = player:leaveSequence()
+]]
+--[[
+        restoreStamina(amount)
+
+        Description:
+            Increases the player's stamina value.
+
+        Parameters:
+            amount (number) – Amount to restore.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = player:restoreStamina(amount)
+    ]]
+--[[
+        consumeStamina(amount)
+
+        Description:
+            Reduces the player's stamina value.
+
+        Parameters:
+            amount (number) – Amount to subtract.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = player:consumeStamina(amount)
+    ]]
+--[[
+        addMoney(amount)
+
+        Description:
+            Adds funds to the player's character, clamping to limits.
+
+        Parameters:
+            amount (number) – Money to add.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = player:addMoney(amount)
+    ]]
+--[[
+        takeMoney(amount)
+
+        Description:
+            Removes money from the player's character.
+
+        Parameters:
+            amount (number) – Amount to subtract.
+
+        Realm:
+            Server
+
+    Example Usage:
+        local result = player:takeMoney(amount)
+    ]]

--- a/docs/lua/meta/tool.lua
+++ b/docs/lua/meta/tool.lua
@@ -1,0 +1,352 @@
+--[[
+    Create()
+
+    Description:
+        Creates a new tool object with default values.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – The newly created tool object.
+
+    Example Usage:
+        local tool = ToolGunMeta:Create()
+]]
+--[[
+    CreateConVars()
+
+    Description:
+        Creates client and server ConVars for this tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        tool:CreateConVars()
+]]
+--[[
+    GetServerInfo(property)
+
+    Description:
+        Returns the server ConVar for the given property.
+
+    Parameters:
+        property (string) – Property name.
+
+    Realm:
+        Shared
+
+    Returns:
+        ConVar – The server ConVar object.
+
+    Example Usage:
+        local allow = tool:GetServerInfo("allow_use"):GetBool()
+]]
+--[[
+    BuildConVarList()
+
+    Description:
+        Returns a table of client ConVars prefixed by the tool mode.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Table of convars.
+
+    Example Usage:
+        local cvars = tool:BuildConVarList()
+]]
+--[[
+    GetClientInfo(property)
+
+    Description:
+        Retrieves a client ConVar value as a string.
+
+    Parameters:
+        property (string) – ConVar name without mode prefix.
+
+    Realm:
+        Shared
+
+    Returns:
+        string – The value stored in the ConVar.
+
+    Example Usage:
+        local val = tool:GetClientInfo("setting")
+]]
+--[[
+    GetClientNumber(property, default)
+
+    Description:
+        Retrieves a numeric client ConVar value.
+
+    Parameters:
+        property (string) – ConVar name without mode prefix.
+        default (number) – Value returned if the ConVar doesn't exist.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The numeric value of the ConVar.
+
+    Example Usage:
+        local power = tool:GetClientNumber("power", 10)
+]]
+--[[
+    Allowed()
+
+    Description:
+        Determines whether this tool is allowed to be used.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the tool is allowed.
+
+    Example Usage:
+        if tool:Allowed() then print("ok") end
+]]
+--[[
+    Init()
+
+    Description:
+        Placeholder for tool initialization.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:Init()
+]]
+--[[
+    GetMode()
+
+    Description:
+        Gets the current tool mode string.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Tool mode name.
+
+    Example Usage:
+        local result = tool:GetMode()
+]]
+--[[
+    GetSWEP()
+
+    Description:
+        Returns the SWEP associated with this tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        SWEP – The tool's weapon entity.
+
+    Example Usage:
+        local result = tool:GetSWEP()
+]]
+--[[
+    GetOwner()
+
+    Description:
+        Retrieves the tool owner's player object.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player – Owner of the tool.
+
+    Example Usage:
+        local result = tool:GetOwner()
+]]
+--[[
+    GetWeapon()
+
+    Description:
+        Retrieves the weapon entity this tool is attached to.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Weapon – The weapon object.
+
+    Example Usage:
+        local result = tool:GetWeapon()
+]]
+--[[
+    LeftClick()
+
+    Description:
+        Handles the left-click action. Override for custom behavior.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – False by default.
+
+    Example Usage:
+        local result = tool:LeftClick()
+]]
+--[[
+    RightClick()
+
+    Description:
+        Handles the right-click action. Override for custom behavior.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – False by default.
+
+    Example Usage:
+        local result = tool:RightClick()
+]]
+--[[
+    Reload()
+
+    Description:
+        Clears stored objects when the tool reloads.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:Reload()
+]]
+--[[
+    Deploy()
+
+    Description:
+        Called when the tool is equipped. Releases ghost entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:Deploy()
+]]
+--[[
+    Holster()
+
+    Description:
+        Called when the tool is holstered. Releases ghost entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:Holster()
+]]
+--[[
+    Think()
+
+    Description:
+        Called every tick; releases ghost entities by default.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:Think()
+]]
+--[[
+    CheckObjects()
+
+    Description:
+        Validates stored objects and clears them if invalid.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:CheckObjects()
+]]
+--[[
+    ClearObjects()
+
+    Description:
+        Removes all stored objects from the tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:ClearObjects()
+]]
+--[[
+    ReleaseGhostEntity()
+
+    Description:
+        Removes the ghost entity used for previewing placements.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Example Usage:
+        local result = tool:ReleaseGhostEntity()
+]]

--- a/docs/lua/meta/vector.lua
+++ b/docs/lua/meta/vector.lua
@@ -1,0 +1,96 @@
+--[[
+    Center(vec2)
+
+    Description:
+        Returns the midpoint between this vector and the supplied vector.
+
+    Parameters:
+        vec2 (Vector) – The vector to average with this vector.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The center point of the two vectors.
+
+    Example Usage:
+        local midpoint = vector_origin:Center(Vector(10, 10, 10))
+        print(midpoint) -- Vector(5, 5, 5)
+]]
+--[[
+    Distance(vec2)
+
+    Description:
+        Calculates the distance between this vector and another vector.
+
+    Parameters:
+        vec2 (Vector) – The other vector.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The distance between the two vectors.
+
+    Example Usage:
+        local dist = vector_origin:Distance(Vector(3, 4, 0))
+        print(dist) -- 5
+]]
+--[[
+    RotateAroundAxis(axis, degrees)
+
+    Description:
+        Rotates the vector around an axis by the specified degrees and returns the new vector.
+
+    Parameters:
+        axis (Vector) – Axis to rotate around.
+        degrees (number) – Angle in degrees.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The rotated vector.
+
+    Example Usage:
+        local rotated = Vector(1, 0, 0):RotateAroundAxis(Vector(0, 0, 1), 90)
+        print(rotated) -- Vector(0, 1, 0)
+]]
+--[[
+    Right(vUp)
+
+    Description:
+        Returns a normalized right-direction vector relative to this vector.
+
+    Parameters:
+        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The calculated right vector.
+
+    Example Usage:
+        local rightVec = Vector(0, 1, 0):Right()
+        print(rightVec)
+]]
+--[[
+    Up(vUp)
+
+    Description:
+        Returns a normalized up-direction vector relative to this vector.
+
+    Parameters:
+        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The calculated up vector.
+
+    Example Usage:
+        local upVec = Vector(1, 0, 0):Up()
+        print(upVec)
+]]

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -2,69 +2,18 @@
 characterMeta.__index = characterMeta
 characterMeta.id = characterMeta.id or 0
 characterMeta.vars = characterMeta.vars or {}
---[[
-    characterMeta:tostring()
-
-    Description:
-        Returns a printable identifier for this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Format "character[id]".
-]]
 function characterMeta:tostring()
     return "character[" .. (self.id or 0) .. "]"
 end
 
---[[
-    characterMeta:eq(other)
-
-    Description:
-        Compares two characters by ID for equality.
-
-    Parameters:
-        other (Character) – Character to compare.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if both share the same ID.
-]]
 function characterMeta:eq(other)
     return self:getID() == other:getID()
 end
 
---[[
-    characterMeta:getID()
-
-    Description:
-        Returns the unique database ID for this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Character identifier.
-]]
 function characterMeta:getID()
     return self.id
 end
 
---[[
-    characterMeta:getPlayer()
-
-    Description:
-        Returns the player entity currently controlling this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        Player|nil – Owning player or nil.
-]]
 function characterMeta:getPlayer()
     if IsValid(self.player) then return self.player end
     for _, v in player.Iterator() do
@@ -83,21 +32,6 @@ function characterMeta:getPlayer()
     end
 end
 
---[[
-    characterMeta:getDisplayedName(client)
-
-    Description:
-        Returns the character's name as it should be shown to the given player.
-
-    Parameters:
-        client (Player) – Player requesting the name.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Localized or recognized character name.
-]]
 function characterMeta:getDisplayedName(client)
     local isRecognitionEnabled = lia.config.get("RecognitionEnabled", true)
     if not isRecognitionEnabled then return self:getName() end
@@ -112,58 +46,16 @@ function characterMeta:getDisplayedName(client)
     return L("unknown")
 end
 
---[[
-    characterMeta:hasMoney(amount)
-
-    Description:
-        Checks if the character has at least the given amount of money.
-
-    Parameters:
-        amount (number) – Amount to check for.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the character's funds are sufficient.
-]]
 function characterMeta:hasMoney(amount)
     amount = tonumber(amount) or 0
     if amount < 0 then return false end
     return self:getMoney() >= amount
 end
 
---[[
-    characterMeta:getFlags()
-
-    Description:
-        Retrieves the string of permission flags for this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Concatenated flag characters.
-]]
 function characterMeta:getFlags()
     return self:getData("f", "")
 end
 
---[[
-    characterMeta:hasFlags(flags)
-
-    Description:
-        Checks if the character possesses any of the specified flags.
-
-    Parameters:
-        flags (string) – String of flag characters to check.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if at least one flag is present.
-]]
 function characterMeta:hasFlags(flags)
     for i = 1, #flags do
         if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
@@ -171,21 +63,6 @@ function characterMeta:hasFlags(flags)
     return hook.Run("CharHasFlags", self, flags) or false
 end
 
---[[
-    characterMeta:getItemWeapon(requireEquip)
-
-    Description:
-        Checks the player's active weapon against items in the inventory.
-
-    Parameters:
-        requireEquip (boolean) – Only match equipped items if true.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the active weapon corresponds to an item.
-]]
 function characterMeta:getItemWeapon(requireEquip)
     if requireEquip == nil then requireEquip = true end
     local client = self:getPlayer()
@@ -199,114 +76,29 @@ function characterMeta:getItemWeapon(requireEquip)
     return false
 end
 
---[[
-    characterMeta:getMaxStamina()
-
-    Description:
-        Returns the maximum stamina value for this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Maximum stamina points.
-]]
 function characterMeta:getMaxStamina()
     local maxStamina = hook.Run("getCharMaxStamina", self) or lia.config.get("DefaultStamina", 100)
     return maxStamina
 end
 
---[[
-    characterMeta:getStamina()
-
-    Description:
-        Retrieves the character's current stamina value.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Current stamina.
-]]
 function characterMeta:getStamina()
     local stamina = self:getPlayer():getLocalVar("stamina", 100) or lia.config.get("DefaultStamina", 100)
     return stamina
 end
 
---[[
-    characterMeta:hasClassWhitelist(class)
-
-    Description:
-        Checks if the character has whitelisted the given class.
-
-    Parameters:
-        class (number) – Class index.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the class is whitelisted.
-]]
 function characterMeta:hasClassWhitelist(class)
     local wl = self:getData("whitelist", {})
     return wl[class] ~= nil
 end
 
---[[
-    characterMeta:isFaction(faction)
-
-    Description:
-        Returns true if the character's faction matches.
-
-    Parameters:
-        faction (number) – Faction index.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the faction matches.
-]]
 function characterMeta:isFaction(faction)
     return self:getFaction() == faction
 end
 
---[[
-    characterMeta:isClass(class)
-
-    Description:
-        Returns true if the character's class equals the specified class.
-
-    Parameters:
-        class (number) – Class index.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the classes match.
-]]
 function characterMeta:isClass(class)
     return self:getClass() == class
 end
 
---[[
-    characterMeta:getAttrib(key, default)
-
-    Description:
-        Retrieves the value of an attribute including boosts.
-
-    Parameters:
-        key (string) – Attribute identifier.
-        default (number) – Default value when attribute is missing.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Final attribute value.
-]]
 function characterMeta:getAttrib(key, default)
     local att = self:getAttribs()[key] or default or 0
     local boosts = self:getBoosts()[key]
@@ -318,77 +110,20 @@ function characterMeta:getAttrib(key, default)
     return att
 end
 
---[[
-    characterMeta:getBoost(attribID)
-
-    Description:
-        Returns the boost table for the given attribute.
-
-    Parameters:
-        attribID (string) – Attribute identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        table|nil – Table of boosts or nil.
-]]
 function characterMeta:getBoost(attribID)
     local boosts = self:getBoosts()
     return boosts[attribID]
 end
 
---[[
-    characterMeta:getBoosts()
-
-    Description:
-        Retrieves all attribute boosts for this character.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Mapping of attribute IDs to boost tables.
-]]
 function characterMeta:getBoosts()
     return self:getVar("boosts", {})
 end
 
---[[
-    characterMeta:doesRecognize(id)
-
-    Description:
-        Determines if this character recognizes another character.
-
-    Parameters:
-        id (number|Character) – Character ID or object to check.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if recognized.
-]]
 function characterMeta:doesRecognize(id)
     if not isnumber(id) and id.getID then id = id:getID() end
     return hook.Run("isCharRecognized", self, id) ~= false
 end
 
---[[
-    characterMeta:doesFakeRecognize(id)
-
-    Description:
-        Checks if the character has a fake recognition entry for another.
-
-    Parameters:
-        id (number|Character) – Character identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if fake recognized.
-]]
 function characterMeta:doesFakeRecognize(id)
     if not isnumber(id) and id.getID then id = id:getID() end
     return hook.Run("isCharFakeRecognized", self, id) ~= false

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -7,102 +7,26 @@ local validClasses = {
     ["prop_vehicle_prisoner_pod"] = true,
 }
 
---[[
-    entityMeta:isProp()
-
-    Description:
-        Returns true if the entity is a physics prop.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the entity is a physics prop.
-]]
 function entityMeta:isProp()
     return self:GetClass() == "prop_physics"
 end
 
---[[
-    entityMeta:isItem()
-
-    Description:
-        Checks if the entity is an item entity.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the entity represents an item.
-]]
 function entityMeta:isItem()
     return self:GetClass() == "lia_item"
 end
 
---[[
-    entityMeta:isMoney()
-
-    Description:
-        Checks if the entity is a money entity.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the entity represents money.
-]]
 function entityMeta:isMoney()
     return self:GetClass() == "lia_money"
 end
 
---[[
-    entityMeta:isSimfphysCar()
-
-    Description:
-        Checks if the entity is a simfphys car.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if this is a simfphys vehicle.
-]]
 function entityMeta:isSimfphysCar()
     return validClasses[self:GetClass()] or self.IsSimfphyscar or self.LVS or validClasses[self.Base]
 end
 
---[[
-    entityMeta:isLiliaPersistent()
-
-    Description:
-        Determines if the entity is persistent in Lilia.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the entity should persist.
-]]
 function entityMeta:isLiliaPersistent()
     return self.IsLeonNPC or self.IsPersistent
 end
 
---[[
-    entityMeta:checkDoorAccess(client, access)
-
-    Description:
-        Checks if a player has the given door access level.
-
-    Parameters:
-        client (Player) – The player to check.
-        access (number, optional) – Door permission level.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the player has access.
-]]
 function entityMeta:checkDoorAccess(client, access)
     if not self:isDoor() then return false end
     access = access or DOOR_GUEST
@@ -113,18 +37,6 @@ function entityMeta:checkDoorAccess(client, access)
     return false
 end
 
---[[
-    entityMeta:keysOwn(client)
-
-    Description:
-        Assigns the entity to the specified player.
-
-    Parameters:
-        client (Player) – Player to set as owner.
-
-    Realm:
-        Shared
-]]
 function entityMeta:keysOwn(client)
     if self:IsVehicle() then
         self:CPPISetOwner(client)
@@ -134,95 +46,26 @@ function entityMeta:keysOwn(client)
     end
 end
 
---[[
-    entityMeta:keysLock()
-
-    Description:
-        Locks the entity if it is a vehicle.
-
-    Realm:
-        Shared
-]]
 function entityMeta:keysLock()
     if self:IsVehicle() then self:Fire("lock") end
 end
 
---[[
-    entityMeta:keysUnLock()
-
-    Description:
-        Unlocks the entity if it is a vehicle.
-
-    Realm:
-        Shared
-]]
 function entityMeta:keysUnLock()
     if self:IsVehicle() then self:Fire("unlock") end
 end
 
---[[
-    entityMeta:getDoorOwner()
-
-    Description:
-        Returns the player that owns this door if available.
-
-    Realm:
-        Shared
-
-    Returns:
-        Player|nil – Door owner or nil.
-]]
 function entityMeta:getDoorOwner()
     if self:IsVehicle() and self.CPPIGetOwner then return self:CPPIGetOwner() end
 end
 
---[[
-    entityMeta:isLocked()
-
-    Description:
-        Returns the locked state stored in net variables.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the door is locked.
-]]
 function entityMeta:isLocked()
     return self:getNetVar("locked", false)
 end
 
---[[
-    entityMeta:isDoorLocked()
-
-    Description:
-        Checks the internal door locked state.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the door is locked.
-]]
 function entityMeta:isDoorLocked()
     return self:GetInternalVariable("m_bLocked") or self.locked or false
 end
 
---[[
-    entityMeta:getEntItemDropPos(offset)
-
-    Description:
-        Calculates a drop position in front of the entity's eyes.
-
-    Parameters:
-        offset (number) – Distance from the player eye position.
-
-    Realm:
-        Shared
-
-    Returns:
-        Vector – Drop position and angle.
-]]
 function entityMeta:getEntItemDropPos(offset)
     if not offset then offset = 64 end
     local trResult = util.TraceLine({
@@ -234,22 +77,6 @@ function entityMeta:getEntItemDropPos(offset)
     return trResult.HitPos + trResult.HitNormal * 5, trResult.HitNormal:Angle()
 end
 
---[[
-    entityMeta:isNearEntity(radius, otherEntity)
-
-    Description:
-        Checks for another entity of the same class nearby.
-
-    Parameters:
-        radius (number) – Sphere radius in units.
-        otherEntity (Entity, optional) – Specific entity to look for.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if another entity is within radius.
-]]
 function entityMeta:isNearEntity(radius, otherEntity)
     if otherEntity == self then return true end
     if not radius then radius = 96 end
@@ -260,85 +87,24 @@ function entityMeta:isNearEntity(radius, otherEntity)
     return false
 end
 
---[[
-    entityMeta:GetCreator()
-
-    Description:
-        Returns the entity creator player.
-
-    Realm:
-        Shared
-
-    Returns:
-        Player|nil – Creator player if stored.
-]]
 function entityMeta:GetCreator()
     return self:getNetVar("creator", nil)
 end
 
 if SERVER then
-    --[[
-        entityMeta:SetCreator(client)
-
-        Description:
-            Stores the creator player on the entity.
-
-        Parameters:
-            client (Player) – Creator of the entity.
-
-        Realm:
-            Server
-    ]]
     function entityMeta:SetCreator(client)
         self:setNetVar("creator", client)
     end
 
-    --[[
-        entityMeta:sendNetVar(key, receiver)
-
-        Description:
-            Sends a network variable to recipients.
-
-        Parameters:
-            key (string) – Identifier of the variable.
-            receiver (Player|nil) – Who to send to.
-
-        Realm:
-            Server
-
-        Internal:
-            Used by the networking system.
-    ]]
     function entityMeta:sendNetVar(key, receiver)
         netstream.Start(receiver, "nVar", self:EntIndex(), key, lia.net[self] and lia.net[self][key])
     end
 
-    --[[
-        entityMeta:clearNetVars(receiver)
-
-        Description:
-            Clears all network variables on this entity.
-
-        Parameters:
-            receiver (Player|nil) – Receiver to notify.
-
-        Realm:
-            Server
-    ]]
     function entityMeta:clearNetVars(receiver)
         lia.net[self] = nil
         netstream.Start(receiver, "nDel", self:EntIndex())
     end
 
-    --[[
-        entityMeta:removeDoorAccessData()
-
-        Description:
-            Clears all stored door access information.
-
-        Realm:
-            Server
-    ]]
     function entityMeta:removeDoorAccessData()
         if IsValid(self) then
             for k, _ in pairs(self.liaAccess or {}) do
@@ -350,34 +116,10 @@ if SERVER then
         end
     end
 
-    --[[
-        entityMeta:setLocked(state)
-
-        Description:
-            Stores the door locked state in network variables.
-
-        Parameters:
-            state (boolean) – New locked state.
-
-        Realm:
-            Server
-    ]]
     function entityMeta:setLocked(state)
         self:setNetVar("locked", state)
     end
 
-    --[[
-        entityMeta:isDoor()
-
-        Description:
-            Returns true if the entity's class indicates a door.
-
-        Realm:
-            Server
-
-        Returns:
-            boolean – Whether the entity is a door.
-    ]]
     function entityMeta:isDoor()
         if not IsValid(self) then return end
         local class = self:GetClass():lower()
@@ -388,36 +130,10 @@ if SERVER then
         return false
     end
 
-    --[[
-        entityMeta:getDoorPartner()
-
-        Description:
-            Returns the partner door linked with this entity.
-
-        Realm:
-            Server
-
-        Returns:
-            Entity|nil – The partnered door.
-    ]]
     function entityMeta:getDoorPartner()
         return self.liaPartner
     end
 
-    --[[
-        entityMeta:setNetVar(key, value, receiver)
-
-        Description:
-            Updates a network variable and sends it to recipients.
-
-        Parameters:
-            key (string) – Variable name.
-            value (any) – Value to store.
-            receiver (Player|nil) – Who to send update to.
-
-        Realm:
-            Server
-    ]]
     function entityMeta:setNetVar(key, value, receiver)
         if checkBadType(key, value) then return end
         lia.net[self] = lia.net[self] or {}
@@ -425,23 +141,6 @@ if SERVER then
         self:sendNetVar(key, receiver)
     end
 
-    --[[
-        entityMeta:getNetVar(key, default)
-
-        Description:
-            Retrieves a stored network variable or a default value.
-
-        Parameters:
-            key (string) – Variable name.
-            default (any) – Value returned if variable is nil.
-
-        Realm:
-            Server
-            Client
-
-        Returns:
-            any – Stored value or default.
-    ]]
     function entityMeta:getNetVar(key, default)
         if lia.net[self] and lia.net[self][key] ~= nil then return lia.net[self][key] end
         return default
@@ -449,34 +148,10 @@ if SERVER then
 
     playerMeta.getLocalVar = entityMeta.getNetVar
 else
-    --[[
-        entityMeta:isDoor()
-
-        Description:
-            Client-side door check using class name.
-
-        Realm:
-            Client
-
-        Returns:
-            boolean – True if entity class contains "door".
-    ]]
     function entityMeta:isDoor()
         return self:GetClass():find("door")
     end
 
-    --[[
-        entityMeta:getDoorPartner()
-
-        Description:
-            Attempts to find the door partnered with this one.
-
-        Realm:
-            Client
-
-        Returns:
-            Entity|nil – The partner door entity.
-    ]]
     function entityMeta:getDoorPartner()
         local owner = self:GetOwner() or self.liaDoorOwner
         if IsValid(owner) and owner:isDoor() then return owner end
@@ -488,22 +163,6 @@ else
         end
     end
 
-    --[[
-        entityMeta:getNetVar(key, default)
-
-        Description:
-            Retrieves a network variable for this entity on the client.
-
-        Parameters:
-            key (string) – Variable name.
-            default (any) – Default if not set.
-
-        Realm:
-            Client
-
-        Returns:
-            any – Stored value or default.
-    ]]
     function entityMeta:getNetVar(key, default)
         local index = self:EntIndex()
         if lia.net[index] and lia.net[index][key] ~= nil then return lia.net[index][key] end

--- a/gamemode/core/meta/inventory.lua
+++ b/gamemode/core/meta/inventory.lua
@@ -4,43 +4,12 @@ lia.Inventory = Inventory
 Inventory.data = {}
 Inventory.items = {}
 Inventory.id = -1
---[[
-    Inventory:getData(key, default)
-
-    Description:
-        Returns a stored data value for this inventory.
-
-    Parameters:
-        key (string) – Data field key.
-        default (any) – Value if the key does not exist.
-
-    Realm:
-        Shared
-
-    Returns:
-        any – Stored value or default.
-]]
 function Inventory:getData(key, default)
     local value = self.data[key]
     if value == nil then return default end
     return value
 end
 
---[[
-    Inventory:extend(className)
-
-    Description:
-        Creates a subclass of the inventory meta table with a new class name.
-
-    Parameters:
-        className (string) – Name of the subclass meta table.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – The newly derived inventory table.
-]]
 function Inventory:extend(className)
     local base = debug.getregistry()[className] or {}
     table.Empty(base)
@@ -50,53 +19,15 @@ function Inventory:extend(className)
     return subClass
 end
 
---[[
-    Inventory:configure()
-
-    Description:
-        Stub for inventory configuration; meant to be overridden.
-
-    Realm:
-        Shared
-]]
 function Inventory:configure()
 end
 
---[[
-    Inventory:addDataProxy(key, onChange)
-
-    Description:
-        Adds a proxy function that is called when a data field changes.
-
-    Parameters:
-        key (string) – Data field to watch.
-        onChange (function) – Callback receiving old and new values.
-
-    Realm:
-        Shared
-]]
 function Inventory:addDataProxy(key, onChange)
     local dataConfig = self.config.data[key] or {}
     dataConfig.proxies[#dataConfig.proxies + 1] = onChange
     self.config.data[key] = dataConfig
 end
 
---[[
-    Inventory:getItemsByUniqueID(uniqueID, onlyMain)
-
-    Description:
-        Returns all items in the inventory matching the given unique ID.
-
-    Parameters:
-        uniqueID (string) – Item unique identifier.
-        onlyMain (boolean) – Search only the main item list.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Table of matching item objects.
-]]
 function Inventory:getItemsByUniqueID(uniqueID, onlyMain)
     local items = {}
     for _, v in pairs(self:getItems(onlyMain)) do
@@ -105,18 +36,6 @@ function Inventory:getItemsByUniqueID(uniqueID, onlyMain)
     return items
 end
 
---[[
-    Inventory:register(typeID)
-
-    Description:
-        Registers this inventory type with the lia.inventory system.
-
-    Parameters:
-        typeID (string) – Unique identifier for this inventory type.
-
-    Realm:
-        Shared
-]]
 function Inventory:register(typeID)
     assert(isstring(typeID), "Expected argument #1 of " .. self.className .. ".register to be a string")
     self.typeID = typeID
@@ -136,69 +55,18 @@ function Inventory:register(typeID)
     end
 end
 
---[[
-    Inventory:new()
-
-    Description:
-        Creates a new inventory of this type.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – New inventory instance.
-]]
 function Inventory:new()
     return lia.inventory.new(self.typeID)
 end
 
---[[
-    Inventory:tostring()
-
-    Description:
-        Returns a printable representation of this inventory.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Formatted as "ClassName[id]".
-]]
 function Inventory:tostring()
     return self.className .. "[" .. tostring(self.id) .. "]"
 end
 
---[[
-    Inventory:getType()
-
-    Description:
-        Retrieves the inventory type table from lia.inventory.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Inventory type definition.
-]]
 function Inventory:getType()
     return lia.inventory.types[self.typeID]
 end
 
---[[
-    Inventory:onDataChanged(key, oldValue, newValue)
-
-    Description:
-        Called when an inventory data field changes. Executes any
-        registered proxy callbacks for that field.
-
-    Parameters:
-        key (string) – Data field key.
-        oldValue (any) – Previous value.
-        newValue (any) – Updated value.
-
-    Realm:
-        Shared
-]]
 function Inventory:onDataChanged(key, oldValue, newValue)
     local keyData = self.config.data[key]
     if keyData and keyData.proxies then
@@ -208,37 +76,10 @@ function Inventory:onDataChanged(key, oldValue, newValue)
     end
 end
 
---[[
-    Inventory:getItems()
-
-    Description:
-        Returns all items stored in this inventory.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Item instance table indexed by itemID.
-]]
 function Inventory:getItems()
     return self.items
 end
 
---[[
-    Inventory:getItemsOfType(itemType)
-
-    Description:
-        Collects all items that match the given unique ID.
-
-    Parameters:
-        itemType (string) – Item unique identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Array of matching items.
-]]
 function Inventory:getItemsOfType(itemType)
     local items = {}
     for _, item in pairs(self:getItems()) do
@@ -247,42 +88,12 @@ function Inventory:getItemsOfType(itemType)
     return items
 end
 
---[[
-    Inventory:getFirstItemOfType(itemType)
-
-    Description:
-        Retrieves the first item matching the given unique ID.
-
-    Parameters:
-        itemType (string) – Item unique identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        Item|nil – The first matching item or nil.
-]]
 function Inventory:getFirstItemOfType(itemType)
     for _, item in pairs(self:getItems()) do
         if item.uniqueID == itemType then return item end
     end
 end
 
---[[
-    Inventory:hasItem(itemType)
-
-    Description:
-        Determines whether the inventory contains an item type.
-
-    Parameters:
-        itemType (string) – Item unique identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if an item is found.
-]]
 function Inventory:hasItem(itemType)
     for _, item in pairs(self:getItems()) do
         if item.uniqueID == itemType then return true end
@@ -290,21 +101,6 @@ function Inventory:hasItem(itemType)
     return false
 end
 
---[[
-    Inventory:getItemCount(itemType)
-
-    Description:
-        Counts the total quantity of a specific item type.
-
-    Parameters:
-        itemType (string|nil) – Item unique ID to count. Counts all if nil.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Sum of quantities.
-]]
 function Inventory:getItemCount(itemType)
     local count = 0
     for _, item in pairs(self:getItems()) do
@@ -315,55 +111,15 @@ function Inventory:getItemCount(itemType)
     return count
 end
 
---[[
-    Inventory:getID()
-
-    Description:
-        Returns the unique database ID of this inventory.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Inventory identifier.
-]]
 function Inventory:getID()
     return self.id
 end
 
---[[
-    Inventory:eq(other)
-
-    Description:
-        Compares two inventories by ID for equality.
-
-    Parameters:
-        other (Inventory) – Other inventory to compare.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if both inventories share the same ID.
-]]
 function Inventory:eq(other)
     return self:getID() == other:getID()
 end
 
 if SERVER then
-    --[[
-        Inventory:addItem(item, noReplicate)
-
-        Description:
-            Inserts an item instance into this inventory and persists it.
-
-        Parameters:
-            item (Item) – Item to add.
-            noReplicate (boolean) – Skip network replication when true.
-
-        Realm:
-            Server
-    ]]
     function Inventory:addItem(item, noReplicate)
         self.items[item:getID()] = item
         item.invID = self:getID()
@@ -422,19 +178,6 @@ if SERVER then
     function Inventory:restoreFromStorage()
     end
 
-    --[[
-        Inventory:removeItem(itemID, preserveItem)
-
-        Description:
-            Removes an item by ID and optionally deletes it.
-
-        Parameters:
-            itemID (number) – Unique item identifier.
-            preserveItem (boolean) – Keep item in database when true.
-
-        Realm:
-            Server
-    ]]
     function Inventory:removeItem(itemID, preserveItem)
         assert(isnumber(itemID), "itemID must be a number for remove")
         local d = deferred.new()
@@ -567,19 +310,6 @@ if SERVER then
         return lia.inventory.instance(self.typeID, initialData)
     end
 
-    --[[
-        Inventory:syncData(key, recipients)
-
-        Description:
-            Sends a single data field to clients.
-
-        Parameters:
-            key (string) – Field to replicate.
-            recipients (table|nil) – Player recipients.
-
-        Realm:
-            Server
-    ]]
     function Inventory:syncData(key, recipients)
         if self.config.data[key] and self.config.data[key].noReplication then return end
         net.Start("liaInventoryData")
@@ -589,18 +319,6 @@ if SERVER then
         net.Send(recipients or self:getRecipients())
     end
 
-    --[[
-        Inventory:sync(recipients)
-
-        Description:
-            Sends the entire inventory and its items to players.
-
-        Parameters:
-            recipients (table|nil) – Player recipients.
-
-        Realm:
-            Server
-    ]]
     function Inventory:sync(recipients)
         net.Start("liaInventoryInit")
         net.WriteType(self.id)
@@ -629,28 +347,10 @@ if SERVER then
         end
     end
 
-    --[[
-        Inventory:delete()
-
-        Description:
-            Removes this inventory record from the database.
-
-        Realm:
-            Server
-    ]]
     function Inventory:delete()
         lia.inventory.deleteByID(self.id)
     end
 
-    --[[
-        Inventory:destroy()
-
-        Description:
-            Destroys all items and removes network references.
-
-        Realm:
-            Server
-    ]]
     function Inventory:destroy()
         for _, item in pairs(self:getItems()) do
             item:destroy()

--- a/gamemode/core/meta/item.lua
+++ b/gamemode/core/meta/item.lua
@@ -10,142 +10,37 @@ ITEM.isStackable = false
 ITEM.quantity = 1
 ITEM.maxQuantity = 1
 ITEM.canSplit = true
---[[
-    ITEM:getQuantity()
-
-    Description:
-        Retrieves how many of this item the stack represents.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Quantity contained in this item instance.
-]]
 function ITEM:getQuantity()
     if self.id == 0 then return self.maxQuantity end
     return self.quantity
 end
 
---[[
-    ITEM:eq(other)
-
-    Description:
-        Compares this item instance to another by ID.
-
-    Parameters:
-        other (Item) – The other item to compare with.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if both items share the same ID.
-]]
 function ITEM:eq(other)
     return self:getID() == other:getID()
 end
 
---[[
-    ITEM:tostring()
-
-    Description:
-        Returns a printable representation of this item.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Identifier in the form "item[uniqueID][id]".
-]]
 function ITEM:tostring()
     return "item[" .. self.uniqueID .. "][" .. self.id .. "]"
 end
 
---[[
-    ITEM:getID()
-
-    Description:
-        Retrieves the unique identifier of this item.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Item database ID.
-]]
 function ITEM:getID()
     return self.id
 end
 
---[[
-    ITEM:getModel()
-
-    Description:
-        Returns the model path associated with this item.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Model path.
-]]
 function ITEM:getModel()
     return self.model
 end
 
---[[
-    ITEM:getSkin()
-
-    Description:
-        Retrieves the skin index this item uses.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Skin ID applied to the model.
-]]
 function ITEM:getSkin()
     return self.skin
 end
 
---[[
-    ITEM:getPrice()
-
-    Description:
-        Returns the calculated purchase price for the item.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – The price value.
-]]
 function ITEM:getPrice()
     local price = self.price
     if self.calcPrice then price = self:calcPrice(self.price) end
     return price or 0
 end
 
---[[
-    ITEM:call(method, client, entity, ...)
-
-    Description:
-        Invokes an item method with the given player and entity context.
-
-    Parameters:
-        method (string) – Method name to run.
-        client (Player) – The player performing the action.
-        entity (Entity) – Entity representing this item.
-        ... – Additional arguments passed to the method.
-
-    Realm:
-        Shared
-
-    Returns:
-        any – Results returned by the called function.
-]]
 function ITEM:call(method, client, entity, ...)
     local oldPlayer, oldEntity = self.player, self.entity
     self.player = client or self.player
@@ -162,18 +57,6 @@ function ITEM:call(method, client, entity, ...)
     self.entity = oldEntity
 end
 
---[[
-    ITEM:getOwner()
-
-    Description:
-        Attempts to find the player currently owning this item.
-
-    Realm:
-        Shared
-
-    Returns:
-        Player|nil – The owner if available.
-]]
 function ITEM:getOwner()
     local inventory = lia.inventory.instances[self.invID]
     if inventory and SERVER then return inventory:getRecipients()[1] end
@@ -184,22 +67,6 @@ function ITEM:getOwner()
     end
 end
 
---[[
-    ITEM:getData(key, default)
-
-    Description:
-        Retrieves a piece of persistent data stored on the item.
-
-    Parameters:
-        key (string) – Data key to read.
-        default (any) – Value to return when the key is absent.
-
-    Realm:
-        Shared
-
-    Returns:
-        any – Stored value or default.
-]]
 function ITEM:getData(key, default)
     self.data = self.data or {}
     local value = self.data[key]
@@ -212,19 +79,6 @@ function ITEM:getData(key, default)
     return default
 end
 
---[[
-    ITEM:getAllData()
-
-    Description:
-        Returns a merged table of this item's stored data and any
-        networked values on its entity.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Key/value table of all data fields.
-]]
 function ITEM:getAllData()
     self.data = self.data or {}
     local fullData = table.Copy(self.data)
@@ -237,65 +91,18 @@ function ITEM:getAllData()
     return fullData
 end
 
---[[
-    ITEM:hook(name, func)
-
-    Description:
-        Registers a hook callback for this item instance.
-
-    Parameters:
-        name (string) – Hook identifier.
-        func (function) – Function to call.
-
-    Realm:
-        Shared
-]]
 function ITEM:hook(name, func)
     if name then self.hooks[name] = func end
 end
 
---[[
-    ITEM:postHook(name, func)
-
-    Description:
-        Registers a post-hook callback for this item.
-
-    Parameters:
-        name (string) – Hook identifier.
-        func (function) – Function invoked after the main hook.
-
-    Realm:
-        Shared
-]]
 function ITEM:postHook(name, func)
     if name then self.postHooks[name] = func end
 end
 
---[[
-    ITEM:onRegistered()
-
-    Description:
-        Called when the item table is first registered.
-
-    Realm:
-        Shared
-]]
 function ITEM:onRegistered()
     if self.model and isstring(self.model) then util.PrecacheModel(self.model) end
 end
 
---[[
-    ITEM:print(detail)
-
-    Description:
-        Prints a simple representation of the item to the console.
-
-    Parameters:
-        detail (boolean) – Include position details when true.
-
-    Realm:
-        Server
-]]
 function ITEM:print(detail)
     if detail then
         print(Format("%s[%s]: >> [%s](%s,%s)", self.uniqueID, self.id, self.owner, self.gridX, self.gridY))
@@ -304,15 +111,6 @@ function ITEM:print(detail)
     end
 end
 
---[[
-    ITEM:printData()
-
-    Description:
-        Debug helper that prints all stored item data.
-
-    Realm:
-        Server
-]]
 function ITEM:printData()
     self:print(true)
     lia.information("ITEM DATA:")
@@ -471,38 +269,10 @@ if SERVER then
         self.data.x, self.data.y = x, y
     end
 
-    --[[
-        ITEM:addQuantity(quantity, receivers, noCheckEntity)
-
-        Description:
-            Increases the stored quantity for this item instance.
-
-        Parameters:
-            quantity (number) – Amount to add.
-            receivers (Player|nil) – Who to network the change to.
-            noCheckEntity (boolean) – Skip entity network update.
-
-        Realm:
-            Server
-    ]]
     function ITEM:addQuantity(quantity, receivers, noCheckEntity)
         self:setQuantity(self:getQuantity() + quantity, receivers, noCheckEntity)
     end
 
-    --[[
-        ITEM:setQuantity(quantity, receivers, noCheckEntity)
-
-        Description:
-            Sets the current stack quantity and replicates the change.
-
-        Parameters:
-            quantity (number) – New amount to store.
-            receivers (Player|nil) – Recipients to send updates to.
-            noCheckEntity (boolean) – Skip entity updates when true.
-
-        Realm:
-            Server
-    ]]
     function ITEM:setQuantity(quantity, receivers, noCheckEntity)
         self.quantity = quantity
         if not noCheckEntity then

--- a/gamemode/core/meta/panel.lua
+++ b/gamemode/core/meta/panel.lua
@@ -1,17 +1,6 @@
 local ScreenScale, ScreenScaleH = ScreenScale(), ScreenScaleH()
 local panel = FindMetaTable("Panel")
 
---[[
-    Screen-scaling helper wrappers for Panel positioning functions.
-
-    Description:
-        These helpers apply ScreenScale and ScreenScaleH to common panel
-        positioning and sizing methods so that UIs remain consistent across
-        different resolutions.
-
-    Realm:
-        Client
-]]
 
 local map = {
     SetPos = {ScreenScale, ScreenScaleH},    -- panel:SetPos(x, y)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -3,34 +3,10 @@ local vectorMeta = FindMetaTable("Vector")
 do
     playerMeta.steamName = playerMeta.steamName or playerMeta.Name
     playerMeta.SteamName = playerMeta.steamName
-    --[[
-        playerMeta:getChar()
-
-        Description:
-            Returns the currently loaded character object for this player.
-
-        Realm:
-            Shared
-
-        Returns:
-            Character|nil – The player's active character.
-    ]]
     function playerMeta:getChar()
         return lia.char.loaded[self.getNetVar(self, "char")]
     end
 
-    --[[
-        playerMeta:Name()
-
-        Description:
-            Returns either the character's roleplay name or the player's Steam name.
-
-        Realm:
-            Shared
-
-        Returns:
-            string – Display name.
-    ]]
     function playerMeta:Name()
         local character = self.getChar(self)
         return character and character.getName(character) or self.steamName(self)
@@ -41,71 +17,20 @@ do
     playerMeta.GetName = playerMeta.Name
 end
 
---[[
-    playerMeta:hasPrivilege(privilegeName)
-
-    Description:
-        Wrapper for CAMI privilege checks.
-
-    Parameters:
-        privilegeName (string) – Privilege identifier.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Result from CAMI.PlayerHasAccess.
-]]
 function playerMeta:hasPrivilege(privilegeName)
     return CAMI.PlayerHasAccess(self, privilegeName)
 end
 
---[[
-    playerMeta:getCurrentVehicle()
-
-    Description:
-        Safely returns the vehicle the player is currently using.
-
-    Realm:
-        Shared
-
-    Returns:
-        Entity|nil – Vehicle entity or nil.
-]]
 function playerMeta:getCurrentVehicle()
     local vehicle = self:GetVehicle()
     if vehicle and IsValid(vehicle) then return vehicle end
     return nil
 end
 
---[[
-    playerMeta:hasValidVehicle()
-
-    Description:
-        Determines if the player is currently inside a valid vehicle.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if a vehicle entity is valid.
-]]
 function playerMeta:hasValidVehicle()
     return IsValid(self:getCurrentVehicle())
 end
 
---[[
-    playerMeta:isNoClipping()
-
-    Description:
-        Returns true if the player is in noclip mode and not inside a vehicle.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the player is noclipping.
-]]
 function playerMeta:isNoClipping()
     return self:GetMoveType() == MOVETYPE_NOCLIP and not self:hasValidVehicle()
 end
@@ -189,18 +114,6 @@ function playerMeta:getItemDropPos()
     return trace.HitPos
 end
 
---[[
-    playerMeta:getItems()
-
-    Description:
-        Returns the player's inventory item list if a character is loaded.
-
-    Realm:
-        Shared
-
-    Returns:
-        table|nil – Table of items or nil if absent.
-]]
 function playerMeta:getItems()
     local character = self:getChar()
     if character then
@@ -209,21 +122,6 @@ function playerMeta:getItems()
     end
 end
 
---[[
-    playerMeta:getTracedEntity(distance)
-
-    Description:
-        Performs a simple trace from the player's shoot position.
-
-    Parameters:
-        distance (number) – Trace length in units.
-
-    Realm:
-        Shared
-
-    Returns:
-        Entity|nil – The entity hit or nil.
-]]
 function playerMeta:getTracedEntity(distance)
     if not distance then distance = 96 end
     local data = {}
@@ -234,21 +132,6 @@ function playerMeta:getTracedEntity(distance)
     return targetEntity
 end
 
---[[
-    playerMeta:getTrace(distance)
-
-    Description:
-        Returns a hull trace in front of the player.
-
-    Parameters:
-        distance (number) – Hull length in units.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Trace result.
-]]
 function playerMeta:getTrace(distance)
     if not distance then distance = 200 end
     local data = {}
@@ -261,160 +144,42 @@ function playerMeta:getTrace(distance)
     return trace
 end
 
---[[
-    playerMeta:getEyeEnt(distance)
-
-    Description:
-        Returns the entity the player is looking at within a distance.
-
-    Parameters:
-        distance (number) – Maximum distance.
-
-    Realm:
-        Shared
-
-    Returns:
-        Entity|nil – The entity or nil if too far.
-]]
 function playerMeta:getEyeEnt(distance)
     distance = distance or 150
     local e = self:GetEyeTrace().Entity
     return e:GetPos():Distance(self:GetPos()) <= distance and e or nil
 end
 
---[[
-    playerMeta:notify(message)
-
-    Description:
-        Sends a plain notification message to the player.
-
-    Parameters:
-        message (string) – Text to display.
-
-    Realm:
-        Server
-]]
 function playerMeta:notify(message)
     lia.notices.notify(message, self)
 end
 
---[[
-    playerMeta:notifyLocalized(message, ...)
-
-    Description:
-        Sends a localized notification to the player.
-
-    Parameters:
-        message (string) – Translation key.
-        ... – Additional parameters for localization.
-
-    Realm:
-        Server
-]]
 function playerMeta:notifyLocalized(message, ...)
     lia.notices.notifyLocalized(message, self, ...)
 end
 
---[[
-    playerMeta:CanEditVendor(vendor)
-
-    Description:
-        Determines whether the player can edit the given vendor.
-
-    Parameters:
-        vendor (Entity) – Vendor entity to check.
-
-    Realm:
-        Server
-
-    Returns:
-        boolean – True if allowed to edit.
-]]
 function playerMeta:CanEditVendor(vendor)
     local hookResult = hook.Run("CanPerformVendorEdit", self, vendor)
     if hookResult ~= nil then return hookResult end
     return self:hasPrivilege("Staff Permissions - Can Edit Vendors")
 end
 
---[[
-    playerMeta:isUser()
-
-    Description:
-        Convenience wrapper to check if the player is in the "user" group.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether usergroup is "user".
-]]
 function playerMeta:isUser()
     return self:IsUserGroup("user")
 end
 
---[[
-    playerMeta:isStaff()
-
-    Description:
-        Returns true if the player belongs to a staff group.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Result from the privilege check.
-]]
 function playerMeta:isStaff()
     return self:hasPrivilege("UserGroups - Staff Group")
 end
 
---[[
-    playerMeta:isVIP()
-
-    Description:
-        Checks whether the player is in the VIP group.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Result from privilege check.
-]]
 function playerMeta:isVIP()
     return self:hasPrivilege("UserGroups - VIP Group")
 end
 
---[[
-    playerMeta:isStaffOnDuty()
-
-    Description:
-        Determines if the player is currently in the staff faction.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if staff faction is active.
-]]
 function playerMeta:isStaffOnDuty()
     return self:Team() == FACTION_STAFF
 end
 
---[[
-    playerMeta:isFaction(faction)
-
-    Description:
-        Checks if the player's character belongs to the given faction.
-
-    Parameters:
-        faction (number) – Faction index to compare.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the factions match.
-]]
 function playerMeta:isFaction(faction)
     local character = self:getChar()
     if not character then return end
@@ -422,21 +187,6 @@ function playerMeta:isFaction(faction)
     return pFaction and pFaction == faction
 end
 
---[[
-    playerMeta:isClass(class)
-
-    Description:
-        Returns true if the player's character is of the given class.
-
-    Parameters:
-        class (number) – Class index to compare.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the character matches the class.
-]]
 function playerMeta:isClass(class)
     local character = self:getChar()
     if not character then return end
@@ -444,21 +194,6 @@ function playerMeta:isClass(class)
     return pClass and pClass == class
 end
 
---[[
-    playerMeta:hasWhitelist(faction)
-
-    Description:
-        Determines if the player has whitelist access for a faction.
-
-    Parameters:
-        faction (number) – Faction index.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if whitelisted.
-]]
 function playerMeta:hasWhitelist(faction)
     local data = lia.faction.indices[faction]
     if data then
@@ -470,38 +205,11 @@ function playerMeta:hasWhitelist(faction)
     return false
 end
 
---[[
-    playerMeta:getClass()
-
-    Description:
-        Retrieves the class index of the player's character.
-
-    Realm:
-        Shared
-
-    Returns:
-        number|nil – Class index or nil.
-]]
 function playerMeta:getClass()
     local character = self:getChar()
     if character then return character:getClass() end
 end
 
---[[
-    playerMeta:hasClassWhitelist(class)
-
-    Description:
-        Checks if the player's character is whitelisted for a class.
-
-    Parameters:
-        class (number) – Class index.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if class whitelist exists.
-]]
 function playerMeta:hasClassWhitelist(class)
     local char = self:getChar()
     if not char then return false end
@@ -509,18 +217,6 @@ function playerMeta:hasClassWhitelist(class)
     return wl[class] ~= nil
 end
 
---[[
-    playerMeta:getClassData()
-
-    Description:
-        Returns the class table of the player's current class.
-
-    Realm:
-        Shared
-
-    Returns:
-        table|nil – Class definition table.
-]]
 function playerMeta:getClassData()
     local character = self:getChar()
     if character then
@@ -532,100 +228,27 @@ function playerMeta:getClassData()
     end
 end
 
---[[
-    playerMeta:getDarkRPVar(var)
-
-    Description:
-        Compatibility helper for retrieving money with DarkRP-style calls.
-
-    Parameters:
-        var (string) – Currently only supports "money".
-
-    Realm:
-        Shared
-
-    Returns:
-        number|nil – Money amount or nil.
-]]
 function playerMeta:getDarkRPVar(var)
     if var ~= "money" then return end
     local char = self:getChar()
     return char:getMoney()
 end
 
---[[
-    playerMeta:getMoney()
-
-    Description:
-        Convenience function to get the character's money amount.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – Current funds or 0.
-]]
 function playerMeta:getMoney()
     local character = self:getChar()
     return character and character:getMoney() or 0
 end
 
---[[
-    playerMeta:canAfford(amount)
-
-    Description:
-        Checks if the player has enough money for a purchase.
-
-    Parameters:
-        amount (number) – Cost to test.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if funds are sufficient.
-]]
 function playerMeta:canAfford(amount)
     local character = self:getChar()
     return character and character:hasMoney(amount)
 end
 
---[[
-    playerMeta:hasSkillLevel(skill, level)
-
-    Description:
-        Verifies the player's character meets an attribute level.
-
-    Parameters:
-        skill (string) – Attribute ID.
-        level (number) – Required level.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – Whether the character satisfies the requirement.
-]]
 function playerMeta:hasSkillLevel(skill, level)
     local currentLevel = self:getChar():getAttrib(skill, 0)
     return currentLevel >= level
 end
 
---[[
-    playerMeta:meetsRequiredSkills(requiredSkillLevels)
-
-    Description:
-        Checks a table of skill requirements against the player.
-
-    Parameters:
-        requiredSkillLevels (table) – Mapping of attribute IDs to levels.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if all requirements are met.
-]]
 function playerMeta:meetsRequiredSkills(requiredSkillLevels)
     if not requiredSkillLevels then return true end
     for skill, level in pairs(requiredSkillLevels) do
@@ -634,24 +257,6 @@ function playerMeta:meetsRequiredSkills(requiredSkillLevels)
     return true
 end
 
---[[
-    playerMeta:forceSequence(sequenceName, callback, time, noFreeze)
-
-    Description:
-        Plays an animation sequence and optionally freezes the player.
-
-    Parameters:
-        sequenceName (string) – Sequence to play.
-        callback (function|nil) – Called when finished.
-        time (number|nil) – Duration override.
-        noFreeze (boolean) – Don't freeze movement when true.
-
-    Realm:
-        Shared
-
-    Returns:
-        number|boolean – Duration or false on failure.
-]]
 function playerMeta:forceSequence(sequenceName, callback, time, noFreeze)
     hook.Run("OnPlayerEnterSequence", self, sequenceName, callback, time, noFreeze)
     if not sequenceName then
@@ -684,15 +289,6 @@ function playerMeta:forceSequence(sequenceName, callback, time, noFreeze)
     return false
 end
 
---[[
-    playerMeta:leaveSequence()
-
-    Description:
-        Stops any forced sequence and restores player movement.
-
-    Realm:
-        Shared
-]]
 function playerMeta:leaveSequence()
     hook.Run("OnPlayerLeaveSequence", self)
     net.Start("seqSet")
@@ -706,18 +302,6 @@ function playerMeta:leaveSequence()
 end
 
 if SERVER then
-    --[[
-        playerMeta:restoreStamina(amount)
-
-        Description:
-            Increases the player's stamina value.
-
-        Parameters:
-            amount (number) – Amount to restore.
-
-        Realm:
-            Server
-    ]]
     function playerMeta:restoreStamina(amount)
         local current = self:getLocalVar("stamina", 0)
         local maxStamina = self:getChar():getMaxStamina()
@@ -729,18 +313,6 @@ if SERVER then
         end
     end
 
-    --[[
-        playerMeta:consumeStamina(amount)
-
-        Description:
-            Reduces the player's stamina value.
-
-        Parameters:
-            amount (number) – Amount to subtract.
-
-        Realm:
-            Server
-    ]]
     function playerMeta:consumeStamina(amount)
         local current = self:getLocalVar("stamina", 0)
         local value = math.Clamp(current - amount, 0, self:getChar():getMaxStamina())
@@ -751,18 +323,6 @@ if SERVER then
         end
     end
 
-    --[[
-        playerMeta:addMoney(amount)
-
-        Description:
-            Adds funds to the player's character, clamping to limits.
-
-        Parameters:
-            amount (number) – Money to add.
-
-        Realm:
-            Server
-    ]]
     function playerMeta:addMoney(amount)
         local character = self:getChar()
         if not character then return false end
@@ -787,18 +347,6 @@ if SERVER then
         return true
     end
 
-    --[[
-        playerMeta:takeMoney(amount)
-
-        Description:
-            Removes money from the player's character.
-
-        Parameters:
-            amount (number) – Amount to subtract.
-
-        Realm:
-            Server
-    ]]
     function playerMeta:takeMoney(amount)
         local character = self:getChar()
         if character then character:giveMoney(-amount) end

--- a/gamemode/core/meta/tool.lua
+++ b/gamemode/core/meta/tool.lua
@@ -1,19 +1,4 @@
 ﻿local ToolGunMeta = lia.meta.tool or {}
---[[
-    ToolGunMeta:Create()
-
-    Description:
-        Creates a new tool object with default values.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – The newly created tool object.
-
-    Example Usage:
-        local tool = ToolGunMeta:Create()
-]]
 
 function ToolGunMeta:Create()
     local object = {}
@@ -32,18 +17,6 @@ function ToolGunMeta:Create()
     return object
 end
 
---[[
-    ToolGunMeta:CreateConVars()
-
-    Description:
-        Creates client and server ConVars for this tool.
-
-    Realm:
-        Shared
-
-    Example Usage:
-        tool:CreateConVars()
-]]
 function ToolGunMeta:CreateConVars()
     local mode = self:GetMode()
     if CLIENT then
@@ -56,44 +29,11 @@ function ToolGunMeta:CreateConVars()
     end
 end
 
---[[
-    ToolGunMeta:GetServerInfo(property)
-
-    Description:
-        Returns the server ConVar for the given property.
-
-    Parameters:
-        property (string) – Property name.
-
-    Realm:
-        Shared
-
-    Returns:
-        ConVar – The server ConVar object.
-
-    Example Usage:
-        local allow = tool:GetServerInfo("allow_use"):GetBool()
-]]
 function ToolGunMeta:GetServerInfo(property)
     local mode = self:GetMode()
     return ConVar(mode .. "_" .. property)
 end
 
---[[
-    ToolGunMeta:BuildConVarList()
-
-    Description:
-        Returns a table of client ConVars prefixed by the tool mode.
-
-    Realm:
-        Shared
-
-    Returns:
-        table – Table of convars.
-
-    Example Usage:
-        local cvars = tool:BuildConVarList()
-]]
 function ToolGunMeta:BuildConVarList()
     local mode = self:GetMode()
     local convars = {}
@@ -103,268 +43,72 @@ function ToolGunMeta:BuildConVarList()
     return convars
 end
 
---[[
-    ToolGunMeta:GetClientInfo(property)
-
-    Description:
-        Retrieves a client ConVar value as a string.
-
-    Parameters:
-        property (string) – ConVar name without mode prefix.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – The value stored in the ConVar.
-
-    Example Usage:
-        local val = tool:GetClientInfo("setting")
-]]
 function ToolGunMeta:GetClientInfo(property)
     return self:GetOwner():GetInfo(self:GetMode() .. "_" .. property)
 end
 
---[[
-    ToolGunMeta:GetClientNumber(property, default)
-
-    Description:
-        Retrieves a numeric client ConVar value.
-
-    Parameters:
-        property (string) – ConVar name without mode prefix.
-        default (number) – Value returned if the ConVar doesn't exist.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – The numeric value of the ConVar.
-
-    Example Usage:
-        local power = tool:GetClientNumber("power", 10)
-]]
 function ToolGunMeta:GetClientNumber(property, default)
     return self:GetOwner():GetInfoNum(self:GetMode() .. "_" .. property, tonumber(default) or 0)
 end
 
---[[
-    ToolGunMeta:Allowed()
-
-    Description:
-        Determines whether this tool is allowed to be used.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – True if the tool is allowed.
-
-    Example Usage:
-        if tool:Allowed() then print("ok") end
-]]
 function ToolGunMeta:Allowed()
     if CLIENT then return true end
     return self.AllowedCVar:GetBool()
 end
 
---[[
-    ToolGunMeta:Init()
-
-    Description:
-        Placeholder for tool initialization.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:Init()
 end
 
---[[
-    ToolGunMeta:GetMode()
-
-    Description:
-        Gets the current tool mode string.
-
-    Realm:
-        Shared
-
-    Returns:
-        string – Tool mode name.
-]]
 function ToolGunMeta:GetMode()
     return self.Mode
 end
 
---[[
-    ToolGunMeta:GetSWEP()
-
-    Description:
-        Returns the SWEP associated with this tool.
-
-    Realm:
-        Shared
-
-    Returns:
-        SWEP – The tool's weapon entity.
-]]
 function ToolGunMeta:GetSWEP()
     return self.SWEP
 end
 
---[[
-    ToolGunMeta:GetOwner()
-
-    Description:
-        Retrieves the tool owner's player object.
-
-    Realm:
-        Shared
-
-    Returns:
-        Player – Owner of the tool.
-]]
 function ToolGunMeta:GetOwner()
     return self:GetSWEP().Owner or self:GetOwner()
 end
 
---[[
-    ToolGunMeta:GetWeapon()
-
-    Description:
-        Retrieves the weapon entity this tool is attached to.
-
-    Realm:
-        Shared
-
-    Returns:
-        Weapon – The weapon object.
-]]
 function ToolGunMeta:GetWeapon()
     return self:GetSWEP().Weapon or self.Weapon
 end
 
---[[
-    ToolGunMeta:LeftClick()
-
-    Description:
-        Handles the left-click action. Override for custom behavior.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – False by default.
-]]
 function ToolGunMeta:LeftClick()
     return false
 end
 
---[[
-    ToolGunMeta:RightClick()
-
-    Description:
-        Handles the right-click action. Override for custom behavior.
-
-    Realm:
-        Shared
-
-    Returns:
-        boolean – False by default.
-]]
 function ToolGunMeta:RightClick()
     return false
 end
 
---[[
-    ToolGunMeta:Reload()
-
-    Description:
-        Clears stored objects when the tool reloads.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:Reload()
     self:ClearObjects()
 end
 
---[[
-    ToolGunMeta:Deploy()
-
-    Description:
-        Called when the tool is equipped. Releases ghost entity.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:Deploy()
     self:ReleaseGhostEntity()
 end
 
---[[
-    ToolGunMeta:Holster()
-
-    Description:
-        Called when the tool is holstered. Releases ghost entity.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:Holster()
     self:ReleaseGhostEntity()
 end
 
---[[
-    ToolGunMeta:Think()
-
-    Description:
-        Called every tick; releases ghost entities by default.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:Think()
     self:ReleaseGhostEntity()
 end
 
---[[
-    ToolGunMeta:CheckObjects()
-
-    Description:
-        Validates stored objects and clears them if invalid.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:CheckObjects()
     for _, v in pairs(self.Objects) do
         if not v.Ent:IsWorld() and not IsValid(v.Ent) then self:ClearObjects() end
     end
 end
 
---[[
-    ToolGunMeta:ClearObjects()
-
-    Description:
-        Removes all stored objects from the tool.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:ClearObjects()
     self.Objects = {}
 end
 
---[[
-    ToolGunMeta:ReleaseGhostEntity()
-
-    Description:
-        Removes the ghost entity used for previewing placements.
-
-    Realm:
-        Shared
-]]
 function ToolGunMeta:ReleaseGhostEntity()
     if IsValid(self.GhostEntity) then
         SafeRemoveEntity(self.GhostEntity)

--- a/gamemode/core/meta/vector.lua
+++ b/gamemode/core/meta/vector.lua
@@ -1,73 +1,15 @@
 local vectorMeta = FindMetaTable("Vector")
 
---[[
-    vectorMeta:Center(vec2)
-
-    Description:
-        Returns the midpoint between this vector and the supplied vector.
-
-    Parameters:
-        vec2 (Vector) – The vector to average with this vector.
-
-    Realm:
-        Shared
-
-    Returns:
-        Vector – The center point of the two vectors.
-
-    Example Usage:
-        local midpoint = vector_origin:Center(Vector(10, 10, 10))
-        print(midpoint) -- Vector(5, 5, 5)
-]]
 function vectorMeta:Center(vec2)
     return (self + vec2) / 2
 end
 
---[[
-    vectorMeta:Distance(vec2)
-
-    Description:
-        Calculates the distance between this vector and another vector.
-
-    Parameters:
-        vec2 (Vector) – The other vector.
-
-    Realm:
-        Shared
-
-    Returns:
-        number – The distance between the two vectors.
-
-    Example Usage:
-        local dist = vector_origin:Distance(Vector(3, 4, 0))
-        print(dist) -- 5
-]]
 function vectorMeta:Distance(vec2)
     local x, y, z = self.x, self.y, self.z
     local x2, y2, z2 = vec2.x, vec2.y, vec2.z
     return math.sqrt((x - x2) ^ 2 + (y - y2) ^ 2 + (z - z2) ^ 2)
 end
 
---[[
-    vectorMeta:RotateAroundAxis(axis, degrees)
-
-    Description:
-        Rotates the vector around an axis by the specified degrees and returns the new vector.
-
-    Parameters:
-        axis (Vector) – Axis to rotate around.
-        degrees (number) – Angle in degrees.
-
-    Realm:
-        Shared
-
-    Returns:
-        Vector – The rotated vector.
-
-    Example Usage:
-        local rotated = Vector(1, 0, 0):RotateAroundAxis(Vector(0, 0, 1), 90)
-        print(rotated) -- Vector(0, 1, 0)
-]]
 function vectorMeta:RotateAroundAxis(axis, degrees)
     local rad = math.rad(degrees)
     local cosTheta = math.cos(rad)
@@ -81,25 +23,6 @@ end
 
 local right = Vector(0, -1, 0)
 
---[[
-    vectorMeta:Right(vUp)
-
-    Description:
-        Returns a normalized right-direction vector relative to this vector.
-
-    Parameters:
-        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
-
-    Realm:
-        Shared
-
-    Returns:
-        Vector – The calculated right vector.
-
-    Example Usage:
-        local rightVec = Vector(0, 1, 0):Right()
-        print(rightVec)
-]]
 function vectorMeta:Right(vUp)
     if self[1] == 0 and self[2] == 0 then return right end
     if not vUp then vUp = vector_up end
@@ -108,25 +31,6 @@ function vectorMeta:Right(vUp)
     return vRet
 end
 
---[[
-    vectorMeta:Up(vUp)
-
-    Description:
-        Returns a normalized up-direction vector relative to this vector.
-
-    Parameters:
-        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
-
-    Realm:
-        Shared
-
-    Returns:
-        Vector – The calculated up vector.
-
-    Example Usage:
-        local upVec = Vector(1, 0, 0):Up()
-        print(upVec)
-]]
 function vectorMeta:Up(vUp)
     if self[1] == 0 and self[2] == 0 then return Vector(-self[3], 0, 0) end
     if not vUp then vUp = vector_up end


### PR DESCRIPTION
## Summary
- adjust meta documentation headers by removing meta prefixes
- ensure spacing between Description, Parameters, Realm, Returns, and Example Usage sections

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e28a5ec2c8327af0233ca6bbfca27