### PR TITLE
Improve hook documentation

### DIFF
--- a/docs/lua/hooks/class.lua
+++ b/docs/lua/hooks/class.lua
@@ -35,6 +35,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function CLASS:OnLeave(client)
                 local character = client:getChar()
@@ -52,6 +56,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function CLASS:OnSet(client)
                 client:setModel("models/police.mdl")
@@ -68,6 +76,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function CLASS:OnSpawn(client)
                 client:SetMaxHealth(500)
@@ -87,6 +99,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function CLASS:OnTransferred(client, oldClass)
                 print(client:Name(), "switched from class", oldClass)

--- a/docs/lua/hooks/faction.lua
+++ b/docs/lua/hooks/faction.lua
@@ -15,6 +15,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            string – Default name text.
+
         Example Usage:
             function FACTION:GetDefaultName(client)
                 return "CT-" .. math.random(111111, 999999)
@@ -31,6 +35,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            string – Default description text.
+
         Example Usage:
             function FACTION:GetDefaultDesc(client)
                 return "A police officer"
@@ -48,6 +56,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function FACTION:OnCharCreated(client, character)
                 local inventory = character:getInv()
@@ -65,6 +77,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function FACTION:OnSpawn(client)
                 client:ChatPrint("You have spawned!")
@@ -81,6 +97,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             function FACTION:OnTransferred(client)
                 local randomModelIndex = math.random(1, #self.models)

--- a/docs/lua/hooks/gamemode.lua
+++ b/docs/lua/hooks/gamemode.lua
@@ -11,8 +11,15 @@
             Called after the F1 menu panel is created so additional sections can be added.
             Populates the character information sections of the F1 menu.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Prints a message after the info panel is built.
             hook.Add("LoadCharInformation", "PrintLoad", function()
@@ -31,6 +38,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Inserts a custom "Help" tab into the F1 menu.
             hook.Add("CreateMenuButtons", "AddHelpTab", function(tabs)
@@ -50,6 +61,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Draws "Preview" text over the character model each frame.
             hook.Add("DrawLiliaModelView", "Watermark", function(panel, entity)
@@ -68,6 +83,10 @@
 
         Realm:
             Client
+
+        Returns:
+            boolean – Return true to allow override
+
         Example Usage:
             -- Allows other hooks to replace player names on the scoreboard.
             hook.Add("ShouldAllowScoreboardOverride", "OverrideNames", function(ply, field)
@@ -85,6 +104,10 @@
 
         Realm:
             Client
+
+        Returns:
+            string or nil – Name text to display
+
         Example Usage:
             -- Displays player names with an admin prefix.
             hook.Add("GetDisplayedName", "AdminPrefix", function(ply)
@@ -104,6 +127,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Announces in chat when someone stops using voice chat.
             hook.Add("PlayerEndVoice", "NotifyVoiceStop", function(ply)
@@ -122,6 +149,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Lets you react when a spawn menu icon is removed.
             hook.Add("SpawnlistContentChanged", "IconRemoved", function(icon)
@@ -143,6 +174,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Draws the item quantity in the bottom-right corner.
             hook.Add("ItemPaintOver", "ShowQuantity", function(panel, item, w, h)
@@ -163,6 +198,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds an "Inspect" choice to an item's context menu.
             hook.Add("OnCreateItemInteractionMenu", "AddInspect", function(panel, menu, item)
@@ -185,6 +224,7 @@
 
         Returns:
             boolean – True if the action can run.
+
         Example Usage:
             -- Disables the drop action for all items.
             hook.Add("CanRunItemAction", "BlockDrop", function(item, action)
@@ -204,6 +244,10 @@
 
         Realm:
             Client
+
+        Returns:
+            number – Maximum starting points
+
         Example Usage:
             -- Gives every new character 60 starting points.
             hook.Add("GetMaxStartingAttributePoints", "DoublePoints", function(client)
@@ -223,6 +267,10 @@
 
         Realm:
             Client
+
+        Returns:
+            number – Maximum starting value
+
         Example Usage:
             -- Limits the Strength attribute to a maximum of 20.
             hook.Add("GetAttributeStartingMax", "CapStrength", function(client, attribute)
@@ -241,6 +289,10 @@
 
         Realm:
             Client
+
+        Returns:
+            boolean – False to hide the player
+
         Example Usage:
             -- Stops bots from showing up on the scoreboard.
             hook.Add("ShouldShowPlayerOnScoreboard", "HideBots", function(ply)
@@ -260,6 +312,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds a friendly "Wave" choice in the scoreboard menu.
             hook.Add("ShowPlayerOptions", "WaveOption", function(ply, options)
@@ -279,6 +335,10 @@
 
         Realm:
             Client
+
+        Returns:
+            string – Description text
+
         Example Usage:
             -- Shows an OOC description when requested by the scoreboard.
             hook.Add("GetDisplayedDescription", "OOCDesc", function(ply, isOOC)
@@ -297,6 +357,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Displays a hint when the user types "/help".
             hook.Add("ChatTextChanged", "CommandHint", function(text)
@@ -310,8 +374,15 @@
             Fires when the chat box closes.
             Fired when the chat box is closed.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Prints a message whenever the chat box closes.
             hook.Add("FinishChat", "ChatClosed", function()
@@ -325,8 +396,15 @@
             Fires when the chat box opens.
             Fired when the chat box is opened.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Plays a sound whenever the chat box opens.
             hook.Add("StartChat", "ChatOpened", function()
@@ -349,6 +427,7 @@
 
         Returns:
             string – Modified markup text.
+
         Example Usage:
             -- Turns chat messages green before they appear.
             hook.Add("ChatAddText", "GreenSystem", function(text, ...)
@@ -369,6 +448,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds the item's weight to its tooltip.
             hook.Add("DisplayItemRelevantInfo", "ShowWeight", function(extra, client, item)
@@ -390,6 +473,7 @@
 
         Returns:
             Vector, Angle – Position and angle values.
+
         Example Usage:
             -- Positions the main menu camera with a slight offset.
             hook.Add("GetMainMenuPosition", "OffsetCharView", function(character)
@@ -411,6 +495,7 @@
 
         Returns:
             boolean – False to disallow deletion.
+
         Example Usage:
             -- Blocks deletion of the first character slot.
             hook.Add("CanDeleteChar", "ProtectSlot1", function(id)
@@ -430,6 +515,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds the character's faction to the menu info panel.
             hook.Add("LoadMainMenuInformation", "AddFactionInfo", function(info, character)
@@ -451,6 +540,7 @@
 
         Returns:
             boolean – False to disallow creation.
+
         Example Usage:
             -- Restricts character creation to admins only.
             hook.Add("CanPlayerCreateChar", "AdminsOnly", function(ply)
@@ -470,6 +560,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Changes a bodygroup on the preview model.
             hook.Add("ModifyCharacterModel", "ApplyBodygroup", function(ent, character)
@@ -488,6 +582,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds a custom "background" step to the character creator.
             hook.Add("ConfigureCharacterCreationSteps", "InsertBackground", function(panel)
@@ -509,6 +607,7 @@
 
         Returns:
             number – Maximum character count.
+
         Example Usage:
             -- Gives admins extra character slots.
             hook.Add("GetMaxPlayerChar", "AdminSlots", function(ply)
@@ -530,6 +629,7 @@
 
         Returns:
             boolean, string – False and reason to hide.
+
         Example Usage:
             -- Hides the delete button when the feature is locked.
             hook.Add("ShouldMenuButtonShow", "HideDelete", function(name)
@@ -543,8 +643,15 @@
             Called when the character creation panel should reset.
             Called to reset the character creation panel.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Notifies whenever the creation panel resets.
             hook.Add("ResetCharacterPanel", "ClearFields", function()
@@ -558,8 +665,15 @@
             Notifies when the EasyIcons font sheet has loaded.
             Fired when the EasyIcons library has loaded.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Prints a message once the EasyIcons font is loaded.
             hook.Add("EasyIconsLoaded", "Notify", function()
@@ -579,6 +693,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Logs newly registered CAMI usergroups.
             hook.Add("CAMI.OnUsergroupRegistered", "LogGroup", function(group)
@@ -598,6 +716,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Logs whenever a usergroup is removed from CAMI.
             hook.Add("CAMI.OnUsergroupUnregistered", "LogRemoval", function(group)
@@ -616,6 +738,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Reports when a new CAMI privilege is registered.
             hook.Add("CAMI.OnPrivilegeRegistered", "LogPrivilege", function(priv)
@@ -634,6 +760,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Reports when a CAMI privilege is removed.
             hook.Add("CAMI.OnPrivilegeUnregistered", "LogPrivRemoval", function(priv)
@@ -657,6 +787,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Lets superadmins bypass privilege checks.
             hook.Add("CAMI.PlayerHasAccess", "AllowSuperadmins", function(_, actor, priv, cb)
@@ -680,6 +814,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Grants access for a specific SteamID.
             hook.Add("CAMI.SteamIDHasAccess", "AllowSteamID", function(_, steamID, priv, cb)
@@ -701,6 +839,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Announces when a player's usergroup changes.
             hook.Add("CAMI.PlayerUsergroupChanged", "AnnounceChange", function(ply, old, new)
@@ -722,6 +864,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Logs usergroup changes by SteamID.
             hook.Add("CAMI.SteamIDUsergroupChanged", "LogSIDChange", function(sid, old, new)
@@ -739,6 +885,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Sets a fixed width for tooltips before layout.
             hook.Add("TooltipLayout", "FixedWidth", function(panel)
@@ -758,6 +908,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds a dark background and skips default paint.
             hook.Add("TooltipPaint", "BlurBackground", function(panel, w, h)
@@ -778,6 +932,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Fades tooltips in when they are created.
             hook.Add("TooltipInitialize", "SetupFade", function(panel, target)
@@ -797,6 +955,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Gives players a crowbar on spawn.
             hook.Add("PlayerLoadout", "GiveCrowbar", function(ply)
@@ -817,6 +979,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – Return true to mark for permanent death
+
         Example Usage:
             -- Prevent permanent death from fall damage.
             hook.Add("PlayerShouldPermaKill", "NoFallPK", function(ply, inflictor)
@@ -836,6 +1002,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to block dropping
+
         Example Usage:
             -- Disallow dropping locked items.
             hook.Add("CanPlayerDropItem", "NoLockedDrop", function(ply, item)
@@ -855,6 +1025,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to prevent pickup
+
         Example Usage:
             -- Block taking admin items.
             hook.Add("CanPlayerTakeItem", "NoAdminPickup", function(ply, item)
@@ -874,6 +1048,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to block equipping
+
         Example Usage:
             -- Allow equipping only if level requirement met.
             hook.Add("CanPlayerEquipItem", "CheckLevel", function(ply, item)
@@ -895,6 +1073,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to prevent unequipping
+
         Example Usage:
             -- Prevent unequipping cursed gear.
             hook.Add("CanPlayerUnequipItem", "Cursed", function(ply, item)
@@ -916,6 +1098,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Log all OOC chat.
             hook.Add("PostPlayerSay", "LogOOC", function(ply, msg, chatType)
@@ -934,6 +1120,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to skip ragdoll
+
         Example Usage:
             -- Disable ragdolls for bots.
             hook.Add("ShouldSpawnClientRagdoll", "NoBotRagdoll", function(ply)
@@ -947,8 +1137,15 @@
             Called when the framework saves persistent data.
             Modules can store custom information here.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Save a timestamp to file.
             hook.Add("SaveData", "RecordTime", function()
@@ -962,8 +1159,15 @@
             Fires when map persistence should be written to disk.
             Allows adding extra persistent entities.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PersistenceSave", "Notice", function()
                 print("Saving persistent entities")
@@ -998,8 +1202,15 @@
             Triggered when stored data should be loaded.
             Modules can restore custom information here.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("LoadData", "LoadExtras", function()
                 print("Loading custom data")
@@ -1012,8 +1223,15 @@
             Called after all persistent data has loaded.
             Useful for post-processing.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PostLoadData", "Ready", function()
                 print("Data fully loaded")
@@ -1026,8 +1244,15 @@
             Queries if data saving should occur during shutdown.
             Return false to cancel saving.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            boolean – False to cancel saving
+
         Example Usage:
             -- Skip saving during quick restarts.
             hook.Add("ShouldDataBeSaved", "NoSave", function()
@@ -1047,6 +1272,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharDisconnect", "Goodbye", function(ply, char)
                 print(char:getName(), "has left")
@@ -1064,6 +1293,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("SetupBotPlayer", "WelcomeBot", function(bot)
                 bot:ChatPrint("Beep boop!")
@@ -1081,6 +1314,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PlayerLiliaDataLoaded", "SendWelcome", function(ply)
                 ply:ChatPrint("Data loaded")
@@ -1098,6 +1335,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PostPlayerInitialSpawn", "Greet", function(ply)
                 print("Hello", ply:Nick())
@@ -1115,6 +1356,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("FactionOnLoadout", "GiveRadio", function(ply)
                 if ply:getChar():getFaction() == "police" then
@@ -1134,6 +1379,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ClassOnLoadout", "MedicItems", function(ply)
                 if ply:getChar():getClass() == "medic" then
@@ -1153,6 +1402,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PostPlayerLoadout", "SetColor", function(ply)
                 ply:SetPlayerColor(Vector(0,1,0))
@@ -1170,6 +1423,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("FactionPostLoadout", "Shout", function(ply)
                 if ply:getChar():getFaction() == "soldier" then
@@ -1189,6 +1446,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ClassPostLoadout", "Pose", function(ply)
                 ply:ConCommand("act muscle")
@@ -1206,6 +1467,10 @@
 
         Realm:
             Server
+
+        Returns:
+            string – Inventory type
+
         Example Usage:
             hook.Add("GetDefaultInventoryType", "UseGrid", function()
                 return "GridInv"
@@ -1218,8 +1483,15 @@
             Decides whether saved persistent items should be deleted on load.
             Return true to wipe them from the database.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            boolean – True to delete items
+
         Example Usage:
             hook.Add("ShouldDeleteSavedItems", "ClearDrops", function()
                 return false
@@ -1237,6 +1509,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnSavedItemLoaded", "PrintCount", function(items)
                 print("Loaded", #items, "items")
@@ -1254,6 +1530,10 @@
 
         Realm:
             Client
+
+        Returns:
+            boolean – False to hide info
+
         Example Usage:
             hook.Add("ShouldDrawEntityInfo", "HideNPCs", function(ent)
                 if ent:IsNPC() then return false end
@@ -1273,6 +1553,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("DrawEntityInfo", "LabelProps", function(ent, a, pos)
                 draw.SimpleText(ent:GetClass(), "DermaDefault", pos.x, pos.y, Color(255,255,255,a))
@@ -1290,6 +1574,10 @@
 
         Realm:
             Client
+
+        Returns:
+            table – {text, color} info
+
         Example Usage:
             hook.Add("GetInjuredText", "SimpleHealth", function(ply)
                 if ply:Health() <= 20 then return {"Critical", Color(255,0,0)} end
@@ -1307,6 +1595,10 @@
 
         Realm:
             Client
+
+        Returns:
+            boolean – False to hide info
+
         Example Usage:
             hook.Add("ShouldDrawPlayerInfo", "HideLocal", function(ply)
                 if ply == LocalPlayer() then return false end
@@ -1326,6 +1618,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("DrawCharInfo", "JobTitle", function(ply, char, info)
                 info[#info + 1] = {"Job: " .. (char:getClass() or "None")}
@@ -1343,6 +1639,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ItemShowEntityMenu", "QuickTake", function(ent)
                 print("Opening menu for", ent)
@@ -1355,8 +1655,15 @@
             Fired just before the client finishes loading the framework.
             Useful for setup tasks.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PreLiliaLoaded", "Prep", function()
                 print("About to finish loading")
@@ -1369,8 +1676,15 @@
             Indicates the client finished initializing the framework.
             Modules can start creating panels here.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("LiliaLoaded", "Ready", function()
                 print("Lilia client ready")
@@ -1391,6 +1705,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InventoryDataChanged", "TrackWeight", function(inv, k, old, new)
                 if k == "weight" then print("Weight changed to", new) end
@@ -1408,6 +1726,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ItemInitialized", "PrintID", function(item)
                 print("Created item", item.uniqueID)
@@ -1425,6 +1747,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InventoryInitialized", "AnnounceInv", function(inv)
                 print("Inventory", inv:getID(), "ready")
@@ -1443,6 +1769,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InventoryItemAdded", "NotifyAdd", function(inv, item)
                 print("Added", item.name)
@@ -1461,6 +1791,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InventoryItemRemoved", "NotifyRemove", function(inv, item)
                 print("Removed", item.name)
@@ -1478,6 +1812,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InventoryDeleted", "Clear", function(inv)
                 print("Inventory", inv:getID(), "deleted")
@@ -1495,6 +1833,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ItemDeleted", "Log", function(item)
                 print("Item", item.uniqueID, "gone")
@@ -1515,6 +1857,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharVarChanged", "WatchMoney", function(char, k, old, new)
                 if k == "money" then print("Money changed", new) end
@@ -1535,6 +1881,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharLocalVarChanged", "WatchFlags", function(char, k, old, new)
                 if k == "flags" then print("Flags changed") end
@@ -1555,6 +1905,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ItemDataChanged", "TrackDurability", function(item, key)
                 if key == "durability" then print("New durability", item.data[key]) end
@@ -1574,6 +1928,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("ItemQuantityChanged", "CountStacks", function(item, old, new)
                 print("Quantity now", new)
@@ -1592,6 +1950,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("KickedFromChar", "Notify", function(id, current)
                 print("Kicked from", id, current and "(current)" or "")
@@ -1613,6 +1975,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("HandleItemTransferRequest", "LogMove", function(ply, itemID, x, y)
                 print(ply, "moved item", itemID, "to", x, y)
@@ -1630,6 +1996,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharLoaded", "Notify", function(id)
                 print("Character", id, "loaded")
@@ -1647,6 +2017,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PreCharDelete", "Protect", function(id)
                 if id == 1 then return false end
@@ -1665,6 +2039,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharDelete", "Announce", function(ply, id)
                 print(ply, "deleted char", id)
@@ -1684,6 +2062,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharCreated", "Welcome", function(ply, char)
                 print("Created", char:getName())
@@ -1701,6 +2083,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnTransferred", "Goodbye", function(ply)
                 print(ply, "left the server")
@@ -1718,6 +2104,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharPreSave", "Record", function(char)
                 char:setData("lastSave", os.time())
@@ -1735,6 +2125,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharListLoaded", "CountChars", function(list)
                 print("Loaded", #list, "characters")
@@ -1753,6 +2147,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharListUpdated", "Diff", function(old, new)
                 print("Characters updated")
@@ -1770,6 +2168,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
         hook.Add("getCharMaxStamina", "Double", function(char)
             return 200
@@ -1791,6 +2193,7 @@
 
         Returns:
             number – Modified stamina cost.
+
         Example Usage:
             hook.Add("AdjustStaminaOffsetRunning", "EnduranceBonus", function(ply, cost)
                 return cost + ply:getChar():getAttrib("stamina", 0) * -0.01
@@ -1812,6 +2215,7 @@
 
         Returns:
             number – Modified regeneration amount.
+
         Example Usage:
             hook.Add("AdjustStaminaRegeneration", "RestAreaBoost", function(ply, amount)
                 if ply:isInSafeZone() then
@@ -1835,6 +2239,7 @@
 
         Returns:
             number – New offset to apply.
+
         Example Usage:
             hook.Add("AdjustStaminaOffset", "MinimumDrain", function(ply, off)
                 return math.max(off, -1)
@@ -1853,6 +2258,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PostLoadFonts", "LogoFont", function()
                 surface.CreateFont("Logo", {size = 32, font = "Tahoma"})
@@ -1874,6 +2283,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Adds a custom thirst bar next to stamina.
             hook.Add("AddBarField", "AddThirstBar", function(section, id, label, min, max, value)
@@ -1894,6 +2307,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Add a custom "Settings" tab.
             hook.Add("AddSection", "AddSettingsSection", function(name, color, priority)
@@ -1917,6 +2334,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean, string – False and reason to block
+
         Example Usage:
             -- Prevent quest items from being dropped.
             hook.Add("CanItemBeTransfered", "BlockQuestItemDrop", function(item, newInv, oldInv)
@@ -1934,8 +2355,10 @@
 
         Realm:
             Client
+
         Returns:
             boolean – False to block opening.
+
         Example Usage:
             -- Disallow bag use while fighting.
             hook.Add("CanOpenBagPanel", "BlockBagInCombat", function(item)
@@ -1953,8 +2376,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to block the change.
+
         Example Usage:
             -- Restrict model swaps for certain factions.
             hook.Add("CanOutfitChangeModel", "RestrictModelSwap", function(item)
@@ -1973,8 +2398,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to disallow editing.
+
         Example Usage:
             -- Allow only admins to edit vendors.
             hook.Add("CanPerformVendorEdit", "AdminVendorEdit", function(client)
@@ -1993,8 +2420,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to disallow pickup.
+
         Example Usage:
             -- Prevent money pickup while handcuffed.
             hook.Add("CanPickupMoney", "BlockWhileCuffed", function(client)
@@ -2014,8 +2443,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to deny access.
+
         Example Usage:
             -- Only police can unlock jail cells.
             hook.Add("CanPlayerAccessDoor", "PoliceDoors", function(client, door, access)
@@ -2034,8 +2465,10 @@
 
         Realm:
             Server
+
         Returns:
             boolean – False to deny access.
+
         Example Usage:
             -- Block access unless the vendor allows the player's faction.
             hook.Add("CanPlayerAccessVendor", "CheckVendorFaction", function(client, vendor)
@@ -2054,8 +2487,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to prevent holding.
+
         Example Usage:
             -- Prevent grabbing heavy physics objects.
             hook.Add("CanPlayerHoldObject", "WeightLimit", function(client, ent)
@@ -2075,8 +2510,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to block the action.
+
         Example Usage:
             -- Block medkit use inside safe zones.
             hook.Add("CanPlayerInteractItem", "SafeZoneBlock", function(client, action, item)
@@ -2097,8 +2534,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to block knocking.
+
         Example Usage:
             -- Prevent knocking while disguised.
             hook.Add("CanPlayerKnock", "BlockDisguisedKnock", function(client, door)
@@ -2118,8 +2557,10 @@
 
         Realm:
             Server
+
         Returns:
             boolean – False to deny spawning.
+
         Example Usage:
             -- Limit players to one storage crate.
             hook.Add("CanPlayerSpawnStorage", "LimitStorage", function(client, ent, data)
@@ -2137,8 +2578,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean – False to block punching.
+
         Example Usage:
             -- Prevent punching while restrained.
             hook.Add("CanPlayerThrowPunch", "NoPunchWhenTied", function(client)
@@ -2159,6 +2602,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean, string – False and reason to deny trade
+
         Example Usage:
             -- Block selling stolen goods.
             hook.Add("CanPlayerTradeWithVendor", "DisallowStolenItems", function(client, vendor, itemType, selling)
@@ -2171,8 +2618,15 @@
         Description:
             Called before any inventory menu is shown.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            boolean – False to prevent opening
+
         Example Usage:
             -- Prevent opening inventory while in a cutscene.
             hook.Add("CanPlayerViewInventory", "BlockDuringCutscene", function()
@@ -2191,6 +2645,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to cancel saving
+
         Example Usage:
             -- Disable saving during special events.
             hook.Add("CanSaveData", "NoEventSaves", function(entity, inv)
@@ -2209,6 +2667,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Grant extra access for characters owned by admins.
             hook.Add("CharHasFlags", "AdminExtraFlags", function(char, flags)
@@ -2229,6 +2691,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Log every time characters save data.
             hook.Add("CharPostSave", "LogCharSaves", function(char)
@@ -2241,8 +2707,15 @@
         Description:
             Fired after the database has been successfully connected.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Prepare custom tables once the DB connects.
             hook.Add("DatabaseConnected", "CreateCustomTables", function()
@@ -2264,6 +2737,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Display remaining uses next to item name.
             hook.Add("DrawItemDescription", "AddUseCount", function(item, x, y, color, alpha)
@@ -2282,6 +2759,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            number – Maximum attribute value
+
         Example Usage:
             -- Increase stamina cap for admins.
             hook.Add("GetAttributeMax", "AdminStamina", function(client, attrib)
@@ -2301,6 +2782,10 @@
 
         Realm:
             Server
+
+        Returns:
+            number, number – Width and height
+
         Example Usage:
             -- Expand default bags for admins.
             hook.Add("GetDefaultInventorySize", "AdminBags", function(client)
@@ -2320,6 +2805,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            string – Model path to use
+
         Example Usage:
             -- Use a golden model for large sums.
             hook.Add("GetMoneyModel", "GoldMoneyModel", function(amount)
@@ -2340,6 +2829,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Scale punch damage by strength attribute.
             hook.Add("GetPlayerPunchDamage", "StrengthPunch", function(client, dmg, context)
@@ -2359,6 +2852,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Shift-click to quickly move items.
             hook.Add("InterceptClickItemIcon", "ShiftQuickMove", function(panel, icon, key)
@@ -2381,6 +2878,7 @@
 
         Returns:
             bool – true if combination succeeds and items are consumed, false otherwise.
+
         Example Usage:
             -- Combine two ammo boxes into one stack.
             hook.Add("ItemCombine", "StackAmmo", function(client, base, other)
@@ -2403,6 +2901,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Drop the item into the world when removed.
             hook.Add("ItemDraggedOutOfInventory", "DropOnDragOut", function(_, item)
@@ -2424,6 +2926,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Log item function usage for analytics.
             hook.Add("ItemFunctionCalled", "TrackItemUse", function(item, action, client, entity, result)
@@ -2441,6 +2947,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Notify the player about the transfer result.
             hook.Add("ItemTransfered", "NotifyTransfer", function(context)
@@ -2462,6 +2972,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Notify the player when they gain a temporary bonus.
             hook.Add("OnCharAttribBoosted", "BoostNotice", function(client, char, key, id, amount)
@@ -2482,6 +2996,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Print the changed attribute on the local player's HUD.
             hook.Add("OnCharAttribUpdated", "PrintAttribChange", function(client, char, key, value)
@@ -2503,6 +3021,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Apply a stun effect when knocked down.
             hook.Add("OnCharFallover", "ApplyStun", function(client, _, forced)
@@ -2521,6 +3043,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Record the kick reason.
             hook.Add("OnCharKick", "LogKickReason", function(char, client)
@@ -2539,6 +3065,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Announce permadeath in chat.
             hook.Add('OnCharPermakilled', 'AnnouncePK', function(char, time)
@@ -2556,6 +3086,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Play a sound whenever someone becomes recognized.
             hook.Add('OnCharRecognized', 'PlayRecognizeSound', function(client)
@@ -2579,6 +3113,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Log vendor transactions to the console.
             hook.Add('OnCharTradeVendor', 'LogVendorTrade', function(client, vendor, item, selling)
@@ -2598,6 +3136,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Tint death ragdolls red.
             hook.Add('OnCreatePlayerRagdoll', 'RedRagdoll', function(client, ent, dead)
@@ -2617,6 +3159,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Add a custom tab to storage windows.
             hook.Add('OnCreateStoragePanel', 'AddSortTab', function(localPanel, storagePanel, storage)
@@ -2635,6 +3181,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Play a sound when ammo is picked up.
             hook.Add('OnItemAdded', 'AmmoPickupSound', function(ply, item)
@@ -2655,6 +3205,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Set custom data on freshly made items.
             hook.Add('OnItemCreated', 'InitCustomData', function(item)
@@ -2672,6 +3226,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Play a sound when rare items appear.
             hook.Add('OnItemSpawned', 'RareSpawnSound', function(itemEnt)
@@ -2690,6 +3248,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Automatically switch to the buy tab.
             hook.Add('OnOpenVendorMenu', 'DefaultBuyTab', function(panel, vendor)
@@ -2708,6 +3270,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Reward an achievement for looting money.
             hook.Add('OnPickupMoney', 'MoneyAchievement', function(client, ent)
@@ -2729,6 +3295,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Freeze the player during the sequence.
             hook.Add('OnPlayerEnterSequence', 'FreezeDuringSeq', function(client, seq, callback, time, noFreeze)
@@ -2750,6 +3320,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Send analytics for item usage.
             hook.Add('OnPlayerInteractItem', 'Analytics', function(client, action, item, result, data)
@@ -2769,6 +3343,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Give class specific weapons.
             hook.Add('OnPlayerJoinClass', 'ClassWeapons', function(client, class, oldClass)
@@ -2786,6 +3364,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Unfreeze the player after the sequence.
             hook.Add('OnPlayerLeaveSequence', 'UnfreezeAfterSeq', function(client)
@@ -2803,6 +3385,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Warn players when their ammo stack disappears.
             hook.Add('OnPlayerLostStackItem', 'WarnLostAmmo', function(item)
@@ -2822,6 +3408,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Prevent switching while in combat.
             hook.Add('OnPlayerSwitchClass', 'NoCombatSwap', function(client, class, oldClass)
@@ -2843,6 +3433,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Validate transfers before sending to the server.
             hook.Add('OnRequestItemTransfer', 'ValidateTransfer', function(panel, itemID, invID, x, y)
@@ -2860,6 +3454,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Verify entities when the map reloads.
             hook.Add('PersistenceLoad', 'CheckPersistent', function(name)
@@ -2878,6 +3476,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Track how often players browse vendors.
             hook.Add('PlayerAccessVendor', 'VendorAnalytics', function(client, vendor)
@@ -2895,6 +3497,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Print the player's stamina amount whenever it increases.
             hook.Add('PlayerStaminaGained', 'PrintStaminaGain', function(client)
@@ -2914,6 +3520,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Play a sound when the player runs out of stamina.
             hook.Add('PlayerStaminaLost', 'TiredSound', function(client)
@@ -2934,6 +3544,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Play a custom sound on punch.
             hook.Add('PlayerThrowPunch', 'PunchSound', function(client, trace)
@@ -2952,6 +3566,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Draw a watermark over the inventory.
             hook.Add('PostDrawInventory', 'InventoryWatermark', function(panel)
@@ -2971,6 +3589,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Deny using keys on locked chests.
             hook.Add('PrePlayerInteractItem', 'BlockChestKeys', function(client, action, item)
@@ -2988,6 +3610,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Only the bag owner may open it.
             hook.Add('SetupBagInventoryAccessRules', 'OwnerOnlyBags', function(inv)
@@ -3000,8 +3626,15 @@
         Description:
             Runs before the gamemode initializes its database connection.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Register additional tables.
             hook.Add('SetupDatabase', 'AddExtraTables', function()
@@ -3021,6 +3654,10 @@
 
         Realm:
             Server
+
+        Returns:
+            boolean – False to disallow transfer
+
         Example Usage:
             -- Prevent weapons from being stored in car trunks.
             hook.Add('StorageCanTransferItem', 'NoWeaponsInCars', function(client, storage, item)
@@ -3039,6 +3676,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Drop items when a crate is destroyed.
             hook.Add('StorageEntityRemoved', 'DropContents', function(entity, inv)
@@ -3058,6 +3699,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             -- Send a notification when storage is initialized.
             hook.Add('StorageInventorySet', 'NotifyStorage', function(entity, inv, isCar)
@@ -3076,6 +3721,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Display storage name in the chat.
             hook.Add('StorageOpen', 'AnnounceStorage', function(entity, isCar)
@@ -3094,6 +3743,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Log how many items were restored.
             hook.Add('StorageRestored', 'PrintRestore', function(storage, inv)
@@ -3111,6 +3764,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Auto-fill a remembered password.
             hook.Add('StorageUnlockPrompt', 'AutoFill', function(entity)
@@ -3123,8 +3780,15 @@
         Description:
             Called when a vendor's allowed classes are updated.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- React to class access changes.
             hook.Add("VendorClassUpdated", "LogVendorClassChange", function(vendor, id, allowed)
@@ -3137,8 +3801,15 @@
         Description:
             Called after a delay when a vendor's data is edited.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Log which key changed.
             hook.Add("VendorEdited", "PrintVendorEdit", function(vendor, key)
@@ -3151,8 +3822,15 @@
         Description:
             Called when a player exits from interacting with a vendor.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Notify the player when they leave a vendor.
             hook.Add("VendorExited", "PrintVendorExit", function()
@@ -3165,8 +3843,15 @@
         Description:
             Called when a vendor's allowed factions are updated.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print updated faction permissions.
             hook.Add("VendorFactionUpdated", "LogVendorFactionUpdate", function(vendor, id, allowed)
@@ -3179,8 +3864,15 @@
         Description:
             Called when a vendor's item max stock value changes.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Log stock limit changes.
             hook.Add("VendorItemMaxStockUpdated", "LogVendorStockLimits", function(vendor, itemType, value)
@@ -3193,8 +3885,15 @@
         Description:
             Called when a vendor's item mode is changed.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print the new mode value.
             hook.Add("VendorItemModeUpdated", "PrintVendorMode", function(vendor, itemType, value)
@@ -3207,8 +3906,15 @@
         Description:
             Called when a vendor's item price is changed.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print the new item price.
             hook.Add("VendorItemPriceUpdated", "LogVendorItemPrice", function(vendor, itemType, value)
@@ -3221,8 +3927,15 @@
         Description:
             Called when a vendor's item stock value changes.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Log remaining stock for the item.
             hook.Add("VendorItemStockUpdated", "LogVendorItemStock", function(vendor, itemType, value)
@@ -3235,8 +3948,15 @@
         Description:
             Called when a vendor's available money changes.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print the vendor's new money amount.
             hook.Add("VendorMoneyUpdated", "LogVendorMoney", function(vendor, money, oldMoney)
@@ -3249,8 +3969,15 @@
         Description:
             Called when a vendor menu is opened on the client.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print which vendor was opened.
             hook.Add("VendorOpened", "PrintVendorOpened", function(vendor)
@@ -3263,8 +3990,15 @@
         Description:
             Called when vendor synchronization data is received.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Print a message when vendor data syncs.
             hook.Add("VendorSynchronized", "LogVendorSync", function(vendor)
@@ -3277,8 +4011,15 @@
         Description:
             Called when a player attempts to trade with a vendor.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             -- Log all vendor trades to the console.
             hook.Add("VendorTradeEvent", "LogVendorTrades", function(client, entity, uniqueID, isSellingToVendor)
@@ -3292,11 +4033,15 @@
         Description:
             Returns an alternate model path for a dropped item.
 
+        Parameters:
+            None
+
         Realm:
             Server
 
         Returns:
             string|nil – Alternate model path or nil for default.
+
         Example Usage:
             -- Replace drop model for weapons.
             hook.Add("getItemDropModel", "CustomDropModelForWeapons", function(itemTable, entity)
@@ -3311,11 +4056,15 @@
         Description:
             Allows modules to override a vendor item's price dynamically.
 
+        Parameters:
+            None
+
         Realm:
             Shared
 
         Returns:
             integer|nil – New price or nil for default.
+
         Example Usage:
             -- Increase price for rare items when buying from the vendor.
             hook.Add("getPriceOverride", "DynamicPricing", function(vendor, uniqueID, price, isSellingToVendor)
@@ -3334,11 +4083,15 @@
         Description:
             Checks if a character is fake recognized rather than truly known.
 
+        Parameters:
+            None
+
         Realm:
             Shared
 
         Returns:
             boolean
+
         Example Usage:
             -- Flag suspicious characters as fake.
             hook.Add("isCharFakeRecognized", "DetectFakeCharacters", function(character, id)
@@ -3353,11 +4106,15 @@
         Description:
             Determines whether one character recognizes another.
 
+        Parameters:
+            None
+
         Realm:
             Shared
 
         Returns:
             boolean
+
         Example Usage:
             -- Only recognize characters from the same faction.
             hook.Add("isCharRecognized", "ValidateCharacterRecognition", function(character, id)
@@ -3370,11 +4127,15 @@
         Description:
             Determines if a chat type counts toward recognition.
 
+        Parameters:
+            None
+
         Realm:
             Shared
 
         Returns:
             boolean
+
         Example Usage:
             -- Mark admin chat as recognized to reveal player names.
             hook.Add("isRecognizedChatType", "ValidateRecognitionChat", function(chatType)
@@ -3388,11 +4149,15 @@
         Description:
             Determines whether an entity can be used as trunk storage.
 
+        Parameters:
+            None
+
         Realm:
             Shared
 
         Returns:
             boolean
+
         Example Usage:
             -- Only vehicles are valid trunk containers.
             hook.Add("isSuitableForTrunk", "AllowOnlyCars", function(entity)
@@ -3415,6 +4180,7 @@
 
         Returns:
             bool
+
         Example Usage:
             hook.Add("CanPlayerEarnSalary", "RestrictSalaryToActivePlayers", function(client, faction, class)
                 if not client:isActive() then
@@ -3439,6 +4205,7 @@
 
         Returns:
             bool|nil: false to block, nil to allow.
+
         Example Usage:
             hook.Add("CanPlayerJoinClass", "RestrictEliteClass", function(client, class, info)
                 if class == CLASS_ELITE and not client:hasPermission("join_elite") then
@@ -3461,6 +4228,7 @@
 
         Returns:
             bool|nil: false to block, nil to allow.
+
         Example Usage:
             hook.Add("CanPlayerUseCommand", "BlockSensitiveCommands", function(client, command)
                 local blockedCommands = {"shutdown", "restart"}
@@ -3485,6 +4253,7 @@
 
         Returns:
             bool: false to block, nil or true to allow.
+
         Example Usage:
             hook.Add("CanPlayerUseDoor", "AllowOnlyOwners", function(client, door, access)
                 if access == DOOR_LOCK and door:getOwner() ~= client then
@@ -3504,6 +4273,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharCleanUp", "RemoveTemporaryItems", function(character)
                 local inventory = character:getInv()
@@ -3521,8 +4294,15 @@
         Description:
             Called after a character has been restored from the database. Useful for post-restoration logic such as awarding default items or setting up data.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharRestored", "AwardWelcomePackage", function(character)
                 local welcomePackage = {"welcome_pack", "starter_weapon", "basic_armor"}
@@ -3538,8 +4318,15 @@
         Description:
             Called when creating a default inventory for a character. Should return a [deferred](https://github.com/Be1zebub/luassert-deferred) (or similar promise) object that resolves with the new inventory.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CreateDefaultInventory", "InitializeStarterInventory", function(character)
                 local d = deferred.new()
@@ -3570,6 +4357,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CreateInventoryPanel", "CustomInventoryUI", function(inventory, parent)
                 local panel = vgui.Create("DPanel", parent)
@@ -3605,6 +4396,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CreateSalaryTimer", "SetupSalaryTimer", function(client)
                 timer.Create("SalaryTimer_" .. client:SteamID(), 60, 0, function()
@@ -3630,6 +4425,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("DoModuleIncludes", "TrackModuleDependencies", function(path, module)
                 print("Including submodule from path:", path)
@@ -3653,6 +4452,7 @@
         Returns:
             string: The default description.
             bool: Whether to override.
+
         Example Usage:
             hook.Add("GetDefaultCharDesc", "CitizenDefaultDesc", function(client, faction)
                 if faction == FACTION_CITIZEN then
@@ -3677,6 +4477,7 @@
         Returns:
             string: The default name.
             bool: Whether to override the user-provided name.
+
         Example Usage:
             hook.Add("GetDefaultCharName", "PoliceDefaultName", function(client, faction, data)
                 if faction == FACTION_POLICE then
@@ -3700,6 +4501,7 @@
 
         Returns:
             any: The salary amount
+
         Example Usage:
             hook.Add("GetSalaryAmount", "CalculateDynamicSalary", function(client, faction, class)
                 local baseSalary = faction.baseSalary or 1000
@@ -3723,6 +4525,7 @@
 
         Returns:
             any: The salary limit
+
         Example Usage:
             hook.Add("GetSalaryLimit", "SetSalaryLimitsBasedOnRole", function(client, faction, class)
                 if faction.name == "Police" then
@@ -3738,8 +4541,15 @@
         Description:
             Called when `lia.config` is fully initialized.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             function MODULE:InitializedConfig()
                 if lia.config.enableSpecialFeatures then
@@ -3756,8 +4566,15 @@
         Description:
             Called once all item modules have been loaded from a directory.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InitializedItems", "SetupSpecialItems", function()
                 local specialItem = lia.item.create({
@@ -3778,8 +4595,15 @@
         Description:
             Called after all modules are fully initialized.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InitializedModules", "FinalizeModuleSetup", function()
                 lia.modules.finalizeSetup()
@@ -3792,8 +4616,15 @@
         Description:
             Called when `lia.option` is fully initialized.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             function MODULE:InitializedOptions()
                LocalPlayer():ChatPrint("LOADED OPTIONS!")
@@ -3805,8 +4636,15 @@
         Description:
             Called after the schema has finished initializing.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InitializedSchema", "SchemaReadyNotification", function()
                 print("Schema has been successfully initialized.")
@@ -3826,6 +4664,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("KeyLock", "LogDoorLock", function(owner, entity, time)
                 entity:setLocked(true)
@@ -3846,6 +4688,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("KeyUnlock", "LogDoorUnlock", function(owner, entity, time)
                 entity:setLocked(false)
@@ -3859,8 +4705,15 @@
         Description:
             Called after all essential DB tables have been loaded.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("LiliaTablesLoaded", "InitializeGameState", function()
                 lia.gameState = lia.gameState or {}
@@ -3879,6 +4732,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnItemRegistered", "AddItemDurability", function(item)
                 if item.uniqueID == "sword_basic" then
@@ -3900,8 +4757,15 @@
         Description:
             Called before the faction tables are loaded. Good spot for data setup prior to factions being processed.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnLoadTables", "SetupFactionDefaults", function()
                 lia.factions = lia.factions or {}
@@ -3915,8 +4779,15 @@
         Description:
             Called when MySQLOO successfully connects to the database. Use to register prepared statements or init DB logic.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnMySQLOOConnected", "PrepareDatabaseStatements", function()
                 lia.db.prepare("insertPlayer", "INSERT INTO lia_players (_steamID, _steamName) VALUES (?, ?)", {MYSQLOO_STRING, MYSQLOO_STRING})
@@ -3938,6 +4809,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnPlayerPurchaseDoor", "HandleDoorPurchase", function(client, entity, buying, CallOnDoorChild)
                 if buying then
@@ -3967,6 +4842,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnServerLog", "AlertAdminsOnHighSeverity", function(client, logType, logString, category, color)
                 if category == "error" then
@@ -3984,8 +4863,15 @@
         Description:
             Called after wiping tables in the DB, typically after major resets/cleanups.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnWipeTables", "ReinitializeDefaults", function()
                 lia.db.execute("INSERT INTO lia_factions (name, description) VALUES ('Citizen', 'Regular inhabitants.')")
@@ -4010,6 +4896,7 @@
 
         Returns:
             bool|nil|modifiedString: false to cancel, or return a modified string to change the message.
+
         Example Usage:
             hook.Add("PlayerMessageSend", "FilterProfanity", function(speaker, chatType, message, anonymous)
                 local filteredMessage = string.gsub(message, "badword", "****")
@@ -4030,6 +4917,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PlayerModelChanged", "UpdatePlayerAppearance", function(client, model)
                 print(client:Name() .. " changed their model to " .. model)
@@ -4052,6 +4943,7 @@
 
         Returns:
             bool|nil: false to disallow, true to allow, or nil to let other hooks decide.
+
         Example Usage:
             hook.Add("PlayerUseDoor", "LogDoorUsage", function(client, entity)
                 print(client:Name() .. " is attempting to use door ID:", entity:EntIndex())
@@ -4067,8 +4959,15 @@
         Description:
             Called for registering DB prepared statements post-MySQLOO connection.
 
+        Parameters:
+            None
+
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
 ]]
 --[[
@@ -4085,6 +4984,7 @@
 
         Returns:
             bool|nil: false to hide, nil to allow.
+
         Example Usage:
             hook.Add("ShouldBarDraw", "HideArmorHUD", function(barName)
                 if barName == "armor" then
@@ -4106,6 +5006,7 @@
 
         Returns:
             bool (true if 3rd-person should be disabled)
+
         Example Usage:
             hook.Add("ShouldDisableThirdperson", "DisableForInvisibles", function(client)
                 if client:isInvisible() then
@@ -4119,11 +5020,15 @@
         Description:
             Determines whether all HUD bars should be hidden.
 
+        Parameters:
+            None
+
         Realm:
             Client
 
         Returns:
             bool|nil: true to hide, nil to allow rendering.
+
         Example Usage:
             hook.Add("ShouldHideBars", "HideHUDInCinematic", function()
                 if gui.IsInCinematicMode() then
@@ -4142,6 +5047,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("thirdPersonToggled", "NotifyThirdPersonChange", function(state)
                 if state then
@@ -4167,6 +5076,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Change the money field label.
             hook.Add("AddTextField", "RenameMoneyField", function(section, name, label, value)
@@ -4189,6 +5102,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             -- Log newly added fields.
             hook.Add("F1OnAddTextField", "LogFields", function(section, name)
@@ -4211,6 +5128,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("F1OnAddBarField", "TrackBars", function(section, name)
                 print("Added bar", name)
@@ -4227,6 +5148,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CreateInformationButtons", "AddHelpPage", function(pages)
                 table.insert(pages, {name = "Help", drawFunc = function(parent) end})
@@ -4243,6 +5168,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PopulateConfigurationButtons", "AddControlsPage", function(pages)
                 table.insert(pages, {name = "Controls", drawFunc = function(p) end})
@@ -4254,8 +5183,15 @@
         Description:
             Called after keybinds have been loaded from disk.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("InitializedKeybinds", "NotifyKeybinds", function()
                 chat.AddText("Keybinds loaded")
@@ -4272,8 +5208,10 @@
 
         Realm:
             Server
+
         Returns:
             number|nil – Custom cooldown in seconds.
+
         Example Usage:
             hook.Add("getOOCDelay", "AdminOOC", function(ply)
                 if ply:IsAdmin() then
@@ -4296,8 +5234,10 @@
 
         Realm:
             Client
+
         Returns:
             string|nil – Replacement text.
+
         Example Usage:
             hook.Add("OnChatReceived", "CensorChat", function(ply, type, msg)
                 return msg:gsub("badword", "****")
@@ -4315,8 +5255,10 @@
 
         Realm:
             Client
+
         Returns:
             table|nil – Adjusted part data.
+
         Example Usage:
             hook.Add("getAdjustedPartData", "DebugParts", function(ply, partID)
                 print("Requesting part", partID)
@@ -4335,8 +5277,10 @@
 
         Realm:
             Client
+
         Returns:
             table|nil – Modified data table.
+
         Example Usage:
             hook.Add("AdjustPACPartData", "ColorParts", function(ply, partID, d)
                 d.Color = Vector(1,0,0)
@@ -4355,6 +5299,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("attachPart", "AnnouncePart", function(ply, partID)
                 print(ply, "received part", partID)
@@ -4372,6 +5320,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("removePart", "LogPartRemoval", function(ply, partID)
                 print(partID, "removed from", ply)
@@ -4388,6 +5340,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnPAC3PartTransfered", "TrackTransfers", function(p)
                 print("Part transferred", p)
@@ -4404,6 +5360,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("DrawPlayerRagdoll", "TintRagdoll", function(ent)
                 render.SetColorModulation(1,0,0)
@@ -4415,8 +5375,15 @@
         Description:
             Initializes PAC3 outfits from equipped items after modules load.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("setupPACDataFromItems", "InitPAC", function()
                 print("Equipped PAC data loaded")
@@ -4433,8 +5400,10 @@
 
         Realm:
             Client
+
         Returns:
             Entity – Replacement entity.
+
         Example Usage:
             hook.Add("TryViewModel", "UsePlayerViewModel", function(ent)
                 return ent == LocalPlayer():GetViewModel() and LocalPlayer() or ent
@@ -4446,11 +5415,16 @@
         Description:
             Lets modules provide a custom sound when cycling weapons in the selector.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
         Returns:
             string|nil – Sound path.
             number|nil – Playback pitch.
+
         Example Usage:
             hook.Add("WeaponCycleSound", "SilentCycle", function()
                 return "buttons/button15.wav", 100
@@ -4462,11 +5436,16 @@
         Description:
             Similar to WeaponCycleSound but used when confirming a weapon choice.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
         Returns:
             string|nil – Sound path.
             number|nil – Playback pitch.
+
         Example Usage:
             hook.Add("WeaponSelectSound", "CustomSelectSound", function()
                 return "buttons/button24.wav", 90
@@ -4483,8 +5462,10 @@
 
         Realm:
             Client
+
         Returns:
             boolean
+
         Example Usage:
             hook.Add("ShouldDrawWepSelect", "HideInVehicles", function(ply)
                 return not ply:InVehicle()
@@ -4501,8 +5482,10 @@
 
         Realm:
             Client
+
         Returns:
             boolean|nil – false to block selection.
+
         Example Usage:
             hook.Add("CanPlayerChooseWeapon", "BlockPhysgun", function(wep)
                 if IsValid(wep) and wep:GetClass() == "weapon_physgun" then
@@ -4522,8 +5505,10 @@
 
         Realm:
             Client
+
         Returns:
             number|nil – New respawn time.
+
         Example Usage:
             hook.Add("OverrideSpawnTime", "ShortRespawns", function(ply, time)
                 if ply:IsAdmin() then return 2 end
@@ -4535,10 +5520,15 @@
         Description:
             Lets modules suppress the respawn HUD from showing.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
         Returns:
             boolean|nil – false to hide.
+
         Example Usage:
             hook.Add("ShouldRespawnScreenAppear", "NoRespawnHUD", function()
                 return false
@@ -4555,6 +5545,10 @@
 
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("VoiceToggled", "AnnounceVoice", function(state)
                 print("Voice chat set to", state)
@@ -4566,8 +5560,15 @@
         Description:
             Requests recreation of all registered UI fonts.
 
+        Parameters:
+            None
+
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("RefreshFonts", "ReloadFonts", function()
                 print("Fonts refreshed")
@@ -4587,6 +5588,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("AdjustCreationData", "EnforceName", function(ply, data, newData)
                 if data.name == "" then newData.name = "Unnamed" end
@@ -4605,8 +5610,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to block.
+
         Example Usage:
             hook.Add("CanCharBeTransfered", "BlockRestrictedFactions", function(char, faction)
                 if faction.isRestricted then return false end
@@ -4624,8 +5631,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to deny.
+
         Example Usage:
             hook.Add("CanPlayerUseChar", "CheckBans", function(ply, char)
                 if char:isBanned() then return false, "Character banned" end
@@ -4644,8 +5653,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to block the switch.
+
         Example Usage:
             hook.Add("CanPlayerSwitchChar", "NoSwitchInCombat", function(ply)
                 if ply:isInCombat() then return false end
@@ -4663,8 +5674,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to disallow.
+
         Example Usage:
             hook.Add("CanPlayerLock", "AdminsAlwaysLock", function(ply)
                 if ply:IsAdmin() then return true end
@@ -4682,8 +5695,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to disallow.
+
         Example Usage:
             hook.Add("CanPlayerUnlock", "AdminsAlwaysUnlock", function(ply)
                 if ply:IsAdmin() then return true end
@@ -4701,8 +5716,10 @@
 
         Realm:
             Server
+
         Returns:
             bool|nil – false to deny modification.
+
         Example Usage:
             hook.Add("CanPlayerModifyConfig", "RestrictConfig", function(ply, k)
                 return ply:IsSuperAdmin()
@@ -4720,6 +5737,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("CharDeleted", "LogDeletion", function(ply, char)
                 print(ply:Name(), "deleted character", char:getName())
@@ -4738,8 +5759,10 @@
 
         Realm:
             Shared
+
         Returns:
             boolean
+
         Example Usage:
             hook.Add("CheckFactionLimitReached", "IgnoreAdmins", function(faction, char, ply)
                 if ply:IsAdmin() then
@@ -4761,6 +5784,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("F1OnAddSection", "PrintSection", function(name)
                 print("Added section", name)
@@ -4777,8 +5804,10 @@
 
         Realm:
             Client
+
         Returns:
             string|nil – Replacement name.
+
         Example Usage:
             hook.Add("GetWeaponName", "UppercaseName", function(wep)
                 return wep:GetClass():upper()
@@ -4796,6 +5825,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnCharGetup", "NotifyGetup", function(ply)
                 ply:ChatPrint("You stood up")
@@ -4807,8 +5840,15 @@
         Description:
             Fired once language files finish loading.
 
+        Parameters:
+            None
+
         Realm:
             Shared
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnLocalizationLoaded", "PrintLang", function()
                 print("Localization ready")
@@ -4826,6 +5866,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("OnPlayerObserve", "AnnounceObserve", function(ply, s)
                 print(ply, s and "entered" or "left", "observe mode")
@@ -4844,6 +5888,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PlayerLoadedChar", "WelcomeBack", function(ply, char)
                 ply:ChatPrint("Welcome, " .. char:getName())
@@ -4862,6 +5910,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PrePlayerLoadedChar", "SaveStuff", function(ply, new, old)
                 print("Switching characters")
@@ -4880,6 +5932,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PostPlayerLoadedChar", "GiveItems", function(ply, char)
                 -- Give starter items here
@@ -4897,6 +5953,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PlayerSay", "LogChat", function(ply, msg)
                 print(ply:Name() .. ": " .. msg)
@@ -4914,6 +5974,10 @@
 
         Realm:
             Client
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("PopulateAdminStick", "AddCustomOption", function(menu, ent)
                 menu:AddOption("Wave", function() RunConsoleCommand("act", "wave") end)
@@ -4931,6 +5995,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("TicketSystemClaim", "NotifyClaim", function(staff, ply)
                 staff:ChatPrint("Claimed ticket from " .. ply:Name())
@@ -4949,6 +6017,10 @@
 
         Realm:
             Server
+
+        Returns:
+            None
+
         Example Usage:
             hook.Add("liaOptionReceived", "PrintOptionChange", function(_, k, v)
                 print("Option", k, "set to", v)


### PR DESCRIPTION
## Summary
- clarify returns for several hook docs
- ensure newline at end of hook docs
- fix formatting for storage transfer section
- add blank line between each documentation field

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685e280c56188327baa531253c7343d3