### PR TITLE
Support spaces in command syntax fields

### DIFF
--- a/docs/docs/framework/definitions/command.md
+++ b/docs/docs/framework/definitions/command.md
@@ -94,10 +94,11 @@ privilege = "Manage Doors"
 
 **Type:** `string`
 **Description:** Human-readable syntax string shown in help menus. Does not affect argument parsing.
+You can use spaces in argument names for better readability.
 **Example:**
 
 ```lua
-syntax = "[string target] [number amount]"
+syntax = "[string Target Name] [number Amount]"
 ```
 
 ---

--- a/docs/lua/definitions/command_fields.lua
+++ b/docs/lua/definitions/command_fields.lua
@@ -58,7 +58,7 @@
         the arguments.
 
     Example Usage:
-            syntax = "[string target] [number amount]"
+            syntax = "[string Target Name] [number Amount]"
 ]]
 
 --[[

--- a/docs/lua/libraries/commands.lua
+++ b/docs/lua/libraries/commands.lua
@@ -61,7 +61,7 @@
      Each field contains a name and a type derived from the syntax.
 
   Parameters:
-     syntax (string) - The syntax string, e.g. "[string name] [number time]".
+     syntax (string) - The syntax string, e.g. "[string Name] [number Time]".
 
   Returns:
      table - List of fields in call order.
@@ -71,7 +71,7 @@
 
   Example Usage:
         -- Extract field data from a syntax string
-        local fields = lia.command.parseSyntaxFields("[string name] [number time]")
+        local fields = lia.command.parseSyntaxFields("[string Name] [number Time]")
   ]]
 --[[
       lia.command.run

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -102,7 +102,7 @@ function lia.command.parseSyntaxFields(syntax)
     if not syntax or syntax == "" then return fields end
     for token in syntax:gmatch("%b[]") do
         local inner = token:sub(2, -2)
-        local typ, name = inner:match("^(%S+)%s+(%S+)$")
+        local typ, name = inner:match("^(%S+)%s+(.+)$")
         if name then
             typ = typ:lower()
             if typ == "string" then

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -140,7 +140,7 @@ lia.command.add("playtime", {
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = "View Playtime",
-    syntax = "[string charname]",
+    syntax = "[string Char Name]",
     AdminStick = {
         Name = L("adminStickGetPlayTimeName"),
         Category = "moderationTools",

--- a/modules/characters/attributes/commands.lua
+++ b/modules/characters/attributes/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = L("setAttributes"),
-    syntax = "[string playerName] [string attribname] [number level]",
+    syntax = "[string Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("setAttributes"),
@@ -47,7 +47,7 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = L("checkAttributes"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("checkAttributes"),
@@ -109,7 +109,7 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = L("addAttributes"),
-    syntax = "[string playerName] [string attribname] [number level]",
+    syntax = "[string Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("addAttributes"),

--- a/modules/characters/inventory/commands.lua
+++ b/modules/characters/inventory/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = L("updateInventorySizeDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -42,7 +42,7 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = L("setInventorySizeDesc"),
-    syntax = "[string playerName] [number width] [number height]",
+    syntax = "[string Player Name] [number Width] [number Height]",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
         if not target or not IsValid(target) then

--- a/modules/characters/inventory/submodules/storage/commands.lua
+++ b/modules/characters/inventory/submodules/storage/commands.lua
@@ -2,7 +2,7 @@
     privilege = "Lock Storage",
     adminOnly = true,
     desc = L("storagelockDesc"),
-    syntax = "[string password]",
+    syntax = "[string Password]",
     onRun = function(client, arguments)
         local entity = client:getTracedEntity()
         if entity and IsValid(entity) then

--- a/modules/characters/inventory/submodules/vendor/commands.lua
+++ b/modules/characters/inventory/submodules/vendor/commands.lua
@@ -50,7 +50,7 @@ lia.command.add("resetallvendormoney", {
     privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = L("resetAllVendorMoneyDesc"),
-    syntax = "[number amount]",
+    syntax = "[number Amount]",
     AdminStick = {
         Name = L("resetAllVendorMoneyStickName"),
         TargetClass = "lia_vendor",
@@ -79,7 +79,7 @@ lia.command.add("restockvendormoney", {
     privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = L("restockVendorMoneyDesc"),
-    syntax = "[number amount]",
+    syntax = "[number Amount]",
     AdminStick = {
         Name = L("restockVendorMoneyStickName"),
         TargetClass = "lia_vendor",

--- a/modules/core/administration/commands.lua
+++ b/modules/core/administration/commands.lua
@@ -75,7 +75,7 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("sendToSitRoomDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("sendToSitRoom"),
         Category = "moderationTools",
@@ -121,7 +121,7 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("returnFromSitroomDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("returnFromSitroom"),
         Category = "moderationTools",

--- a/modules/core/administration/submodules/permissions/commands.lua
+++ b/modules/core/administration/submodules/permissions/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Toggle Permakill",
     desc = L("togglePermakillDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = "Toggle Character Killing (Ban)",
         Category = "characterManagement",
@@ -37,7 +37,7 @@ lia.command.add("playglobalsound", {
     superAdminOnly = true,
     privilege = "Play Sounds",
     desc = L("playGlobalSoundDesc"),
-    syntax = "[string sound]",
+    syntax = "[string Sound]",
     onRun = function(client, arguments)
         local sound = arguments[1]
         if not sound or sound == "" then
@@ -55,7 +55,7 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = "Play Sounds",
     desc = L("playSoundDesc"),
-    syntax = "[string playerName] [string sound]",
+    syntax = "[string Player Name] [string Sound]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -106,7 +106,7 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = "Force Fallover",
     desc = L("forceFalloverDesc"),
-    syntax = "[string playerName] [number time]",
+    syntax = "[string Player Name] [number Time]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -150,7 +150,7 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = "Force GetUp",
     desc = L("forceGetUpDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -179,7 +179,7 @@ lia.command.add("forcegetup", {
 lia.command.add("chardesc", {
     adminOnly = false,
     desc = L("changeCharDesc"),
-    syntax = "[string desc]",
+    syntax = "[string Desc]",
     onRun = function(client, arguments)
         local desc = table.concat(arguments, " ")
         if not desc:find("%S") then return client:requestString(L("chgName"), L("chgNameDesc"), function(text) lia.command.run(client, "chardesc", {text}) end, client:getChar() and client:getChar():getDesc() or "") end
@@ -215,7 +215,7 @@ lia.command.add("chargetup", {
 lia.command.add("fallover", {
     adminOnly = false,
     desc = L("fallOverDesc"),
-    syntax = "[number time]",
+    syntax = "[number Time]",
     onRun = function(client, arguments)
         if client:getNetVar("FallOverCooldown", false) then
             client:notifyLocalized("cmdCooldown")
@@ -261,7 +261,7 @@ lia.command.add("togglelockcharacters", {
     superAdminOnly = true,
     privilege = "Toggle Character Lock",
     desc = L("toggleCharLockDesc"),
-    syntax = "[boolean lock]",
+    syntax = "[boolean Lock]",
     onRun = function()
         local newVal = not GetGlobalBool("characterSwapLock", false)
         SetGlobalBool("characterSwapLock", newVal)
@@ -277,7 +277,7 @@ lia.command.add("checkinventory", {
     adminOnly = true,
     privilege = "Check Inventories",
     desc = L("checkInventoryDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickCheckInventoryName"),
         Category = "characterManagement",
@@ -311,7 +311,7 @@ lia.command.add("flaggive", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("flagGiveDesc"),
-    syntax = "[string playerName] [string flags]",
+    syntax = "[string Player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -345,7 +345,7 @@ lia.command.add("flaggiveall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("giveAllFlagsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGiveAllFlagsName"),
         Category = "characterManagement",
@@ -373,7 +373,7 @@ lia.command.add("flagtakeall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("takeAllFlagsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickTakeAllFlagsName"),
         Category = "characterManagement",
@@ -406,7 +406,7 @@ lia.command.add("flagtake", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("flagTakeDesc"),
-    syntax = "[string playerName] [string flags]",
+    syntax = "[string Player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -442,7 +442,7 @@ lia.command.add("charvoicetoggle", {
     adminOnly = true,
     privilege = "Toggle Voice Ban Character",
     desc = L("charVoiceToggleDesc"),
-    syntax = "[string name]",
+    syntax = "[string Name]",
     AdminStick = {
         Name = L("toggleVoice"),
         Category = "moderationTools",
@@ -532,7 +532,7 @@ lia.command.add("charunban", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("charUnbanDesc"),
-    syntax = "[string name or number id]",
+    syntax = "[string Name or Number ID]",
     onRun = function(client, arguments)
         if (client.liaNextSearch or 0) >= CurTime() then return L("searchingChar") end
         local queryArg = table.concat(arguments, " ")
@@ -591,7 +591,7 @@ lia.command.add("clearinv", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("clearInvDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickClearInventoryName"),
         Category = "characterManagement",
@@ -614,7 +614,7 @@ lia.command.add("charkick", {
     adminOnly = true,
     privilege = "Kick Characters",
     desc = L("kickCharDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickKickCharacterName"),
         Category = "characterManagement",
@@ -645,7 +645,7 @@ lia.command.add("freezeallprops", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("freezeAllPropsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -673,7 +673,7 @@ lia.command.add("charban", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("banCharDesc"),
-    syntax = "[string name or number id]",
+    syntax = "[string Name or Number ID]",
     AdminStick = {
         Name = L("adminStickBanCharacterName"),
         Category = "characterManagement",
@@ -722,7 +722,7 @@ lia.command.add("checkmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("checkMoneyDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickCheckMoneyName"),
         Category = "characterManagement",
@@ -745,7 +745,7 @@ lia.command.add("listbodygroups", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("listBodygroupsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -790,7 +790,7 @@ lia.command.add("charsetspeed", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setSpeedDesc"),
-    syntax = "[string playerName] [number speed]",
+    syntax = "[string Player Name] [number Speed]",
     AdminStick = {
         Name = L("adminStickSetCharSpeedName"),
         Category = "characterManagement",
@@ -816,7 +816,7 @@ lia.command.add("charsetmodel", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setModelDesc"),
-    syntax = "[string playerName] [string model]",
+    syntax = "[string Player Name] [string Model]",
     AdminStick = {
         Name = L("adminStickSetCharModelName"),
         Category = "characterManagement",
@@ -845,7 +845,7 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = "Manage Items",
     desc = L("giveItemDesc"),
-    syntax = "[string playerName] [string itemNameOrID]",
+    syntax = "[string Player Name] [string Item Name Or ID]",
     AdminStick = {
         Name = L("adminStickGiveItemName"),
         Category = "characterManagement",
@@ -910,7 +910,7 @@ lia.command.add("charsetdesc", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setDescDesc"),
-    syntax = "[string playerName] [string description]",
+    syntax = "[string Player Name] [string Description]",
     AdminStick = {
         Name = L("adminStickSetCharDescName"),
         Category = "characterManagement",
@@ -943,7 +943,7 @@ lia.command.add("charsetname", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setNameDesc"),
-    syntax = "[string playerName] [string newName]",
+    syntax = "[string Player Name] [string New Name]",
     AdminStick = {
         Name = L("adminStickSetCharNameName"),
         Category = "characterManagement",
@@ -971,7 +971,7 @@ lia.command.add("charsetscale", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setScaleDesc"),
-    syntax = "[string playerName] [number scale]",
+    syntax = "[string Player Name] [number Scale]",
     AdminStick = {
         Name = L("adminStickSetCharScaleName"),
         Category = "characterManagement",
@@ -998,7 +998,7 @@ lia.command.add("charsetjump", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setJumpDesc"),
-    syntax = "[string playerName] [number power]",
+    syntax = "[string Player Name] [number Power]",
     AdminStick = {
         Name = L("adminStickSetCharJumpName"),
         Category = "characterManagement",
@@ -1025,7 +1025,7 @@ lia.command.add("charsetbodygroup", {
     adminOnly = true,
     privilege = "Manage Bodygroups",
     desc = L("setBodygroupDesc"),
-    syntax = "[string playerName] [string bodyGroupName] [number value]",
+    syntax = "[string Player Name] [string BodyGroup Name] [number Value]",
     onRun = function(client, arguments)
         local name = arguments[1]
         local bodyGroup = arguments[2]
@@ -1054,7 +1054,7 @@ lia.command.add("charsetskin", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setSkinDesc"),
-    syntax = "[string playerName] [number skin]",
+    syntax = "[string Player Name] [number Skin]",
     AdminStick = {
         Name = L("adminStickSetCharSkinName"),
         Category = "characterManagement",
@@ -1083,7 +1083,7 @@ lia.command.add("charsetmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("setMoneyDesc"),
-    syntax = "[string playerName] [number amount]",
+    syntax = "[string Player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1107,7 +1107,7 @@ lia.command.add("charaddmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("addMoneyDesc"),
-    syntax = "[string playerName] [number amount]",
+    syntax = "[string Player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1134,7 +1134,7 @@ lia.command.add("globalbotsay", {
     superAdminOnly = true,
     privilege = "Bot Say",
     desc = L("globalBotSayDesc"),
-    syntax = "[string message]",
+    syntax = "[string Message]",
     onRun = function(client, arguments)
         local message = table.concat(arguments, " ")
         if message == "" then
@@ -1152,7 +1152,7 @@ lia.command.add("botsay", {
     superAdminOnly = true,
     privilege = "Bot Say",
     desc = L("botSayDesc"),
-    syntax = "[string botName] [string message]",
+    syntax = "[string Bot Name] [string Message]",
     onRun = function(client, arguments)
         if #arguments < 2 then
             client:notifyLocalized("needBotAndMessage")
@@ -1182,7 +1182,7 @@ lia.command.add("forcesay", {
     superAdminOnly = true,
     privilege = "Force Say",
     desc = L("forceSayDesc"),
-    syntax = "[string playerName] [string message]",
+    syntax = "[string Player Name] [string Message]",
     AdminStick = {
         Name = "Force Say",
         Category = "moderationTools",
@@ -1226,7 +1226,7 @@ lia.command.add("getmodel", {
 
 lia.command.add("pm", {
     desc = L("pmDesc"),
-    syntax = "[string playerName] [string message]",
+    syntax = "[string Player Name] [string Message]",
     onRun = function(client, arguments)
         if not lia.config.get("AllowPMs") then
             client:notifyLocalized("pmsDisabled")
@@ -1254,7 +1254,7 @@ lia.command.add("chargetmodel", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getCharModelDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharModelName"),
         Category = "characterManagement",
@@ -1288,7 +1288,7 @@ lia.command.add("checkflags", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("checkFlagsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharFlagsName"),
         Category = "characterManagement",
@@ -1315,7 +1315,7 @@ lia.command.add("chargetname", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getCharNameDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharNameName"),
         Category = "characterManagement",
@@ -1337,7 +1337,7 @@ lia.command.add("chargethealth", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getHealthDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharHealthName"),
         Category = "characterManagement",
@@ -1359,7 +1359,7 @@ lia.command.add("chargetmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getMoneyDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharMoneyName"),
         Category = "characterManagement",
@@ -1382,7 +1382,7 @@ lia.command.add("chargetinventory", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getInventoryDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharInventoryName"),
         Category = "characterManagement",

--- a/modules/core/administration/submodules/tickets/commands.lua
+++ b/modules/core/administration/submodules/tickets/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "View Claims",
     desc = L("plyViewClaimsDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("viewTicketClaims"),
         Category = "moderationTools",

--- a/modules/core/administration/submodules/warns/commands.lua
+++ b/modules/core/administration/submodules/warns/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Issue Warnings",
     desc = L("warnDesc"),
-    syntax = "[string target] [string reason]",
+    syntax = "[string Target] [string Reason]",
     AdminStick = {
         Name = L("warnPlayer"),
         Category = "moderationTools",
@@ -41,7 +41,7 @@ lia.command.add("viewwarns", {
     adminOnly = true,
     privilege = "View Player Warnings",
     desc = L("viewWarnsDesc"),
-    syntax = "[string target]",
+    syntax = "[string Target]",
     AdminStick = {
         Name = L("viewPlayerWarnings"),
         Category = "moderationTools",

--- a/modules/core/spawns/commands.lua
+++ b/modules/core/spawns/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("spawnadd", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnAddDesc"),
-    syntax = "[string faction]",
+    syntax = "[string Faction]",
     onRun = function(client, arguments)
         local factionName = arguments[1]
         if not factionName then return L("invalidArg") end
@@ -33,7 +33,7 @@ lia.command.add("spawnremoveinradius", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnRemoveInRadiusDesc"),
-    syntax = "[number radius]",
+    syntax = "[number Radius]",
     onRun = function(client, arguments)
         local position = client:GetPos()
         local radius = tonumber(arguments[1]) or 120
@@ -57,7 +57,7 @@ lia.command.add("spawnremovebyname", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnRemoveByNameDesc"),
-    syntax = "[string faction]",
+    syntax = "[string Faction]",
     onRun = function(_, arguments)
         local factionName = arguments[1]
         local factionInfo = lia.faction.indices[factionName:lower()]
@@ -90,7 +90,7 @@ lia.command.add("returnitems", {
     superAdminOnly = true,
     privilege = "Return Items",
     desc = L("returnItemsDesc"),
-    syntax = "[string name]",
+    syntax = "[string Name]",
     AdminStick = {
         Name = L("returnItemsName"),
         Category = "characterManagement",

--- a/modules/core/teams/commands.lua
+++ b/modules/core/teams/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Manage Transfers",
     desc = L("plyTransferDesc"),
-    syntax = "[string name] [string faction]",
+    syntax = "[string Name] [string Faction]",
     alias = {"charsetfaction"},
     onRun = function(client, arguments)
         local targetPlayer = lia.util.findPlayer(client, arguments[1])
@@ -39,7 +39,7 @@ lia.command.add("plywhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyWhitelistDesc"),
-    syntax = "[string name] [string faction]",
+    syntax = "[string Name] [string Faction]",
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -62,7 +62,7 @@ lia.command.add("plyunwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyUnwhitelistDesc"),
-    syntax = "[string name] [string faction]",
+    syntax = "[string Name] [string Faction]",
     alias = {"factionunwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -84,7 +84,7 @@ lia.command.add("plyunwhitelist", {
 lia.command.add("beclass", {
     adminOnly = false,
     desc = L("beClassDesc"),
-    syntax = "[string class]",
+    syntax = "[string Class]",
     onRun = function(client, arguments)
         local className = table.concat(arguments, " ")
         local character = client:getChar()
@@ -112,7 +112,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("setClassDesc"),
-    syntax = "[string playerName] [string class]",
+    syntax = "[string Player Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -143,7 +143,7 @@ lia.command.add("classwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("classWhitelistDesc"),
-    syntax = "[string name] [string class]",
+    syntax = "[string Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))
@@ -173,7 +173,7 @@ lia.command.add("classunwhitelist", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("classUnwhitelistDesc"),
-    syntax = "[string name] [string class]",
+    syntax = "[string Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))

--- a/modules/frameworkui/chatbox/commands.lua
+++ b/modules/frameworkui/chatbox/commands.lua
@@ -4,7 +4,7 @@ lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
     desc = L("banOOCCommandDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("banOOCCommandName"),
         Category = "moderationTools",
@@ -28,7 +28,7 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = "Unban OOC",
     desc = L("unbanOOCCommandDesc"),
-    syntax = "[string playerName]",
+    syntax = "[string Player Name]",
     AdminStick = {
         Name = L("unbanOOCCommandName"),
         Category = "moderationTools",

--- a/modules/frameworkui/chatbox/libraries/shared.lua
+++ b/modules/frameworkui/chatbox/libraries/shared.lua
@@ -1,6 +1,6 @@
 ﻿local MODULE = MODULE
 lia.chat.register("meclose", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("mecloseDesc"),
     format = "**%s %s",
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -11,7 +11,7 @@ lia.chat.register("meclose", {
 })
 
 lia.chat.register("actions", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("actionsDesc"),
     format = "**%s %s",
     color = Color(255, 150, 0),
@@ -20,7 +20,7 @@ lia.chat.register("actions", {
 })
 
 lia.chat.register("mefar", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("mefarDesc"),
     format = "**%s %s",
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -31,7 +31,7 @@ lia.chat.register("mefar", {
 })
 
 lia.chat.register("itclose", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("itcloseDesc"),
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -42,7 +42,7 @@ lia.chat.register("itclose", {
 })
 
 lia.chat.register("itfar", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("itfarDesc"),
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -64,7 +64,7 @@ lia.chat.register("coinflip", {
 })
 
 lia.chat.register("ic", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("icDesc"),
     format = "%s says \"%s\"",
     onGetColor = function(speaker)
@@ -80,7 +80,7 @@ lia.chat.register("ic", {
 })
 
 lia.chat.register("me", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("meDesc"),
     format = "**%s %s",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -96,7 +96,7 @@ lia.chat.register("me", {
 })
 
 lia.chat.register("globalme", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("globalMeDesc"),
     format = "**%s %s",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -108,7 +108,7 @@ lia.chat.register("globalme", {
 })
 
 lia.chat.register("it", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("itDesc"),
     onChatAdd = function(_, text) chat.AddText(lia.chat.timestamp(false), lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = function(speaker, listener)
@@ -123,7 +123,7 @@ lia.chat.register("it", {
 })
 
 lia.chat.register("w", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("wDesc"),
     format = "%s whispers \"%s\"",
     onGetColor = function(speaker)
@@ -139,7 +139,7 @@ lia.chat.register("w", {
 })
 
 lia.chat.register("y", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("yDesc"),
     format = "%s yells \"%s\"",
     onGetColor = function(speaker)
@@ -155,7 +155,7 @@ lia.chat.register("y", {
 })
 
 lia.chat.register("looc", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("loocDesc"),
     onCanSay = function(speaker)
         local delay = lia.config.get("LOOCDelay", false)
@@ -181,7 +181,7 @@ lia.chat.register("looc", {
 })
 
 lia.chat.register("adminchat", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("adminchatDesc"),
     onGetColor = function() return Color(0, 196, 255) end,
     onCanHear = function(_, listener) return listener:hasPrivilege("Staff Permissions - Admin Chat") end,
@@ -211,7 +211,7 @@ lia.chat.register("roll", {
 })
 
 lia.chat.register("pm", {
-    syntax = "[string playerName] [string message]",
+    syntax = "[string Player Name] [string Message]",
     desc = L("pmDesc"),
     format = "[PM] %s: %s.",
     color = Color(249, 211, 89),
@@ -220,7 +220,7 @@ lia.chat.register("pm", {
 })
 
 lia.chat.register("eventlocal", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("eventlocalDesc"),
     onCanSay = function(speaker) return speaker:hasPrivilege("Staff Permissions - Local Event Chat") end,
     onCanHear = function(speaker, listener)
@@ -234,7 +234,7 @@ lia.chat.register("eventlocal", {
 })
 
 lia.chat.register("event", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("eventDesc"),
     onCanSay = function(speaker) return speaker:hasPrivilege("Staff Permissions - Event Chat") end,
     onCanHear = function() return true end,
@@ -244,7 +244,7 @@ lia.chat.register("event", {
 })
 
 lia.chat.register("ooc", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("oocDesc"),
     onCanSay = function(speaker, text)
         if GetGlobalBool("oocblocked", false) then
@@ -282,7 +282,7 @@ lia.chat.register("ooc", {
 })
 
 lia.chat.register("me's", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("mesDesc"),
     format = "**%s's %s",
     onCanHear = lia.config.get("ChatRange", 280),
@@ -307,7 +307,7 @@ lia.chat.register("me's", {
 })
 
 lia.chat.register("mefarfar", {
-    syntax = "[string action]",
+    syntax = "[string Action]",
     desc = L("mefarfarDesc"),
     format = "**%s %s",
     onChatAdd = function(speaker, text, anonymous)
@@ -332,7 +332,7 @@ lia.chat.register("mefarfar", {
 })
 
 lia.chat.register("help", {
-    syntax = "[string text]",
+    syntax = "[string Text]",
     desc = L("helpDesc"),
     onCanSay = function() return true end,
     onCanHear = function(speaker, listener)

--- a/modules/utilities/doors/commands.lua
+++ b/modules/utilities/doors/commands.lua
@@ -248,7 +248,7 @@ lia.command.add("doortogglehidden", {
 
 lia.command.add("doorsetprice", {
     desc = L("doorsetpriceDesc"),
-    syntax = "[number price]",
+    syntax = "[number Price]",
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
@@ -276,7 +276,7 @@ lia.command.add("doorsetprice", {
 
 lia.command.add("doorsettitle", {
     desc = L("doorsettitleDesc"),
-    syntax = "[string title]",
+    syntax = "[string Title]",
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
@@ -435,7 +435,7 @@ lia.command.add("doorinfo", {
 
 lia.command.add("dooraddfaction", {
     desc = L("dooraddfactionDesc"),
-    syntax = "[string faction]",
+    syntax = "[string Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)
@@ -485,7 +485,7 @@ lia.command.add("dooraddfaction", {
 
 lia.command.add("doorremovefaction", {
     desc = L("doorremovefactionDesc"),
-    syntax = "[string faction]",
+    syntax = "[string Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)
@@ -535,7 +535,7 @@ lia.command.add("doorremovefaction", {
 
 lia.command.add("doorsetclass", {
     desc = L("doorsetclassDesc"),
-    syntax = "[string class]",
+    syntax = "[string Class]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)


### PR DESCRIPTION
## Summary
- allow spaces in command syntax argument names
- document that spaces can be used in syntax examples
- update all command definitions to use Title Case for argument names

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f201fcd248327b4fd897650a9c1ec