### PR TITLE
Remove empty syntax placeholders

### DIFF
--- a/modules/characters/attributes/commands.lua
+++ b/modules/characters/attributes/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = L("setAttributes"),
-    syntax = "[string charname] [string attribname] [number level]",
+    syntax = "[string playerName] [string attribname] [number level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("setAttributes"),
@@ -47,7 +47,7 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = L("checkAttributes"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("checkAttributes"),
@@ -109,7 +109,7 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = L("addAttributes"),
-    syntax = "[string charname] [string attribname] [number level]",
+    syntax = "[string playerName] [string attribname] [number level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("addAttributes"),

--- a/modules/characters/inventory/submodules/storage/commands.lua
+++ b/modules/characters/inventory/submodules/storage/commands.lua
@@ -29,7 +29,6 @@
 lia.command.add("trunk", {
     adminOnly = false,
     desc = L("trunkOpenDesc"),
-    syntax = nil,
     onRun = function(client)
         local entity = client:getTracedEntity()
         local maxDistance = 110

--- a/modules/core/administration/commands.lua
+++ b/modules/core/administration/commands.lua
@@ -75,7 +75,7 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("sendToSitRoomDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = L("sendToSitRoom"),
         Category = "moderationTools",
@@ -121,7 +121,7 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("returnFromSitroomDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = L("returnFromSitroom"),
         Category = "moderationTools",

--- a/modules/core/administration/submodules/permissions/commands.lua
+++ b/modules/core/administration/submodules/permissions/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Toggle Permakill",
     desc = L("togglePermakillDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = "Toggle Character Killing (Ban)",
         Category = "characterManagement",
@@ -55,7 +55,7 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = "Play Sounds",
     desc = L("playSoundDesc"),
-    syntax = "[string player] [string sound]",
+    syntax = "[string playerName] [string sound]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -106,7 +106,7 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = "Force Fallover",
     desc = L("forceFalloverDesc"),
-    syntax = "[player target] [number time]",
+    syntax = "[string playerName] [number time]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -150,7 +150,7 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = "Force GetUp",
     desc = L("forceGetUpDesc"),
-    syntax = "[player target]",
+    syntax = "[string playerName]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then

--- a/modules/core/administration/submodules/tickets/commands.lua
+++ b/modules/core/administration/submodules/tickets/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "View Claims",
     desc = L("plyViewClaimsDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = L("viewTicketClaims"),
         Category = "moderationTools",

--- a/modules/core/teams/commands.lua
+++ b/modules/core/teams/commands.lua
@@ -112,7 +112,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("setClassDesc"),
-    syntax = "[string charname] [string class]",
+    syntax = "[string playerName] [string class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then

--- a/modules/frameworkui/chatbox/commands.lua
+++ b/modules/frameworkui/chatbox/commands.lua
@@ -4,7 +4,7 @@ lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
     desc = L("banOOCCommandDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = L("banOOCCommandName"),
         Category = "moderationTools",
@@ -28,7 +28,7 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = "Unban OOC",
     desc = L("unbanOOCCommandDesc"),
-    syntax = "[string charname]",
+    syntax = "[string playerName]",
     AdminStick = {
         Name = L("unbanOOCCommandName"),
         Category = "moderationTools",

--- a/modules/frameworkui/chatbox/libraries/shared.lua
+++ b/modules/frameworkui/chatbox/libraries/shared.lua
@@ -211,7 +211,7 @@ lia.chat.register("roll", {
 })
 
 lia.chat.register("pm", {
-    syntax = "[string player] [string message]",
+    syntax = "[string playerName] [string message]",
     desc = L("pmDesc"),
     format = "[PM] %s: %s.",
     color = Color(249, 211, 89),


### PR DESCRIPTION
## Summary
- standardize player argument documentation to `[string playerName]`
- remove leftover references to `[string charname]`

## Testing
- `luacheck modules/characters/inventory/submodules/storage/commands.lua modules/core/administration/commands.lua modules/frameworkui/chatbox/commands.lua modules/utilities/doors/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee3707d3883278c1d74a5f79f1f5c