### PR TITLE
Add storage unlock logging

### DIFF
--- a/modules/characters/inventory/submodules/storage/netcalls/server.lua
+++ b/modules/characters/inventory/submodules/storage/netcalls/server.lua
@@ -19,8 +19,10 @@ net.Receive("liaStorageUnlock", function(_, client)
         client:notifyLocalized("passwordTooQuick")
     else
         if storage.password == password then
+            lia.log.add(client, "storageUnlock", storage:GetClass())
             storage:openInv(client)
         else
+            lia.log.add(client, "storageUnlockFailed", storage:GetClass(), password)
             client:notifyLocalized("wrongPassword")
             client.liaStorageEntity = nil
         end

--- a/modules/core/administration/submodules/logging/logs.lua
+++ b/modules/core/administration/submodules/logging/logs.lua
@@ -348,6 +348,60 @@
         end,
         category = "Connections"
     },
+    ["failedPassword"] = {
+        func = function(_, steamid64, name, svpass, clpass)
+            return string.format(
+                "[%s] %s failed server password (Server: '%s', Client: '%s')",
+                steamid64,
+                name,
+                svpass,
+                clpass
+            )
+        end,
+        category = "Connections"
+    },
+    ["exploitAttempt"] = {
+        func = function(_, name, steamID, netMessage)
+            return string.format(
+                "Player '%s' [%s] triggered exploit net message '%s'.",
+                name,
+                steamID,
+                netMessage
+            )
+        end,
+        category = "Connections"
+    },
+    ["steamIDMissing"] = {
+        func = function(_, name, steamID)
+            return string.format(
+                "SteamID missing for '%s' [%s] during CheckSeed.",
+                name,
+                steamID
+            )
+        end,
+        category = "Connections"
+    },
+    ["steamIDMismatch"] = {
+        func = function(_, name, realSteamID, sentSteamID)
+            return string.format(
+                "SteamID mismatch for '%s': expected [%s] but got [%s].",
+                name,
+                realSteamID,
+                sentSteamID
+            )
+        end,
+        category = "Connections"
+    },
+    ["hackAttempt"] = {
+        func = function(client)
+            return string.format(
+                "Client [%s] %s triggered hack detection.",
+                client:SteamID64(),
+                client:Name()
+            )
+        end,
+        category = "Connections"
+    },
     ["doorSetClass"] = {
         func = function(client, door, className)
             return string.format(
@@ -1149,6 +1203,29 @@
         end,
         category = "Storage"
     },
+    ["storageUnlock"] = {
+        func = function(client, entClass)
+            return string.format(
+                "Client [%s] %s unlocked storage %s.",
+                client:SteamID64(),
+                client:Name(),
+                entClass
+            )
+        end,
+        category = "Storage"
+    },
+    ["storageUnlockFailed"] = {
+        func = function(client, entClass, password)
+            return string.format(
+                "Client [%s] %s failed to unlock storage %s with password '%s'.",
+                client:SteamID64(),
+                client:Name(),
+                entClass,
+                password
+            )
+        end,
+        category = "Storage"
+    },
     ["spawnAdd"] = {
         func = function(client, faction)
             return string.format(
@@ -1191,6 +1268,81 @@
                 client:SteamID64(),
                 client:Name(),
                 targetName
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["banOOC"] = {
+        func = function(client, targetName, steamID)
+            return string.format(
+                "Admin [%s] '%s' banned %s (%s) from OOC chat.",
+                client:SteamID64(),
+                client:Name(),
+                targetName,
+                steamID
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["unbanOOC"] = {
+        func = function(client, targetName, steamID)
+            return string.format(
+                "Admin [%s] '%s' unbanned %s (%s) from OOC chat.",
+                client:SteamID64(),
+                client:Name(),
+                targetName,
+                steamID
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["blockOOC"] = {
+        func = function(client, state)
+            return string.format(
+                "Admin [%s] '%s' %s OOC chat globally.",
+                client:SteamID64(),
+                client:Name(),
+                state and "blocked" or "unblocked"
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["clearChat"] = {
+        func = function(client)
+            return string.format(
+                "Admin [%s] '%s' cleared the chat.",
+                client:SteamID64(),
+                client:Name()
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["cheaterBanned"] = {
+        func = function(_, name, steamID)
+            return string.format(
+                "Cheater '%s' [%s] was automatically banned.",
+                name,
+                steamID
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["altKicked"] = {
+        func = function(_, name, steamID)
+            return string.format(
+                "Alt account '%s' [%s] was kicked.",
+                name,
+                steamID
+            )
+        end,
+        category = "Admin Actions"
+    },
+    ["altBanned"] = {
+        func = function(_, name, steamID)
+            return string.format(
+                "Alt account '%s' [%s] was banned due to blacklist.",
+                name,
+                steamID
             )
         end,
         category = "Admin Actions"

--- a/modules/core/protection/netcalls/server.lua
+++ b/modules/core/protection/netcalls/server.lua
@@ -4,6 +4,7 @@ for _, v in pairs(KnownExploits) do
         client.nextExploitNotify = client.nextExploitNotify or 0
         if client.nextExploitNotify > CurTime() then return end
         client.nextExploitNotify = CurTime() + 2
+        lia.log.add(nil, "exploitAttempt", client:Name(), client:SteamID64(), tostring(v))
         for _, p in player.Iterator() do
             if p:isStaffOnDuty() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID64(), tostring(v)) end
         end
@@ -25,11 +26,18 @@ end
 net.Receive("CheckSeed", function(_, client)
     local sentSteamID = net.ReadString()
     if not sentSteamID or sentSteamID == "" then
+        lia.log.add(nil, "steamIDMissing", client:Name(), client:SteamID64())
         NotifyAdmin(L("steamIDMissing", client:Name(), client:SteamID64()))
         return
     end
 
-    if client:SteamID64() ~= sentSteamID then NotifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID)) end
+    if client:SteamID64() ~= sentSteamID then
+        lia.log.add(nil, "steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID)
+        NotifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID))
+    end
 end)
 
-net.Receive("CheckHack", function(_, client) ApplyPunishment(client, "Hacking", true, true, 0) end)
+net.Receive("CheckHack", function(_, client)
+    lia.log.add(client, "hackAttempt")
+    ApplyPunishment(client, "Hacking", true, true, 0)
+end)

--- a/modules/frameworkui/chatbox/commands.lua
+++ b/modules/frameworkui/chatbox/commands.lua
@@ -20,6 +20,7 @@ lia.command.add("banooc", {
 
         MODULE.OOCBans[target:SteamID64()] = true
         client:notify(target:Name() .. " " .. L("hasBeenBannedFromOOC"))
+        lia.log.add(client, "banOOC", target:Name(), target:SteamID64())
     end
 })
 
@@ -43,6 +44,7 @@ lia.command.add("unbanooc", {
 
         MODULE.OOCBans[target:SteamID64()] = nil
         client:notify(target:Name() .. " " .. L("hasBeenUnbannedFromOOC"))
+        lia.log.add(client, "unbanOOC", target:Name(), target:SteamID64())
     end
 })
 
@@ -54,6 +56,7 @@ lia.command.add("blockooc", {
         local blocked = GetGlobalBool("oocblocked", false)
         SetGlobalBool("oocblocked", not blocked)
         client:notify(blocked and L("unlockedOOC") or L("blockedOOC"))
+        lia.log.add(client, "blockOOC", not blocked)
     end
 })
 
@@ -61,9 +64,10 @@ lia.command.add("clearchat", {
     adminOnly = true,
     privilege = "Clear Chat",
     desc = L("clearChatCommandDesc"),
-    onRun = function()
+    onRun = function(client)
         for _, ply in player.Iterator() do
             ply:ConCommand("fixchatplz")
         end
+        lia.log.add(client, "clearChat")
     end
 })


### PR DESCRIPTION
## Summary
- log unlocking or failed attempts on storage entities
- define `storageUnlock` and `storageUnlockFailed` log types
- add security-related logs for exploit attempts and hack detections
- record mismatched or missing Steam IDs during CheckSeed

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed7b664f083279b1175a2be8ade1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded event logging to cover storage unlock attempts, server password failures, exploit and hack attempts, SteamID issues, and various admin actions such as OOC bans, chat clearing, and blocking.
  * Enhanced traceability for security and moderation events.

* **Bug Fixes**
  * Improved logging for failed storage unlocks and incorrect password attempts.

* **Chores**
  * Updated chat moderation commands to include logging of actions for better auditability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->