### PR TITLE
Fix missing docs sections for time library

### DIFF
--- a/docs/lua/libraries/bars.lua
+++ b/docs/lua/libraries/bars.lua
@@ -14,8 +14,11 @@
         table or nil – The bar table if found, or nil if not found.
 
     Example Usage:
-        -- This snippet demonstrates a common usage of lia.bar.get
+        -- Retrieve the health bar and change its color at runtime
         local bar = lia.bar.get("health")
+        if bar then
+            bar.color = Color(0, 200, 0) -- make the bar green
+        end
 ]]
 
 --[[

--- a/docs/lua/libraries/chatbox.lua
+++ b/docs/lua/libraries/chatbox.lua
@@ -57,8 +57,13 @@
         Shared
 
     Example Usage:
-        -- This snippet demonstrates a common usage of lia.chat.parse
-        local class, text = lia.chat.parse(client, "/me waves")
+        -- Parse chat messages and log "/me" actions to the console
+        hook.Add("PlayerSay", "LogActions", function(ply, text)
+            local class, parsed = lia.chat.parse(ply, text)
+            if class == "me" then
+                print(ply:Name() .. " performs action: " .. parsed)
+            end
+        end)
 ]]
 
 --[[

--- a/docs/lua/libraries/data.lua
+++ b/docs/lua/libraries/data.lua
@@ -19,8 +19,12 @@
         Shared
     
     Example Usage:
-        -- This snippet demonstrates a common usage of lia.data.set
-        lia.data.set("spawn_pos", Vector(0, 0, 0))
+        -- Save the admin's position as the global spawn point with a command
+        concommand.Add("save_spawn", function(ply)
+            if ply:IsAdmin() then
+                lia.data.set("spawn_pos", ply:GetPos(), true)
+            end
+        end)
    ]]
 
     --[[
@@ -68,6 +72,11 @@
         Shared
 
     Example Usage:
-        -- This snippet demonstrates a common usage of lia.data.get
-        local pos = lia.data.get("spawn_pos", Vector(0, 0, 0))
+        -- Teleport players to the saved spawn point when they spawn
+        hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
+            local pos = lia.data.get("spawn_pos", Vector(0, 0, 0), true)
+            if pos then
+                ply:SetPos(pos)
+            end
+        end)
 ]]

--- a/docs/lua/libraries/networking.lua
+++ b/docs/lua/libraries/networking.lua
@@ -17,8 +17,10 @@
         nil
 
     Example Usage:
-        -- This snippet demonstrates a common usage of setNetVar
-        setNetVar("round", 1)
+        -- Start a new round and notify clients of the round number
+        local round = getNetVar("round", 0) + 1
+        setNetVar("round", round)
+        hook.Run("RoundStarted", round)
 ]]
 
 --[[
@@ -38,7 +40,10 @@
         any – Stored value or default.
 
     Example Usage:
-        -- This snippet demonstrates a common usage of getNetVar
-        local round = getNetVar("round", 0)
+        -- Inform a joining player of the current round
+        hook.Add("PlayerInitialSpawn", "ShowRound", function(ply)
+            local round = getNetVar("round", 0)
+            ply:ChatPrint("Current round: " .. round)
+        end)
 ]]
 

--- a/docs/lua/libraries/time.lua
+++ b/docs/lua/libraries/time.lua
@@ -13,8 +13,21 @@
        Shared
 
     Example Usage:
-        -- This snippet demonstrates a common usage of print
-       print(lia.time.TimeSince("2025-03-27"))
+        -- Greet players with the time since they last joined using persistence data
+        hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
+            -- Retrieve the time this player last joined from persistent data
+            local key = "lastLogin_" .. ply:SteamID64()
+            local last = lia.data.get(key, nil, true)
+
+            if last then
+                ply:ChatPrint("Welcome back! You last joined " .. lia.time.TimeSince(last) .. ".")
+            else
+                ply:ChatPrint("Welcome for the first time!")
+            end
+
+            -- Store the current time for the next login
+            lia.data.set(key, os.time(), true)
+        end)
  ]]
 
 --[[
@@ -34,10 +47,15 @@
       Shared
 
    Example Usage:
-        -- This snippet demonstrates a common usage of lia.time.toNumber
-      local t = lia.time.toNumber("2025-03-27 14:30:00")
-      print(t.year, t.month, t.day, t.hour, t.min, t.sec)
- ]]
+        -- Schedule an event at a custom date and time using the parsed table
+        local targetInfo = lia.time.toNumber("2025-04-01 12:30:00")
+        local delay = os.time(targetInfo) - os.time()
+        if delay > 0 then
+            timer.Simple(delay, function()
+                print("It's now April 1st, 2025, 12:30 PM!")
+            end)
+        end
+]]
 
 --[[
     lia.time.GetDate
@@ -53,6 +71,18 @@
 
     Returns:
        (string) Formatted date and time string.
+
+    Realm:
+       Shared
+
+    Example Usage:
+        -- Announce the current server date and time to all players every hour
+        timer.Create("ServerTimeAnnounce", 3600, 0, function()
+            local dateString = lia.time.GetDate()
+            for _, ply in ipairs(player.GetAll()) do
+                ply:ChatPrint("Server time: " .. dateString)
+            end
+        end)
  ]]
 
 --[[
@@ -70,4 +100,16 @@
     Returns:
        (string|number) Current hour string with suffix when AmericanTimeStamps
                       is enabled, otherwise numeric hour in 24-hour format.
+
+    Realm:
+       Shared
+
+    Example Usage:
+        -- Toggle an NPC's shop based on the in-game hour
+        local hour = lia.time.GetHour()
+        if hour >= 9 and hour < 17 then
+            npc:SetNWBool("ShopOpen", true)
+        else
+            npc:SetNWBool("ShopOpen", false)
+        end
  ]]


### PR DESCRIPTION
## Summary
- expand `lia.time.TimeSince` example to use `lia.data` for persistence
- showcase modifying bar color in `lia.bar.get` docs
- add action logging example for `lia.chat.parse`
- demonstrate saving and applying spawn position with `lia.data`
- show round variable networking in `setNetVar` and `getNetVar`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3b32f5fc8327961dd6b9add7a684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved example usage in documentation for various libraries, providing more practical and context-rich scenarios for bar manipulation, chat parsing, data storage, networking, and time functions. These updates help illustrate real-world integration and event-driven use cases for end-users. No changes were made to the underlying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->