### PR TITLE
Add dropdown player selection for command prompts

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -113,6 +113,8 @@ function lia.command.parseSyntaxFields(syntax)
                 typ = "number"
             elseif typ == "bool" or typ == "boolean" then
                 typ = "boolean"
+            elseif typ == "player" or typ == "ply" then
+                typ = "player"
             else
                 valid = false
             end
@@ -266,6 +268,15 @@ else
 
                     inputs[name] = combo
                 end
+            elseif typ == "player" then
+                local combo = vgui.Create("DComboBox", frame)
+                combo:SetPos(100, y)
+                combo:SetSize(300, 30)
+                combo:SetValue("Select Player")
+                for _, ply in ipairs(player.GetAll()) do
+                    combo:AddChoice(ply:Name(), ply:SteamID())
+                end
+                inputs[name] = combo
             elseif typ == "text" or typ == "number" then
                 local textEntry = vgui.Create("DTextEntry", frame)
                 textEntry:SetPos(100, y)
@@ -294,8 +305,9 @@ else
             local args = {}
             for key, typ in pairs(fields) do
                 local value
-                if isfunction(typ) then
-                    value = inputs[key]:GetSelected()
+                if isfunction(typ) or typ == "player" then
+                    local text, data = inputs[key]:GetSelected()
+                    value = data or text
                 elseif typ == "text" or typ == "number" then
                     value = inputs[key]:GetValue()
                 elseif typ == "boolean" then

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -140,7 +140,7 @@ lia.command.add("playtime", {
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = "View Playtime",
-    syntax = "[string Char Name]",
+    syntax = "[player Char Name]",
     AdminStick = {
         Name = L("adminStickGetPlayTimeName"),
         Category = "moderationTools",

--- a/modules/characters/attributes/commands.lua
+++ b/modules/characters/attributes/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = L("setAttributes"),
-    syntax = "[string Player Name] [string Attribute Name] [number Level]",
+    syntax = "[player Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("setAttributes"),
@@ -47,7 +47,7 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = L("checkAttributes"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("checkAttributes"),
@@ -109,7 +109,7 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = L("addAttributes"),
-    syntax = "[string Player Name] [string Attribute Name] [number Level]",
+    syntax = "[player Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = L("addAttributes"),

--- a/modules/characters/inventory/commands.lua
+++ b/modules/characters/inventory/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = L("updateInventorySizeDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -42,7 +42,7 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = L("setInventorySizeDesc"),
-    syntax = "[string Player Name] [number Width] [number Height]",
+    syntax = "[player Player Name] [number Width] [number Height]",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
         if not target or not IsValid(target) then

--- a/modules/core/administration/commands.lua
+++ b/modules/core/administration/commands.lua
@@ -75,7 +75,7 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("sendToSitRoomDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("sendToSitRoom"),
         Category = "moderationTools",
@@ -121,7 +121,7 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = L("returnFromSitroomDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("returnFromSitroom"),
         Category = "moderationTools",

--- a/modules/core/administration/submodules/permissions/commands.lua
+++ b/modules/core/administration/submodules/permissions/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Toggle Permakill",
     desc = L("togglePermakillDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = "Toggle Character Killing (Ban)",
         Category = "characterManagement",
@@ -55,7 +55,7 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = "Play Sounds",
     desc = L("playSoundDesc"),
-    syntax = "[string Player Name] [string Sound]",
+    syntax = "[player Player Name] [string Sound]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -106,7 +106,7 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = "Force Fallover",
     desc = L("forceFalloverDesc"),
-    syntax = "[string Player Name] [number Time]",
+    syntax = "[player Player Name] [number Time]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -150,7 +150,7 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = "Force GetUp",
     desc = L("forceGetUpDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -277,7 +277,7 @@ lia.command.add("checkinventory", {
     adminOnly = true,
     privilege = "Check Inventories",
     desc = L("checkInventoryDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickCheckInventoryName"),
         Category = "characterManagement",
@@ -311,7 +311,7 @@ lia.command.add("flaggive", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("flagGiveDesc"),
-    syntax = "[string Player Name] [string Flags]",
+    syntax = "[player Player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -345,7 +345,7 @@ lia.command.add("flaggiveall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("giveAllFlagsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGiveAllFlagsName"),
         Category = "characterManagement",
@@ -373,7 +373,7 @@ lia.command.add("flagtakeall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("takeAllFlagsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickTakeAllFlagsName"),
         Category = "characterManagement",
@@ -406,7 +406,7 @@ lia.command.add("flagtake", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = L("flagTakeDesc"),
-    syntax = "[string Player Name] [string Flags]",
+    syntax = "[player Player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -591,7 +591,7 @@ lia.command.add("clearinv", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("clearInvDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickClearInventoryName"),
         Category = "characterManagement",
@@ -614,7 +614,7 @@ lia.command.add("charkick", {
     adminOnly = true,
     privilege = "Kick Characters",
     desc = L("kickCharDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickKickCharacterName"),
         Category = "characterManagement",
@@ -645,7 +645,7 @@ lia.command.add("freezeallprops", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("freezeAllPropsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -722,7 +722,7 @@ lia.command.add("checkmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("checkMoneyDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickCheckMoneyName"),
         Category = "characterManagement",
@@ -745,7 +745,7 @@ lia.command.add("listbodygroups", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("listBodygroupsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -790,7 +790,7 @@ lia.command.add("charsetspeed", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setSpeedDesc"),
-    syntax = "[string Player Name] [number Speed]",
+    syntax = "[player Player Name] [number Speed]",
     AdminStick = {
         Name = L("adminStickSetCharSpeedName"),
         Category = "characterManagement",
@@ -816,7 +816,7 @@ lia.command.add("charsetmodel", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setModelDesc"),
-    syntax = "[string Player Name] [string Model]",
+    syntax = "[player Player Name] [string Model]",
     AdminStick = {
         Name = L("adminStickSetCharModelName"),
         Category = "characterManagement",
@@ -845,7 +845,7 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = "Manage Items",
     desc = L("giveItemDesc"),
-    syntax = "[string Player Name] [string Item Name Or ID]",
+    syntax = "[player Player Name] [string Item Name Or ID]",
     AdminStick = {
         Name = L("adminStickGiveItemName"),
         Category = "characterManagement",
@@ -910,7 +910,7 @@ lia.command.add("charsetdesc", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setDescDesc"),
-    syntax = "[string Player Name] [string Description]",
+    syntax = "[player Player Name] [string Description]",
     AdminStick = {
         Name = L("adminStickSetCharDescName"),
         Category = "characterManagement",
@@ -943,7 +943,7 @@ lia.command.add("charsetname", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = L("setNameDesc"),
-    syntax = "[string Player Name] [string New Name]",
+    syntax = "[player Player Name] [string New Name]",
     AdminStick = {
         Name = L("adminStickSetCharNameName"),
         Category = "characterManagement",
@@ -971,7 +971,7 @@ lia.command.add("charsetscale", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setScaleDesc"),
-    syntax = "[string Player Name] [number Scale]",
+    syntax = "[player Player Name] [number Scale]",
     AdminStick = {
         Name = L("adminStickSetCharScaleName"),
         Category = "characterManagement",
@@ -998,7 +998,7 @@ lia.command.add("charsetjump", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setJumpDesc"),
-    syntax = "[string Player Name] [number Power]",
+    syntax = "[player Player Name] [number Power]",
     AdminStick = {
         Name = L("adminStickSetCharJumpName"),
         Category = "characterManagement",
@@ -1025,7 +1025,7 @@ lia.command.add("charsetbodygroup", {
     adminOnly = true,
     privilege = "Manage Bodygroups",
     desc = L("setBodygroupDesc"),
-    syntax = "[string Player Name] [string BodyGroup Name] [number Value]",
+    syntax = "[player Player Name] [string BodyGroup Name] [number Value]",
     onRun = function(client, arguments)
         local name = arguments[1]
         local bodyGroup = arguments[2]
@@ -1054,7 +1054,7 @@ lia.command.add("charsetskin", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = L("setSkinDesc"),
-    syntax = "[string Player Name] [number Skin]",
+    syntax = "[player Player Name] [number Skin]",
     AdminStick = {
         Name = L("adminStickSetCharSkinName"),
         Category = "characterManagement",
@@ -1083,7 +1083,7 @@ lia.command.add("charsetmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("setMoneyDesc"),
-    syntax = "[string Player Name] [number Amount]",
+    syntax = "[player Player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1107,7 +1107,7 @@ lia.command.add("charaddmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = L("addMoneyDesc"),
-    syntax = "[string Player Name] [number Amount]",
+    syntax = "[player Player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1182,7 +1182,7 @@ lia.command.add("forcesay", {
     superAdminOnly = true,
     privilege = "Force Say",
     desc = L("forceSayDesc"),
-    syntax = "[string Player Name] [string Message]",
+    syntax = "[player Player Name] [string Message]",
     AdminStick = {
         Name = "Force Say",
         Category = "moderationTools",
@@ -1226,7 +1226,7 @@ lia.command.add("getmodel", {
 
 lia.command.add("pm", {
     desc = L("pmDesc"),
-    syntax = "[string Player Name] [string Message]",
+    syntax = "[player Player Name] [string Message]",
     onRun = function(client, arguments)
         if not lia.config.get("AllowPMs") then
             client:notifyLocalized("pmsDisabled")
@@ -1254,7 +1254,7 @@ lia.command.add("chargetmodel", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getCharModelDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharModelName"),
         Category = "characterManagement",
@@ -1288,7 +1288,7 @@ lia.command.add("checkflags", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("checkFlagsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharFlagsName"),
         Category = "characterManagement",
@@ -1315,7 +1315,7 @@ lia.command.add("chargetname", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getCharNameDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharNameName"),
         Category = "characterManagement",
@@ -1337,7 +1337,7 @@ lia.command.add("chargethealth", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getHealthDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharHealthName"),
         Category = "characterManagement",
@@ -1359,7 +1359,7 @@ lia.command.add("chargetmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getMoneyDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharMoneyName"),
         Category = "characterManagement",
@@ -1382,7 +1382,7 @@ lia.command.add("chargetinventory", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = L("getInventoryDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("adminStickGetCharInventoryName"),
         Category = "characterManagement",

--- a/modules/core/administration/submodules/tickets/commands.lua
+++ b/modules/core/administration/submodules/tickets/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "View Claims",
     desc = L("plyViewClaimsDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("viewTicketClaims"),
         Category = "moderationTools",

--- a/modules/core/administration/submodules/warns/commands.lua
+++ b/modules/core/administration/submodules/warns/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Issue Warnings",
     desc = L("warnDesc"),
-    syntax = "[string Target] [string Reason]",
+    syntax = "[player Target] [string Reason]",
     AdminStick = {
         Name = L("warnPlayer"),
         Category = "moderationTools",
@@ -41,7 +41,7 @@ lia.command.add("viewwarns", {
     adminOnly = true,
     privilege = "View Player Warnings",
     desc = L("viewWarnsDesc"),
-    syntax = "[string Target]",
+    syntax = "[player Target]",
     AdminStick = {
         Name = L("viewPlayerWarnings"),
         Category = "moderationTools",

--- a/modules/core/spawns/commands.lua
+++ b/modules/core/spawns/commands.lua
@@ -90,7 +90,7 @@ lia.command.add("returnitems", {
     superAdminOnly = true,
     privilege = "Return Items",
     desc = L("returnItemsDesc"),
-    syntax = "[string Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = L("returnItemsName"),
         Category = "characterManagement",

--- a/modules/core/teams/commands.lua
+++ b/modules/core/teams/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Manage Transfers",
     desc = L("plyTransferDesc"),
-    syntax = "[string Name] [string Faction]",
+    syntax = "[player Name] [string Faction]",
     alias = {"charsetfaction"},
     onRun = function(client, arguments)
         local targetPlayer = lia.util.findPlayer(client, arguments[1])
@@ -39,7 +39,7 @@ lia.command.add("plywhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyWhitelistDesc"),
-    syntax = "[string Name] [string Faction]",
+    syntax = "[player Name] [string Faction]",
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -62,7 +62,7 @@ lia.command.add("plyunwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyUnwhitelistDesc"),
-    syntax = "[string Name] [string Faction]",
+    syntax = "[player Name] [string Faction]",
     alias = {"factionunwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -112,7 +112,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("setClassDesc"),
-    syntax = "[string Player Name] [string Class]",
+    syntax = "[player Player Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -143,7 +143,7 @@ lia.command.add("classwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("classWhitelistDesc"),
-    syntax = "[string Name] [string Class]",
+    syntax = "[player Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))
@@ -173,7 +173,7 @@ lia.command.add("classunwhitelist", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("classUnwhitelistDesc"),
-    syntax = "[string Name] [string Class]",
+    syntax = "[player Name] [string Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))

--- a/modules/frameworkui/chatbox/commands.lua
+++ b/modules/frameworkui/chatbox/commands.lua
@@ -4,7 +4,7 @@ lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
     desc = L("banOOCCommandDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("banOOCCommandName"),
         Category = "moderationTools",
@@ -28,7 +28,7 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = "Unban OOC",
     desc = L("unbanOOCCommandDesc"),
-    syntax = "[string Player Name]",
+    syntax = "[player Player Name]",
     AdminStick = {
         Name = L("unbanOOCCommandName"),
         Category = "moderationTools",


### PR DESCRIPTION
## Summary
- support `[player]` argument type in command syntax
- populate player dropdowns in argument prompts
- retrieve selected player's SteamID
- update many commands to use the new `[player]` syntax

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f2846d30c832794a2319cdfb0fd64