### PR TITLE
Fix module path description

### DIFF
--- a/docs/lua/definitions/module_fields.lua
+++ b/docs/lua/definitions/module_fields.lua
@@ -156,7 +156,7 @@
     path
 
     Description:
-        Absolute path to the module's root directory.
+        Path to the module's root directory used when including files.
 
     Type:
         string


### PR DESCRIPTION
## Summary
- adjust description for `MODULE.path` to clarify that it references the directory used for includes

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2c571cdc8327af60388399bca9d3