### PR TITLE
Fix meta docs missing fields and improve examples

### DIFF
--- a/docs/lua/meta/character.lua
+++ b/docs/lua/meta/character.lua
@@ -71,7 +71,7 @@
         Shared
 
     Returns:
-        Player|nil – Owning player or nil.
+        Player|None – Owning player or None.
 
     Example Usage:
         -- Notify the controlling player that the character loaded
@@ -318,7 +318,7 @@
         Shared
 
     Returns:
-        table|nil – Table of boosts or nil.
+        table|None – Table of boosts or None.
 
     Example Usage:
         -- Inspect active boosts on agility

--- a/docs/lua/meta/entity.lua
+++ b/docs/lua/meta/entity.lua
@@ -137,6 +137,9 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
         -- Assign ownership when a player buys the door
         door:keysOwn(buyer)
@@ -153,6 +156,9 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
         -- Lock the vehicle after the driver exits
         car:keysLock()
@@ -168,6 +174,9 @@
 
     Realm:
         Shared
+
+    Returns:
+        None – This function does not return a value.
 
     Example Usage:
         -- Unlock the vehicle when the owner presses a key
@@ -186,7 +195,7 @@
         Shared
 
     Returns:
-        Player|nil – Door owner or nil.
+        Player|None – Door owner or None.
 
     Example Usage:
         -- Print the name of the door owner when inspecting
@@ -292,7 +301,7 @@
         Shared
 
     Returns:
-        Player|nil – Creator player if stored.
+        Player|None – Creator player if stored.
 
     Example Usage:
         -- Credit the creator when the entity is removed
@@ -313,9 +322,12 @@
         Realm:
             Server
 
-    Example Usage:
-        -- Record the spawner for cleanup tracking
-        ent:SetCreator(client)
+        Returns:
+            None – This function does not return a value.
+
+        Example Usage:
+            -- Record the spawner for cleanup tracking
+            ent:SetCreator(client)
     ]]
 --[[
         sendNetVar(key, receiver)
@@ -325,7 +337,7 @@
 
         Parameters:
             key (string) – Identifier of the variable.
-            receiver (Player|nil) – Who to send to.
+            receiver (Player|None) – Who to send to.
 
         Realm:
             Server
@@ -333,8 +345,14 @@
         Internal:
             Used by the networking system.
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
-        local result = ent:sendNetVar(key, receiver)
+        -- Broadcast the "doorState" variable to every connected player
+        for _, ply in ipairs(player.GetAll()) do
+            ent:sendNetVar("doorState", ply)
+        end
     ]]
 --[[
         clearNetVars(receiver)
@@ -343,13 +361,18 @@
             Clears all network variables on this entity.
 
         Parameters:
-            receiver (Player|nil) – Receiver to notify.
+            receiver (Player|None) – Receiver to notify.
 
         Realm:
             Server
 
+        Returns:
+            None – This function does not return a value.
+
     Example Usage:
-        local result = ent:clearNetVars(receiver)
+        -- Force reinitialization by clearing all variables for this receiver
+        ent:clearNetVars(client)
+        ent:sendNetVar("initialized", client)
     ]]
 --[[
         removeDoorAccessData()
@@ -363,7 +386,11 @@
         Realm:
             Server
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
+        -- Wipe door permissions during cleanup
         local result = ent:removeDoorAccessData()
     ]]
 --[[
@@ -378,8 +405,13 @@
         Realm:
             Server
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
-        local result = ent:setLocked(state)
+        -- Toggle the door lock and play a latch sound for everyone
+        door:setLocked(true)
+        door:EmitSound("doors/door_latch3.wav")
     ]]
 --[[
         isDoor()
@@ -397,6 +429,7 @@
             boolean – Whether the entity is a door.
 
     Example Usage:
+        -- Check if the entity behaves like a door
         local result = ent:isDoor()
     ]]
 --[[
@@ -412,10 +445,14 @@
             Server
 
         Returns:
-            Entity|nil – The partnered door.
+            Entity|None – The partnered door.
 
     Example Usage:
-        local result = ent:getDoorPartner()
+        -- Unlock both doors when opening a double-door setup
+        local partner = ent:getDoorPartner()
+        if IsValid(partner) then
+            partner:setLocked(false)
+        end
     ]]
 --[[
         setNetVar(key, value, receiver)
@@ -426,12 +463,16 @@
         Parameters:
             key (string) – Variable name.
             value (any) – Value to store.
-            receiver (Player|nil) – Who to send update to.
+            receiver (Player|None) – Who to send update to.
 
         Realm:
             Server
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
+        -- Store a variable and sync it to players
         local result = ent:setNetVar(key, value, receiver)
     ]]
 --[[
@@ -452,6 +493,7 @@
             any – Stored value or default.
 
     Example Usage:
+        -- Retrieve the stored variable or fallback to the default
         local result = ent:getNetVar(key, default)
     ]]
 --[[
@@ -470,6 +512,7 @@
             boolean – True if entity class contains "door".
 
     Example Usage:
+        -- Determine if this entity's class name contains "door"
         local result = ent:isDoor()
     ]]
 --[[
@@ -485,10 +528,14 @@
             Client
 
         Returns:
-            Entity|nil – The partner door entity.
+            Entity|None – The partner door entity.
 
     Example Usage:
-        local result = ent:getDoorPartner()
+        -- Highlight the partner door of the one being looked at
+        local partner = ent:getDoorPartner()
+        if IsValid(partner) then
+            partner:SetColor(Color(0, 255, 0))
+        end
     ]]
 --[[
         getNetVar(key, default)
@@ -507,5 +554,6 @@
             any – Stored value or default.
 
     Example Usage:
+        -- Access a synced variable on the client side
         local result = ent:getNetVar(key, default)
     ]]

--- a/docs/lua/meta/inventory.lua
+++ b/docs/lua/meta/inventory.lua
@@ -34,8 +34,13 @@
         table – The newly derived inventory table.
 
     Example Usage:
-        -- Define a custom inventory class for weapon crates
+        -- Define a subclass for weapon crates and register it
         local WeaponInv = inv:extend("WeaponInventory")
+        function WeaponInv:configure()
+            self:addSlot("Ammo")
+            self:addSlot("Weapons")
+        end
+        WeaponInv:register("weapon_inv")
 ]]
 --[[
     configure()
@@ -49,9 +54,15 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
         -- Called from a subclass to set up custom slots
-        inv:configure()
+        function WeaponInv:configure()
+            self:addSlot("Ammo")
+            self:addSlot("Weapons")
+        end
 ]]
 --[[
     addDataProxy(key, onChange)
@@ -66,10 +77,14 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
         -- Track changes to the "locked" data field
         inv:addDataProxy("locked", function(old, new)
             print("Locked state changed", old, new)
+            hook.Run("ChestLocked", inv, new)
         end)
 ]]
 --[[
@@ -104,9 +119,13 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
-        -- Register the custom inventory type
+        -- Register and then immediately create the inventory type
         WeaponInv:register("weapon_inv")
+        local chestInv = WeaponInv:new()
 ]]
 --[[
     new()
@@ -124,8 +143,11 @@
         table – New inventory instance.
 
     Example Usage:
-        -- Create an inventory for a spawned chest
-        local chestInv = WeaponInv:new()
+        -- Create an inventory and attach it to a spawned chest entity
+        local chest = ents.Create("prop_physics")
+        chest:SetModel("models/props_junk/wood_crate001a.mdl")
+        chest:Spawn()
+        chest.inv = WeaponInv:new()
 ]]
 --[[
     tostring()
@@ -179,6 +201,9 @@
 
     Realm:
         Shared
+
+    Returns:
+        None – This function does not return a value.
 
     Example Usage:
         -- React when the stored credit amount changes
@@ -237,7 +262,7 @@
         Shared
 
     Returns:
-        Item|nil – The first matching item or nil.
+        Item|None – The first matching item or None.
 
     Example Usage:
         -- Grab the first pistol found in the inventory
@@ -269,7 +294,7 @@
         Counts the total quantity of a specific item type.
 
     Parameters:
-        itemType (string|nil) – Item unique ID to count. Counts all if nil.
+        itemType (string|None) – Item unique ID to count. Counts all if nil.
 
     Realm:
         Shared
@@ -334,7 +359,7 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Add a looted item to the inventory
@@ -353,7 +378,7 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Remove an item but keep it saved for later
@@ -367,12 +392,12 @@
 
         Parameters:
             key (string) – Field to replicate.
-            recipients (table|nil) – Player recipients.
+            recipients (table|None) – Player recipients.
 
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Sync the locked state to nearby players
@@ -385,12 +410,12 @@
             Sends the entire inventory and its items to players.
 
         Parameters:
-            recipients (table|nil) – Player recipients.
+            recipients (table|None) – Player recipients.
 
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Send all items to the owner after they join
@@ -408,7 +433,7 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Permanently delete a chest inventory on cleanup
@@ -426,7 +451,7 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Clear all items when the container entity is removed

--- a/docs/lua/meta/item.lua
+++ b/docs/lua/meta/item.lua
@@ -172,7 +172,7 @@
         Shared
 
     Returns:
-        Player|nil – The owner if available.
+        Player|None – The owner if available.
 
     Example Usage:
         -- Notify whoever currently owns the item
@@ -234,7 +234,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Run code when the item is used
@@ -253,7 +253,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Give a pistol after the item is picked up
@@ -271,7 +271,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Initialize data when the item type loads
@@ -289,7 +289,7 @@
     Realm:
         Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Output item info while debugging spawn issues
@@ -307,7 +307,7 @@
     Realm:
         Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Dump all stored data to the console
@@ -321,17 +321,18 @@
 
         Parameters:
             quantity (number) – Amount to add.
-            receivers (Player|nil) – Who to network the change to.
+            receivers (Player|None) – Who to network the change to.
             noCheckEntity (boolean) – Skip entity network update.
 
         Realm:
             Server
         Returns:
-            nil – This function does not return a value.
+            None – This function does not return a value.
 
     Example Usage:
-        -- Combine stacks and update clients
+        -- Combine stacks from a loot drop and notify the owner
         item:addQuantity(5, {player})
+        player:notifyLocalized("item_added", item.name, 5)
     ]]
 --[[
         setQuantity(quantity, receivers, noCheckEntity)
@@ -341,13 +342,13 @@
 
         Parameters:
             quantity (number) – New amount to store.
-            receivers (Player|nil) – Recipients to send updates to.
+            receivers (Player|None) – Recipients to send updates to.
             noCheckEntity (boolean) – Skip entity updates when true.
 
         Realm:
             Server
         Returns:
-            nil – This function does not return a value.
+            None – This function does not return a value.
 
     Example Usage:
         -- Set quantity to 1 after splitting the stack

--- a/docs/lua/meta/panel.lua
+++ b/docs/lua/meta/panel.lua
@@ -20,4 +20,6 @@
         local frame = vgui.Create("DFrame")
         frame:SetSize(200, 100)
         frame:SetPos(25, 25)
+        frame:SetTitle("Scaled Frame")
+        frame:MakePopup()
 ]]

--- a/docs/lua/meta/player.lua
+++ b/docs/lua/meta/player.lua
@@ -11,7 +11,7 @@
             Shared
 
         Returns:
-            Character|nil – The player's active character.
+            Character|None – The player's active character.
 
     Example Usage:
         -- Retrieve the character to modify inventory
@@ -70,7 +70,7 @@
         Shared
 
     Returns:
-        Entity|nil – Vehicle entity or nil.
+        Entity|None – Vehicle entity or None.
 
     Example Usage:
         -- Attach a camera to the vehicle the player is in
@@ -132,7 +132,7 @@
         Shared
 
     Returns:
-        table|nil – Table of items or nil if absent.
+        table|None – Table of items or None if absent.
 
     Example Usage:
         -- Iterate player's items to calculate total weight
@@ -153,7 +153,7 @@
         Shared
 
     Returns:
-        Entity|nil – The entity hit or nil.
+        Entity|None – The entity hit or None.
 
     Example Usage:
         -- Grab the entity the player is pointing at
@@ -191,7 +191,7 @@
         Shared
 
     Returns:
-        Entity|nil – The entity or nil if too far.
+        Entity|None – The entity or None if too far.
 
     Example Usage:
         -- Show the name of the object being looked at
@@ -212,11 +212,12 @@
     Realm:
         Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
-        -- Send a chat notification to the player
-        local result = player:notify("Welcome to the server!")
+        -- Send a welcome notification and log the join event
+        player:notify("Welcome to the server!")
+        file.Append("welcome.txt", player:SteamID() .. " joined\n")
 ]]
 --[[
     notifyLocalized(message, ...)
@@ -231,11 +232,12 @@
     Realm:
         Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
-        -- Send a localized message to the player
-        local result = player:notifyLocalized("greeting_key", player:Name())
+        -- Send a localized message including the player's name and score
+        local score = player:GetFrags()
+        player:notifyLocalized("greeting_key", player:Name(), score)
 ]]
 --[[
     CanEditVendor(vendor)
@@ -253,6 +255,7 @@
         boolean – True if allowed to edit.
 
     Example Usage:
+        -- Determine if the player may modify the vendor
         local result = player:CanEditVendor(vendor)
 ]]
 --[[
@@ -271,6 +274,7 @@
         boolean – Whether usergroup is "user".
 
     Example Usage:
+        -- Check if the player belongs to the default user group
         local result = player:isUser()
 ]]
 --[[
@@ -289,6 +293,7 @@
         boolean – Result from the privilege check.
 
     Example Usage:
+        -- Verify staff permissions for administrative actions
         local result = player:isStaff()
 ]]
 --[[
@@ -307,6 +312,7 @@
         boolean – Result from privilege check.
 
     Example Usage:
+        -- Test if the player has VIP status
         local result = player:isVIP()
 ]]
 --[[
@@ -325,6 +331,7 @@
         boolean – True if staff faction is active.
 
     Example Usage:
+        -- Confirm the player is currently in a staff role
         local result = player:isStaffOnDuty()
 ]]
 --[[
@@ -343,6 +350,7 @@
         boolean – True if the factions match.
 
     Example Usage:
+        -- Compare the player's faction to a requirement
         local result = player:isFaction(faction)
 ]]
 --[[
@@ -361,6 +369,7 @@
         boolean – Whether the character matches the class.
 
     Example Usage:
+        -- Determine if the player's class matches
         local result = player:isClass(class)
 ]]
 --[[
@@ -379,6 +388,7 @@
         boolean – True if whitelisted.
 
     Example Usage:
+        -- Check for whitelist permission on a faction
         local result = player:hasWhitelist(faction)
 ]]
 --[[
@@ -394,9 +404,10 @@
         Shared
 
     Returns:
-        number|nil – Class index or nil.
+        number|None – Class index or None.
 
     Example Usage:
+        -- Retrieve the current class index
         local result = player:getClass()
 ]]
 --[[
@@ -415,6 +426,7 @@
         boolean – True if class whitelist exists.
 
     Example Usage:
+        -- Verify the player is approved for a specific class
         local result = player:hasClassWhitelist(class)
 ]]
 --[[
@@ -430,9 +442,10 @@
         Shared
 
     Returns:
-        table|nil – Class definition table.
+        table|None – Class definition table.
 
     Example Usage:
+        -- Access data table for the player's class
         local result = player:getClassData()
 ]]
 --[[
@@ -448,9 +461,10 @@
         Shared
 
     Returns:
-        number|nil – Money amount or nil.
+        number|None – Money amount or None.
 
     Example Usage:
+        -- Read money amount in a DarkRP-compatible way
         local result = player:getDarkRPVar(var)
 ]]
 --[[
@@ -469,6 +483,7 @@
         number – Current funds or 0.
 
     Example Usage:
+        -- Fetch the character's stored funds
         local result = player:getMoney()
 ]]
 --[[
@@ -487,6 +502,7 @@
         boolean – True if funds are sufficient.
 
     Example Usage:
+        -- Check if the player has enough money to buy something
         local result = player:canAfford(amount)
 ]]
 --[[
@@ -506,6 +522,7 @@
         boolean – Whether the character satisfies the requirement.
 
     Example Usage:
+        -- Ensure the player meets a single skill requirement
         local result = player:hasSkillLevel(skill, level)
 ]]
 --[[
@@ -524,6 +541,7 @@
         boolean – True if all requirements are met.
 
     Example Usage:
+        -- Validate multiple skill requirements at once
         local result = player:meetsRequiredSkills(requiredSkillLevels)
 ]]
 --[[
@@ -534,8 +552,8 @@
 
     Parameters:
         sequenceName (string) – Sequence to play.
-        callback (function|nil) – Called when finished.
-        time (number|nil) – Duration override.
+        callback (function|None) – Called when finished.
+        time (number|None) – Duration override.
         noFreeze (boolean) – Don't freeze movement when true.
 
     Realm:
@@ -545,6 +563,7 @@
         number|boolean – Duration or false on failure.
 
     Example Usage:
+        -- Play an animation while freezing the player
         local result = player:forceSequence(sequenceName, callback, time, noFreeze)
 ]]
 --[[
@@ -559,7 +578,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Stop the player's forced animation sequence
@@ -577,7 +596,7 @@
         Realm:
             Server
         Returns:
-            nil – This function does not return a value.
+            None – This function does not return a value.
 
     Example Usage:
         -- Give the player extra stamina points
@@ -595,7 +614,7 @@
         Realm:
             Server
         Returns:
-            nil – This function does not return a value.
+            None – This function does not return a value.
 
     Example Usage:
         -- Spend stamina as the player performs an action
@@ -613,11 +632,12 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
-        -- Give the player additional money
-        local result = player:addMoney(amount)
+        -- Reward the player and announce the payout
+        player:addMoney(100)
+        player:notify("You received $100 for completing the quest.")
     ]]
 --[[
         takeMoney(amount)
@@ -631,7 +651,7 @@
         Realm:
             Server
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Remove money from the player's character

--- a/docs/lua/meta/tool.lua
+++ b/docs/lua/meta/tool.lua
@@ -30,6 +30,9 @@
     Realm:
         Shared
 
+    Returns:
+        None – This function does not return a value.
+
     Example Usage:
         -- Ensure console variables exist for configuration
         tool:CreateConVars()
@@ -127,7 +130,13 @@
         boolean – True if the tool is allowed.
 
     Example Usage:
-        if tool:Allowed() then print("ok") end
+        -- Check if the player can use the current tool
+        if tool:Allowed() then
+            tool:GetOwner():ChatPrint("Tool is permitted!")
+            hook.Run("PlayerToolPermitted", tool:GetOwner(), tool:GetMode())
+        else
+            tool:GetOwner():ChatPrint("Tool usage blocked.")
+        end
 ]]
 --[[
     Init()
@@ -141,7 +150,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Prepare the tool for use
@@ -163,6 +172,7 @@
         string – Tool mode name.
 
     Example Usage:
+        -- Retrieve the tool's active mode string
         local result = tool:GetMode()
 ]]
 --[[
@@ -181,6 +191,7 @@
         SWEP – The tool's weapon entity.
 
     Example Usage:
+        -- Obtain the weapon entity representing this tool
         local result = tool:GetSWEP()
 ]]
 --[[
@@ -199,6 +210,7 @@
         Player – Owner of the tool.
 
     Example Usage:
+        -- Reference the player who deployed the tool
         local result = tool:GetOwner()
 ]]
 --[[
@@ -217,6 +229,7 @@
         Weapon – The weapon object.
 
     Example Usage:
+        -- Access the underlying weapon object
         local result = tool:GetWeapon()
 ]]
 --[[
@@ -269,7 +282,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Clear saved objects when reloading the tool
@@ -287,7 +300,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Equip the tool and spawn its ghost entity
@@ -305,7 +318,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Unequip the tool and remove its ghost entity
@@ -323,7 +336,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Run per-tick logic for the active tool
@@ -341,7 +354,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Validate all stored objects each tick
@@ -359,7 +372,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Remove any objects the tool is storing
@@ -377,7 +390,7 @@
     Realm:
         Shared
     Returns:
-        nil – This function does not return a value.
+        None – This function does not return a value.
 
     Example Usage:
         -- Remove the placement preview entity

--- a/docs/lua/meta/vector.lua
+++ b/docs/lua/meta/vector.lua
@@ -14,6 +14,7 @@
         Vector – The center point of the two vectors.
 
     Example Usage:
+        -- Average two vectors to find the midpoint
         local midpoint = vector_origin:Center(Vector(10, 10, 10))
         print(midpoint) -- Vector(5, 5, 5)
 ]]
@@ -33,6 +34,7 @@
         number – The distance between the two vectors.
 
     Example Usage:
+        -- Measure the distance between two points
         local dist = vector_origin:Distance(Vector(3, 4, 0))
         print(dist) -- 5
 ]]
@@ -53,6 +55,7 @@
         Vector – The rotated vector.
 
     Example Usage:
+        -- Rotate a vector 90 degrees around the Z axis
         local rotated = Vector(1, 0, 0):RotateAroundAxis(Vector(0, 0, 1), 90)
         print(rotated) -- Vector(0, 1, 0)
 ]]
@@ -72,6 +75,7 @@
         Vector – The calculated right vector.
 
     Example Usage:
+        -- Get the right direction vector
         local rightVec = Vector(0, 1, 0):Right()
         print(rightVec)
 ]]
@@ -91,6 +95,7 @@
         Vector – The calculated up vector.
 
     Example Usage:
+        -- Get the up direction vector
         local upVec = Vector(1, 0, 0):Up()
         print(upVec)
 ]]


### PR DESCRIPTION
## Summary
- ensure `Returns` sections use `None` instead of `nil`
- add more practical Example Usage snippets with comments
- update docs in entity, inventory, player, tool and other meta files
- expand several examples with multi-line scenarios

## Testing
- `grep -c "Returns:" docs/lua/meta/*.lua`

------
https://chatgpt.com/codex/tasks/task_e_685e3b01c8ac832786f9c7be0f75973b