### PR TITLE
Fix meta documentation fields

### DIFF
--- a/docs/lua/meta/inventory.lua
+++ b/docs/lua/meta/inventory.lua
@@ -310,8 +310,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Insert a new item without sending it to clients
         local result = inv:addItem(item, noReplicate)
     ]]
 --[[
@@ -326,8 +329,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Remove an item and keep it saved if preserveItem is true
         local result = inv:removeItem(itemID, preserveItem)
     ]]
 --[[
@@ -342,8 +348,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Replicate a single field to the given players
         local result = inv:syncData(key, recipients)
     ]]
 --[[
@@ -357,8 +366,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Send the entire inventory to specified players
         local result = inv:sync(recipients)
     ]]
 --[[
@@ -372,8 +384,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Remove the inventory permanently from the database
         local result = inv:delete()
     ]]
 --[[
@@ -387,7 +402,10 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Completely clear the inventory and its items
         local result = inv:destroy()
     ]]

--- a/docs/lua/meta/item.lua
+++ b/docs/lua/meta/item.lua
@@ -213,8 +213,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Register a function to run when the hook triggers
         local result = item:hook(name, func)
 ]]
 --[[
@@ -229,8 +232,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Run code after the base hook executes
         local result = item:postHook(name, func)
 ]]
 --[[
@@ -244,8 +250,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Called when this item type is first added
         local result = item:onRegistered()
 ]]
 --[[
@@ -259,8 +268,11 @@
 
     Realm:
         Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Debug print the item information
         local result = item:print(detail)
 ]]
 --[[
@@ -274,8 +286,11 @@
 
     Realm:
         Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Output every piece of stored item data
         local result = item:printData()
 ]]
 --[[
@@ -291,8 +306,11 @@
 
         Realm:
             Server
+        Returns:
+            nil – This function does not return a value.
 
     Example Usage:
+        -- Increase the stack count and sync to players
         local result = item:addQuantity(quantity, receivers, noCheckEntity)
     ]]
 --[[
@@ -308,7 +326,10 @@
 
         Realm:
             Server
+        Returns:
+            nil – This function does not return a value.
 
     Example Usage:
+        -- Force the stack to a specific amount
         local result = item:setQuantity(quantity, receivers, noCheckEntity)
     ]]

--- a/docs/lua/meta/panel.lua
+++ b/docs/lua/meta/panel.lua
@@ -16,6 +16,7 @@
         any – Whatever the wrapped Panel function returns.
 
     Example Usage:
+        -- This creates a simple frame positioned using screen scaling
         local frame = vgui.Create("DFrame")
         frame:SetSize(200, 100)
         frame:SetPos(25, 25)

--- a/docs/lua/meta/player.lua
+++ b/docs/lua/meta/player.lua
@@ -189,9 +189,12 @@
 
     Realm:
         Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
-        local result = player:notify(message)
+        -- Send a chat notification to the player
+        local result = player:notify("Welcome to the server!")
 ]]
 --[[
     notifyLocalized(message, ...)
@@ -205,9 +208,12 @@
 
     Realm:
         Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
-        local result = player:notifyLocalized(message, ...)
+        -- Send a localized message to the player
+        local result = player:notifyLocalized("greeting_key", player:Name())
 ]]
 --[[
     CanEditVendor(vendor)
@@ -530,8 +536,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Stop the player's forced animation sequence
         local result = player:leaveSequence()
 ]]
 --[[
@@ -545,8 +554,11 @@
 
         Realm:
             Server
+        Returns:
+            nil – This function does not return a value.
 
     Example Usage:
+        -- Give the player extra stamina points
         local result = player:restoreStamina(amount)
     ]]
 --[[
@@ -560,8 +572,11 @@
 
         Realm:
             Server
+        Returns:
+            nil – This function does not return a value.
 
     Example Usage:
+        -- Spend stamina as the player performs an action
         local result = player:consumeStamina(amount)
     ]]
 --[[
@@ -575,8 +590,11 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Give the player additional money
         local result = player:addMoney(amount)
     ]]
 --[[
@@ -590,7 +608,10 @@
 
         Realm:
             Server
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Remove money from the player's character
         local result = player:takeMoney(amount)
     ]]

--- a/docs/lua/meta/tool.lua
+++ b/docs/lua/meta/tool.lua
@@ -133,8 +133,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Prepare the tool for use
         local result = tool:Init()
 ]]
 --[[
@@ -225,6 +228,7 @@
         boolean – False by default.
 
     Example Usage:
+        -- Attempt the primary tool action
         local result = tool:LeftClick()
 ]]
 --[[
@@ -243,6 +247,7 @@
         boolean – False by default.
 
     Example Usage:
+        -- Attempt the secondary tool action
         local result = tool:RightClick()
 ]]
 --[[
@@ -256,8 +261,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Clear saved objects when reloading the tool
         local result = tool:Reload()
 ]]
 --[[
@@ -271,8 +279,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Equip the tool and spawn its ghost entity
         local result = tool:Deploy()
 ]]
 --[[
@@ -286,8 +297,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Unequip the tool and remove its ghost entity
         local result = tool:Holster()
 ]]
 --[[
@@ -301,8 +315,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Run per-tick logic for the active tool
         local result = tool:Think()
 ]]
 --[[
@@ -316,8 +333,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Validate all stored objects each tick
         local result = tool:CheckObjects()
 ]]
 --[[
@@ -331,8 +351,11 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Remove any objects the tool is storing
         local result = tool:ClearObjects()
 ]]
 --[[
@@ -346,7 +369,10 @@
 
     Realm:
         Shared
+    Returns:
+        nil – This function does not return a value.
 
     Example Usage:
+        -- Remove the placement preview entity
         local result = tool:ReleaseGhostEntity()
 ]]


### PR DESCRIPTION
## Summary
- ensure meta documentation comments include `Returns` sections
- add explanatory comments to example usages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e300390788327acfe0ad0416960cf