### PR TITLE
Streamline Admin Stick prompts

### DIFF
--- a/docs/docs/framework/definitions/command.md
+++ b/docs/docs/framework/definitions/command.md
@@ -127,7 +127,8 @@ desc = L("doorbuyDesc")
 * `Category` (string): Top-level grouping.
 * `SubCategory` (string): Secondary grouping.
 * `Icon` (string): 16×16 icon path.
-* `ExtraFields` (table): Additional field definitions as key→type.
+* `ExtraFields` (table, optional): Legacy way to define extra argument fields.
+  Missing arguments are now prompted automatically using the command's `syntax`.
 
 **Example:**
 
@@ -136,10 +137,7 @@ AdminStick = {
     Name        = "Set Character Skin",
     Category    = "Player Information",
     SubCategory = "Set Attributes",
-    Icon        = "icon16/user_gray.png",
-    ExtraFields = {
-        ["skin"] = "number"
-    }
+    Icon        = "icon16/user_gray.png"
 }
 ```
 

--- a/docs/lua/definitions/command_fields.lua
+++ b/docs/lua/definitions/command_fields.lua
@@ -83,17 +83,15 @@
             Category    - top level grouping.
             SubCategory - secondary grouping.
             Icon        - 16x16 icon path.
-            ExtraFields - additional field definitions.
+            ExtraFields - (optional) legacy field definitions. Missing
+            arguments are now prompted automatically using the syntax string.
 
     Example Usage:
             AdminStick = {
                 Name = "Set Character Skin",
                 Category = "Player Informations",
                 SubCategory = "Set Informations",
-                Icon = "icon16/user_gray.png",
-                ExtraFields = {
-                    ["skin"] = "number"
-                }
+                Icon = "icon16/user_gray.png"
             }
 ]]
 

--- a/modules/characters/attributes/commands.lua
+++ b/modules/characters/attributes/commands.lua
@@ -7,17 +7,7 @@
         Name = L("setAttributes"),
         Category = "characterManagement",
         SubCategory = L("attributes"),
-        Icon = "icon16/wrench.png",
-        ExtraFields = {
-            ["attribute"] = function()
-                local attributes = {}
-                for _, v in pairs(lia.attribs.list) do
-                    table.insert(attributes, L(v.name))
-                end
-                return attributes, "combo"
-            end,
-            ["value"] = "text"
-        }
+        Icon = "icon16/wrench.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -115,17 +105,7 @@ lia.command.add("charaddattrib", {
         Name = L("addAttributes"),
         Category = "characterManagement",
         SubCategory = L("attributes"),
-        Icon = "icon16/add.png",
-        ExtraFields = {
-            ["attribute"] = function()
-                local attributes = {}
-                for _, v in pairs(lia.attribs.list) do
-                    table.insert(attributes, L(v.name))
-                end
-                return attributes, "combo"
-            end,
-            ["value"] = "text"
-        }
+        Icon = "icon16/add.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])

--- a/modules/characters/inventory/submodules/vendor/commands.lua
+++ b/modules/characters/inventory/submodules/vendor/commands.lua
@@ -53,10 +53,7 @@ lia.command.add("resetallvendormoney", {
     syntax = "[number Amount]",
     AdminStick = {
         Name = L("resetAllVendorMoneyStickName"),
-        TargetClass = "lia_vendor",
-        ExtraFields = {
-            [L("amount")] = "text"
-        }
+        TargetClass = "lia_vendor"
     },
     onRun = function(client, arguments)
         local amount = tonumber(arguments[1])
@@ -82,10 +79,7 @@ lia.command.add("restockvendormoney", {
     syntax = "[number Amount]",
     AdminStick = {
         Name = L("restockVendorMoneyStickName"),
-        TargetClass = "lia_vendor",
-        ExtraFields = {
-            [L("amount")] = "text"
-        }
+        TargetClass = "lia_vendor"
     },
     onRun = function(client, arguments)
         local target = client:getTracedEntity()

--- a/modules/core/administration/submodules/adminstick/libraries/client.lua
+++ b/modules/core/administration/submodules/adminstick/libraries/client.lua
@@ -369,12 +369,10 @@ local function AddCommandToMenu(menu, data, key, tgt, name, stores)
     local ic = data.AdminStick.Icon or "icon16/page.png"
     m:AddOption(L(name), function()
         local id = GetIdentifier(tgt)
-        if data.AdminStick.ExtraFields and table.Count(data.AdminStick.ExtraFields) > 0 then
-            lia.command.openArgumentPrompt(key, data.AdminStick.ExtraFields, id ~= "" and id or nil)
-        else
-            if id ~= "" then cl:ConCommand("say /" .. key .. " " .. id) end
-            AdminStickIsOpen = false
-        end
+        local cmd = "say /" .. key
+        if id ~= "" then cmd = cmd .. " " .. id end
+        cl:ConCommand(cmd)
+        AdminStickIsOpen = false
     end):SetIcon(ic)
 end
 

--- a/modules/core/administration/submodules/permissions/commands.lua
+++ b/modules/core/administration/submodules/permissions/commands.lua
@@ -795,10 +795,7 @@ lia.command.add("charsetspeed", {
         Name = L("adminStickSetCharSpeedName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/lightning.png",
-        ExtraFields = {
-            ["speed"] = "text"
-        }
+        Icon = "icon16/lightning.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -821,10 +818,7 @@ lia.command.add("charsetmodel", {
         Name = L("adminStickSetCharModelName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/user_gray.png",
-        ExtraFields = {
-            ["model"] = "text"
-        }
+        Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -850,16 +844,7 @@ lia.command.add("chargiveitem", {
         Name = L("adminStickGiveItemName"),
         Category = "characterManagement",
         SubCategory = L("items"),
-        Icon = "icon16/user_gray.png",
-        ExtraFields = {
-            ["item"] = function()
-                local items = {}
-                for _, v in pairs(lia.item.list) do
-                    table.insert(items, v.name)
-                end
-                return items, "combo"
-            end
-        }
+        Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
         local itemName = arguments[2]
@@ -915,10 +900,7 @@ lia.command.add("charsetdesc", {
         Name = L("adminStickSetCharDescName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/user_comment.png",
-        ExtraFields = {
-            ["desc"] = "text"
-        }
+        Icon = "icon16/user_comment.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -948,10 +930,7 @@ lia.command.add("charsetname", {
         Name = L("adminStickSetCharNameName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/user_edit.png",
-        ExtraFields = {
-            ["newName"] = "text"
-        }
+        Icon = "icon16/user_edit.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -976,10 +955,7 @@ lia.command.add("charsetscale", {
         Name = L("adminStickSetCharScaleName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/arrow_out.png",
-        ExtraFields = {
-            ["value"] = "text"
-        }
+        Icon = "icon16/arrow_out.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -1003,10 +979,7 @@ lia.command.add("charsetjump", {
         Name = L("adminStickSetCharJumpName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/arrow_up.png",
-        ExtraFields = {
-            ["power"] = "text"
-        }
+        Icon = "icon16/arrow_up.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -1059,10 +1032,7 @@ lia.command.add("charsetskin", {
         Name = L("adminStickSetCharSkinName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategorySetInfos"),
-        Icon = "icon16/user_gray.png",
-        ExtraFields = {
-            ["skin"] = "text"
-        }
+        Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
         local name = arguments[1]
@@ -1187,10 +1157,7 @@ lia.command.add("forcesay", {
         Name = "Force Say",
         Category = "moderationTools",
         SubCategory = L("misc"),
-        Icon = "icon16/comments.png",
-        ExtraFields = {
-            ["message"] = "text"
-        }
+        Icon = "icon16/comments.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])

--- a/modules/core/administration/submodules/warns/commands.lua
+++ b/modules/core/administration/submodules/warns/commands.lua
@@ -7,10 +7,7 @@
         Name = L("warnPlayer"),
         Category = "moderationTools",
         SubCategory = L("warnings"),
-        Icon = "icon16/error.png",
-        ExtraFields = {
-            [L("warning")] = "text"
-        }
+        Icon = "icon16/error.png"
     },
     onRun = function(client, arguments)
         local targetName = arguments[1]

--- a/modules/utilities/doors/commands.lua
+++ b/modules/utilities/doors/commands.lua
@@ -253,10 +253,7 @@ lia.command.add("doorsetprice", {
     privilege = "Manage Doors",
     AdminStick = {
         Name = "Set Door Price",
-        TargetClass = "Door",
-        ExtraFields = {
-            ["price"] = "text"
-        }
+        TargetClass = "Door"
     },
     onRun = function(client, arguments)
         local door = client:getTracedEntity()
@@ -281,10 +278,7 @@ lia.command.add("doorsettitle", {
     privilege = "Manage Doors",
     AdminStick = {
         Name = "Set Door Title",
-        TargetClass = "Door",
-        ExtraFields = {
-            ["title"] = "text"
-        }
+        TargetClass = "Door"
     },
     onRun = function(client, arguments)
         local door = client:getTracedEntity()


### PR DESCRIPTION
## Summary
- remove ExtraFields from all commands

## Testing
- `luacheck -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2b64b5d083278ea98de1702a748f