### PR TITLE
Add gamemode hook docs

### DIFF
--- a/docs/docs/framework/definitions/items.md
+++ b/docs/docs/framework/definitions/items.md
@@ -7,19 +7,19 @@ Unspecified fields will use sensible defaults.
 
 ## Table of Contents
 
-1. [Overview](#overview)  
-2. [Field Summary](#field-summary)  
-3. [Field Details](#field-details)  
-   - [Audio & Interaction](#audio--interaction)  
-   - [Restrictions & Whitelists](#restrictions--whitelists)  
-   - [Inventory & Stacking](#inventory--stacking)  
-   - [Categorization & Metadata](#categorization--metadata)  
-   - [Equipment & Stats](#equipment--stats)  
-   - [Combat & Ammo](#combat--ammo)  
-   - [Visuals & Models](#visuals--models)  
-   - [Entity & Content](#entity--content)  
-   - [Economic & Pricing](#economic--pricing)  
-   - [Behavior & Hooks](#behavior--hooks)  
+1. [Overview](#overview)
+2. [Field Summary](#field-summary)
+3. [Field Details](#field-details)
+   - [Audio & Interaction](#audio--interaction)
+   - [Restrictions & Whitelists](#restrictions--whitelists)
+   - [Inventory & Stacking](#inventory--stacking)
+   - [Categorization & Metadata](#categorization--metadata)
+   - [Equipment & Stats](#equipment--stats)
+   - [Combat & Ammo](#combat--ammo)
+   - [Visuals & Models](#visuals--models)
+   - [Entity & Content](#entity--content)
+   - [Economic & Pricing](#economic--pricing)
+   - [Behavior & Hooks](#behavior--hooks)
 
 ---
 
@@ -90,8 +90,8 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 ### Audio & Interaction
 
 #### `BagSound`
-**Type:** `table`  
-**Description:** Sound played when moving items to/from the bag; specified as `{path, volume}`.  
+**Type:** `table`
+**Description:** Sound played when moving items to/from the bag; specified as `{path, volume}`.
 **Example:**
 ```lua
 ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
@@ -319,6 +319,15 @@ ITEM.category = "Storage"
 ITEM.name = "Example Item"
 ```
 
+#### `desc`
+
+**Type:** `string`
+**Description:** Short description shown to players.
+**Example:**
+```lua
+ITEM.desc = "An example item"
+```
+
 #### `uniqueID`
 
 **Type:** `string`
@@ -371,6 +380,15 @@ ITEM.health = 50
 
 ```lua
 ITEM.attribBoosts = {strength = 5}
+```
+
+#### `isOutfit`
+
+**Type:** `boolean`
+**Description:** Marks the item as an outfit.
+**Example:**
+```lua
+ITEM.isOutfit = true
 ```
 
 #### `newSkin`

--- a/docs/docs/framework/hooks/class_hooks.md
+++ b/docs/docs/framework/hooks/class_hooks.md
@@ -173,4 +173,3 @@ function CLASS:OnTransferred(character)
 end
 ```
 
-```

--- a/docs/docs/framework/hooks/faction_hooks.md
+++ b/docs/docs/framework/hooks/faction_hooks.md
@@ -180,5 +180,3 @@ function FACTION:OnTransferred(character)
     character:setModel(self.models[randomModelIndex])
 end
 ```
-
-```

--- a/docs/docs/framework/hooks/gamemode_hooks.md
+++ b/docs/docs/framework/hooks/gamemode_hooks.md
@@ -1,0 +1,6255 @@
+### `LoadCharInformation()`
+
+    
+    Description:
+    Called after the F1 menu panel is created so additional sections can be added.
+    Populates the character information sections of the F1 menu.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds a custom hunger info field after the menu is ready.
+    hook.Add("LoadCharInformation", "AddHungerField", function()
+    local char = LocalPlayer():getChar()
+    if char then
+    hook.Run("AddTextField", L("generalInfo"), "hunger", "Hunger", function()
+    return char:getData("hunger", 0) .. "%"
+    end)
+    end
+    end)
+
+### `CreateMenuButtons(tabs)`
+
+    
+    Description:
+    Executed during menu creation allowing you to define custom tabs.
+    Allows modules to insert additional tabs into the F1 menu.
+    
+    Parameters:
+    tabs (table) – Table to add menu definitions to.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Inserts a custom "Help" tab listing available commands.
+    hook.Add("CreateMenuButtons", "AddHelpTab", function(tabs)
+    tabs.help = {
+    text = "Help",
+    panel = function()
+    local pnl = vgui.Create("DPanel")
+    pnl:Dock(FILL)
+    local label = vgui.Create("DLabel", pnl)
+    local commands = {}
+    for k in pairs(lia.command.list) do
+    commands[#commands + 1] = k
+    end
+    label:SetText(table.concat(commands, "\n"))
+    label:Dock(FILL)
+    label:SetFont("DermaDefault")
+    return pnl
+    end
+    }
+    end)
+
+### `DrawLiliaModelView(panel, entity)`
+
+    
+    Description:
+    Runs every frame when the character model panel draws.
+    Lets code draw over the model view used in character menus.
+    
+    Parameters:
+    panel (Panel) – The model panel being drawn.
+    entity (Entity) – Model entity displayed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Overlays the player's name above the preview model.
+    hook.Add("DrawLiliaModelView", "ShowName", function(panel, entity)
+    local char = LocalPlayer():getChar()
+    if not char then return end
+    draw.SimpleTextOutlined(char:getName(), "Trebuchet24",
+    panel:GetWide() / 2, 8, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, 1, color_black)
+    end)
+
+### `ShouldAllowScoreboardOverride(client, field)`
+
+    
+    Description:
+    Determines if a scoreboard field such as a player's name or model can be replaced.
+    
+    Parameters:
+    client (Player) – Player being displayed.
+    field (string) – Field name such as "name" or "model".
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – Return true to allow override
+    
+    Example Usage:
+    -- Allows other hooks to replace player names on the scoreboard.
+    hook.Add("ShouldAllowScoreboardOverride", "OverrideNames", function(ply, field)
+    if field == "name" then return true end
+    end)
+
+### `GetDisplayedName(client)`
+
+    
+    Description:
+    Returns the name text to display for a player in UI panels.
+    
+    Parameters:
+    client (Player) – Player to query.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string or nil – Name text to display
+    
+    Example Usage:
+    -- Displays player names with an admin prefix.
+    hook.Add("GetDisplayedName", "AdminPrefix", function(ply)
+    if ply:IsAdmin() then
+    return "[ADMIN] " .. ply:Nick()
+    end
+    end)
+
+### `PlayerEndVoice(client)`
+
+    
+    Description:
+    Fired when the voice panel for a player is removed from the HUD.
+    
+    Parameters:
+    client (Player) – Player whose panel ended.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Announces in chat and plays a sound when someone stops using voice chat.
+    hook.Add("PlayerEndVoice", "NotifyVoiceStop", function(ply)
+    chat.AddText(Color(200, 200, 255), ply:Nick() .. " stopped talking")
+    surface.PlaySound("buttons/button19.wav")
+    end)
+
+### `SpawnlistContentChanged(icon)`
+
+    
+    Description:
+    Triggered when a spawn icon is removed from the extended spawn menu.
+    Fired when content is removed from the spawn menu.
+    
+    Parameters:
+    icon (Panel) – Icon affected.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Plays a sound and prints which model was removed from the spawn menu.
+    hook.Add("SpawnlistContentChanged", "IconRemovedNotify", function(icon)
+    surface.PlaySound("buttons/button9.wav")
+    local name = icon:GetSpawnName() or icon:GetModelName() or tostring(icon)
+    print("Removed spawn icon", name)
+    end)
+
+### `ItemPaintOver(panel, itemTable, width, height)`
+
+    
+    Description:
+    Gives a chance to draw additional info over item icons.
+    Allows drawing over item icons in inventories.
+    
+    Parameters:
+    panel (Panel) – Icon panel.
+    itemTable (table) – Item data.
+    width (number) – Panel width.
+    height (number) – Panel height.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Draws the item quantity in the bottom-right corner.
+    hook.Add("ItemPaintOver", "ShowQuantity", function(panel, item, w, h)
+    draw.SimpleText(item.qty or 1, "DermaDefault", w - 4, h - 4, color_white, TEXT_ALIGN_RIGHT, TEXT_ALIGN_BOTTOM)
+    end)
+
+### `OnCreateItemInteractionMenu(panel, menu, itemTable)`
+
+    
+    Description:
+    Allows extensions to populate the right-click menu for an item.
+    Allows overriding the context menu for an item icon.
+    
+    Parameters:
+    panel (Panel) – Icon panel.
+    menu (Panel) – Menu being built.
+    itemTable (table) – Item data.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds an "Inspect" choice to an item's context menu.
+    hook.Add("OnCreateItemInteractionMenu", "AddInspect", function(panel, menu, item)
+    menu:AddOption("Inspect", function() print("Inspecting", item.name) end)
+    end)
+
+### `CanRunItemAction(itemTable, action)`
+
+    
+    Description:
+    Determines whether an item action should be displayed.
+    Determines whether a specific item action is allowed.
+    
+    Parameters:
+    itemTable (table) – Item data.
+    action (string) – Action key.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – True if the action can run.
+    
+    Example Usage:
+    -- Disables the drop action for all items.
+    hook.Add("CanRunItemAction", "BlockDrop", function(item, action)
+    if action == "drop" then return false end
+    end)
+
+### `GetMaxStartingAttributePoints(client, context)`
+
+    
+    Description:
+    Lets you change how many attribute points a new character receives.
+    Retrieves the maximum attribute points available at character creation.
+    
+    Parameters:
+    client (Player) – Viewing player.
+    context (string) – Creation context.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number – Maximum starting points
+    
+    Example Usage:
+    -- Gives every new character 60 starting points.
+    hook.Add("GetMaxStartingAttributePoints", "DoublePoints", function(client)
+    return 60
+    end)
+
+### `GetAttributeStartingMax(client, attribute)`
+
+    
+    Description:
+    Sets a limit for a specific attribute at character creation.
+    Returns the starting maximum for a specific attribute.
+    
+    Parameters:
+    client (Player) – Viewing player.
+    attribute (string) – Attribute identifier.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number – Maximum starting value
+    
+    Example Usage:
+    -- Limits the Strength attribute to a maximum of 20.
+    hook.Add("GetAttributeStartingMax", "CapStrength", function(client, attribute)
+    if attribute == "strength" then return 20 end
+    end)
+
+### `ShouldShowPlayerOnScoreboard(player)`
+
+    
+    Description:
+    Return false to omit players from the scoreboard.
+    Determines if a player should appear on the scoreboard.
+    
+    Parameters:
+    player (Player) – Player to test.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to hide the player
+    
+    Example Usage:
+    -- Stops bots from showing up on the scoreboard.
+    hook.Add("ShouldShowPlayerOnScoreboard", "HideBots", function(ply)
+    if ply:IsBot() then return false end
+    end)
+
+### `ShowPlayerOptions(player, options)`
+
+    
+    Description:
+    Populate the scoreboard context menu with extra options.
+    Allows modules to add scoreboard options for a player.
+    
+    Parameters:
+    player (Player) – Target player.
+    options (table) – Options table to populate.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds a friendly "Wave" choice in the scoreboard menu.
+    hook.Add("ShowPlayerOptions", "WaveOption", function(ply, options)
+    options[#options + 1] = {
+    name = "Wave",
+    func = function()
+    RunConsoleCommand("say", "/me waves to " .. ply:Nick())
+    LocalPlayer():ConCommand("act wave")
+    end
+    }
+    end)
+
+### `GetDisplayedDescription(player, isOOC)`
+
+    
+    Description:
+    Supplies the description text shown on the scoreboard.
+    Returns the description text to display for a player.
+    
+    Parameters:
+    player (Player) – Target player.
+    isOOC (boolean) – Whether OOC description is requested.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string – Description text
+    
+    Example Usage:
+    -- Shows an OOC description when requested by the scoreboard.
+    hook.Add("GetDisplayedDescription", "OOCDesc", function(ply, isOOC)
+    if isOOC then return ply:GetNWString("oocDesc", "") end
+    end)
+
+### `ChatTextChanged(text)`
+
+    
+    Description:
+    Runs whenever the chat entry text is modified.
+    Called whenever the chat entry text changes.
+    
+    Parameters:
+    text (string) – Current text.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Displays a hint when the user types "/help".
+    hook.Add("ChatTextChanged", "CommandHint", function(text)
+    if text == "/help" then chat.AddText("Type /commands for commands list") end
+    end)
+
+### `FinishChat()`
+
+    
+    Description:
+    Fires when the chat box closes.
+    Fired when the chat box is closed.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Fade out the chat box when it closes.
+    hook.Add("FinishChat", "ChatClosed", function()
+    if IsValid(lia.gui.chat) then
+    lia.gui.chat:AlphaTo(0, 0.2, 0, function() lia.gui.chat:Remove() end)
+    end
+    end)
+
+### `StartChat()`
+
+    
+    Description:
+    Fires when the chat box opens.
+    Fired when the chat box is opened.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Plays a sound and focuses the chat window when it opens.
+    hook.Add("StartChat", "ChatOpened", function()
+    surface.PlaySound("buttons/lightswitch2.wav")
+    if IsValid(lia.gui.chat) then
+    lia.gui.chat:MakePopup()
+    end
+    end)
+
+### `ChatAddText(text, ...)`
+
+    
+    Description:
+    Allows modification of the markup before chat messages are printed.
+    Allows modification of markup before chat text is shown.
+    
+    Parameters:
+    text (string) – Base markup text.
+    ... – Additional segments.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string – Modified markup text.
+    
+    Example Usage:
+    -- Turns chat messages green and prefixes the time before they appear.
+    hook.Add("ChatAddText", "GreenSystem", function(text, ...)
+    local stamp = os.date("[%H:%M] ")
+    return Color(0,255,0), stamp .. text, ...
+    end)
+
+### `DisplayItemRelevantInfo(extra, client, item)`
+
+    
+    Description:
+    Add extra lines to an item tooltip.
+    Populates additional information for an item tooltip.
+    
+    Parameters:
+    extra (table) – Info table to fill.
+    client (Player) – Local player.
+    item (table) – Item being displayed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds the item's weight to its tooltip.
+    hook.Add("DisplayItemRelevantInfo", "ShowWeight", function(extra, client, item)
+    extra[#extra + 1] = "Weight: " .. (item.weight or 0)
+    end)
+
+### `GetMainMenuPosition(character)`
+
+    
+    Description:
+    Returns the camera position and angle for the main menu character preview.
+    Provides the camera position and angle for the main menu model.
+    
+    Parameters:
+    character (Character) – Character being viewed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    Vector, Angle – Position and angle values.
+    
+    Example Usage:
+    -- Positions the main menu camera with a slight offset.
+    hook.Add("GetMainMenuPosition", "OffsetCharView", function(character)
+    return Vector(30, 10, 60), Angle(0, 30, 0)
+    end)
+
+### `CanDeleteChar(characterID)`
+
+    
+    Description:
+    Return false here to prevent character deletion.
+    Determines if a character can be deleted.
+    
+    Parameters:
+    characterID (number) – Identifier of the character.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to disallow deletion.
+    
+    Example Usage:
+    -- Blocks deletion of the first character slot.
+    hook.Add("CanDeleteChar", "ProtectSlot1", function(id)
+    if id == 1 then return false end
+    end)
+
+### `LoadMainMenuInformation(info, character)`
+
+    
+    Description:
+    Lets modules insert additional information on the main menu info panel.
+    Allows modules to populate extra information on the main menu panel.
+    
+    Parameters:
+    info (table) – Table to receive information.
+    character (Character) – Selected character.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds the character's faction to the menu info panel.
+    hook.Add("LoadMainMenuInformation", "AddFactionInfo", function(info, character)
+    info.faction = character:getFaction() or "Citizen"
+    end)
+
+### `CanPlayerCreateChar(player)`
+
+    
+    Description:
+    Checks if the local player may start creating a character.
+    Determines if the player may create a new character.
+    
+    Parameters:
+    player (Player) – Local player.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to disallow creation.
+    
+    Example Usage:
+    -- Restricts character creation to admins only.
+    hook.Add("CanPlayerCreateChar", "AdminsOnly", function(ply)
+    if not ply:IsAdmin() then return false end
+    end)
+
+### `ModifyCharacterModel(entity, character)`
+
+    
+    Description:
+    Lets you edit the clientside model used in the main menu.
+    Allows adjustments to the character model in menus.
+    
+    Parameters:
+    entity (Entity) – Model entity.
+    character (Character) – Character data.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Changes a bodygroup on the preview model.
+    hook.Add("ModifyCharacterModel", "ApplyBodygroup", function(ent, character)
+    ent:SetBodygroup(2, 1)
+    end)
+
+### `ConfigureCharacterCreationSteps(panel)`
+
+    
+    Description:
+    Add or reorder steps in the character creation flow.
+    Lets modules alter the character creation step layout.
+    
+    Parameters:
+    panel (Panel) – Creation panel.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds a custom "background" step to the character creator.
+    hook.Add("ConfigureCharacterCreationSteps", "InsertBackground", function(panel)
+    panel:AddStep("background")
+    end)
+
+### `GetMaxPlayerChar(player)`
+
+    
+    Description:
+    Override to change how many characters a player can have.
+    Returns the maximum number of characters a player can have.
+    
+    Parameters:
+    player (Player) – Local player.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number – Maximum character count.
+    
+    Example Usage:
+    -- Gives admins extra character slots.
+    hook.Add("GetMaxPlayerChar", "AdminSlots", function(ply)
+    return ply:IsAdmin() and 10 or 5
+    end)
+
+### `ShouldMenuButtonShow(name)`
+
+    
+    Description:
+    Return false and a reason to hide buttons on the main menu.
+    Determines if a button should be visible on the main menu.
+    
+    Parameters:
+    name (string) – Button identifier.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean, string – False and reason to hide.
+    
+    Example Usage:
+    -- Hides the delete button when the feature is locked.
+    hook.Add("ShouldMenuButtonShow", "HideDelete", function(name)
+    if name == "delete" then return false, "Locked" end
+    end)
+
+### `ResetCharacterPanel()`
+
+    
+    Description:
+    Called when the character creation panel should reset.
+    Called to reset the character creation panel.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Notifies whenever the creation panel resets.
+    hook.Add("ResetCharacterPanel", "ClearFields", function()
+    print("Character creator reset")
+    end)
+
+### `EasyIconsLoaded()`
+
+    
+    Description:
+    Notifies when the EasyIcons font sheet has loaded.
+    Fired when the EasyIcons library has loaded.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Rebuild icons using the font after it loads.
+    hook.Add("EasyIconsLoaded", "Notify", function()
+    surface.SetFont("liaEasyIcons")
+    chat.AddText(Color(0, 255, 200), "EasyIcons font loaded!")
+    hook.Run("RefreshFonts")
+    end)
+
+### `CAMI.OnUsergroupRegistered(usergroup, source)`
+
+    
+    Description:
+    Called when CAMI registers a new usergroup.
+    CAMI notification that a usergroup was registered.
+    
+    Parameters:
+    usergroup (table) – Registered usergroup data.
+    source (string) – Source identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Logs newly registered CAMI usergroups.
+    hook.Add("CAMI.OnUsergroupRegistered", "LogGroup", function(group)
+    print("Registered group:", group.Name)
+    end)
+
+### `CAMI.OnUsergroupUnregistered(usergroup, source)`
+
+    
+    Description:
+    Called when a usergroup is removed from CAMI.
+    CAMI notification that a usergroup was removed.
+    
+    Parameters:
+    usergroup (table) – Unregistered usergroup data.
+    source (string) – Source identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Logs whenever a usergroup is removed from CAMI.
+    hook.Add("CAMI.OnUsergroupUnregistered", "LogRemoval", function(group)
+    print("Removed group:", group.Name)
+    end)
+
+### `CAMI.OnPrivilegeRegistered(privilege)`
+
+    
+    Description:
+    Fired when a privilege is created in CAMI.
+    CAMI notification that a privilege was registered.
+    
+    Parameters:
+    privilege (table) – Privilege data.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Reports when a new CAMI privilege is registered.
+    hook.Add("CAMI.OnPrivilegeRegistered", "LogPrivilege", function(priv)
+    print("Registered privilege:", priv.Name)
+    end)
+
+### `CAMI.OnPrivilegeUnregistered(privilege)`
+
+    
+    Description:
+    Fired when a privilege is removed from CAMI.
+    CAMI notification that a privilege was unregistered.
+    
+    Parameters:
+    privilege (table) – Privilege data.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Reports when a CAMI privilege is removed.
+    hook.Add("CAMI.OnPrivilegeUnregistered", "LogPrivRemoval", function(priv)
+    print("Removed privilege:", priv.Name)
+    end)
+
+### `CAMI.PlayerHasAccess(handler, actor, privilegeName, callback, target, extra)`
+
+    
+    Description:
+    Allows an override of player privilege checks.
+    Allows external libraries to override privilege checks.
+    
+    Parameters:
+    handler (function) – Default handler.
+    actor (Player) – Player requesting access.
+    privilegeName (string) – Privilege identifier.
+    callback (function) – Callback to receive result.
+    target (Player) – Optional target player.
+    extra (table) – Extra information table.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Lets superadmins bypass privilege checks.
+    hook.Add("CAMI.PlayerHasAccess", "AllowSuperadmins", function(_, actor, priv, cb)
+    if actor:IsSuperAdmin() then cb(true) return true end
+    end)
+
+### `CAMI.SteamIDHasAccess(handler, steamID, privilegeName, callback, targetID, extra)`
+
+    
+    Description:
+    Allows an override of SteamID-based privilege checks.
+    Similar to PlayerHasAccess but for SteamIDs.
+    
+    Parameters:
+    handler (function) – Default handler.
+    steamID (string) – SteamID to check.
+    privilegeName (string) – Privilege identifier.
+    callback (function) – Callback to receive result.
+    targetID (string) – Target SteamID.
+    extra (table) – Extra information table.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Grants access for a specific SteamID.
+    hook.Add("CAMI.SteamIDHasAccess", "AllowSteamID", function(_, steamID, priv, cb)
+    if steamID == "STEAM_0:1:1" then cb(true) return true end
+    end)
+
+### `CAMI.PlayerUsergroupChanged(player, oldGroup, newGroup, source)`
+
+    
+    Description:
+    Notification that a player's group changed.
+    Fired when a player's usergroup has changed.
+    
+    Parameters:
+    player (Player) – Affected player.
+    oldGroup (string) – Previous group.
+    newGroup (string) – New group.
+    source (string) – Source identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Announces when a player's usergroup changes.
+    hook.Add("CAMI.PlayerUsergroupChanged", "AnnounceChange", function(ply, old, new)
+    print(ply:Nick() .. " moved from " .. old .. " to " .. new)
+    end)
+
+### `CAMI.SteamIDUsergroupChanged(steamID, oldGroup, newGroup, source)`
+
+    
+    Description:
+    Notification that a SteamID's group changed.
+    Fired when a SteamID's usergroup has changed.
+    
+    Parameters:
+    steamID (string) – Affected SteamID.
+    oldGroup (string) – Previous group.
+    newGroup (string) – New group.
+    source (string) – Source identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Logs usergroup changes by SteamID.
+    hook.Add("CAMI.SteamIDUsergroupChanged", "LogSIDChange", function(sid, old, new)
+    print(sid .. " changed from " .. old .. " to " .. new)
+    end)
+
+### `TooltipLayout(panel)`
+
+    
+    Description:
+    Customize tooltip sizing and layout before it appears.
+    
+    Parameters:
+    panel (Panel) – Tooltip panel being laid out.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Sets a fixed width for tooltips before layout.
+    hook.Add("TooltipLayout", "FixedWidth", function(panel)
+    panel:SetWide(200)
+    end)
+
+### `TooltipPaint(panel, width, height)`
+
+    
+    Description:
+    Draw custom visuals on the tooltip, returning true skips default painting.
+    
+    Parameters:
+    panel (Panel) – Tooltip panel.
+    width (number) – Panel width.
+    height (number) – Panel height.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds a dark background and skips default paint.
+    hook.Add("TooltipPaint", "BlurBackground", function(panel, w, h)
+    surface.SetDrawColor(0, 0, 0, 200)
+    surface.DrawRect(0, 0, w, h)
+    return true
+    end)
+
+### `TooltipInitialize(panel, target)`
+
+    
+    Description:
+    Runs when a tooltip is opened for a panel.
+    
+    Parameters:
+    panel (Panel) – Tooltip panel.
+    target (Panel) – Target panel that opened the tooltip.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Fades tooltips in when they are created.
+    hook.Add("TooltipInitialize", "SetupFade", function(panel, target)
+    panel:SetAlpha(0)
+    panel:AlphaTo(255, 0.2, 0)
+    end)
+
+### `PlayerLoadout(client)`
+
+    
+    Description:
+    Runs when a player spawns and equips items.
+    Allows modification of the default loadout.
+    
+    Parameters:
+    client (Player) – Player being loaded out.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Gives players a crowbar and ammo on spawn.
+    hook.Add("PlayerLoadout", "GiveCrowbar", function(ply)
+    ply:Give("weapon_crowbar")
+    ply:GiveAmmo(10, "357", true)
+    ply:SelectWeapon("weapon_crowbar")
+    end)
+
+### `PlayerShouldPermaKill(client, inflictor, attacker)`
+
+    
+    Description:
+    Determines if a player's death should permanently kill their character.
+    Return true to mark the character for deletion.
+    
+    Parameters:
+    client (Player) – Player that died.
+    inflictor (Entity) – Damage inflictor.
+    attacker (Entity) – Damage attacker.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – Return true to mark for permanent death
+    
+    Example Usage:
+    -- Prevent permanent death from fall damage.
+    hook.Add("PlayerShouldPermaKill", "NoFallPK", function(ply, inflictor)
+    if inflictor == game.GetWorld() then return false end
+    end)
+
+### `CanPlayerDropItem(client, item)`
+
+    
+    Description:
+    Checks if a player may drop an item.
+    Return false to block dropping.
+    
+    Parameters:
+    client (Player) – Player attempting to drop.
+    item (table) – Item being dropped.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to block dropping
+    
+    Example Usage:
+    -- Disallow dropping locked items.
+    hook.Add("CanPlayerDropItem", "NoLockedDrop", function(ply, item)
+    if item.locked then return false end
+    end)
+
+### `CanPlayerTakeItem(client, item)`
+
+    
+    Description:
+    Determines if a player can pick up an item.
+    Return false to prevent taking.
+    
+    Parameters:
+    client (Player) – Player attempting pickup.
+    item (table) – Item in question.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to prevent pickup
+    
+    Example Usage:
+    -- Block taking admin items.
+    hook.Add("CanPlayerTakeItem", "NoAdminPickup", function(ply, item)
+    if item.adminOnly then return false end
+    end)
+
+### `CanPlayerEquipItem(client, item)`
+
+    
+    Description:
+    Queries if a player can equip an item.
+    Returning false stops the equip action.
+    
+    Parameters:
+    client (Player) – Player equipping.
+    item (table) – Item to equip.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to block equipping
+    
+    Example Usage:
+    -- Allow equipping only if level requirement met.
+    hook.Add("CanPlayerEquipItem", "CheckLevel", function(ply, item)
+    if item.minLevel and ply:getChar():getAttrib("level", 0) < item.minLevel then
+    return false
+    end
+    end)
+
+### `CanPlayerUnequipItem(client, item)`
+
+    
+    Description:
+    Called before an item is unequipped.
+    Return false to keep the item equipped.
+    
+    Parameters:
+    client (Player) – Player unequipping.
+    item (table) – Item being unequipped.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to prevent unequipping
+    
+    Example Usage:
+    -- Prevent unequipping cursed gear.
+    hook.Add("CanPlayerUnequipItem", "Cursed", function(ply, item)
+    if item.cursed then return false end
+    end)
+
+### `PostPlayerSay(client, message, chatType, anonymous)`
+
+    
+    Description:
+    Runs after chat messages are processed.
+    Allows reacting to player chat.
+    
+    Parameters:
+    client (Player) – Speaking player.
+    message (string) – Chat text.
+    chatType (string) – Chat channel.
+    anonymous (boolean) – Whether the message was anonymous.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log all OOC chat.
+    hook.Add("PostPlayerSay", "LogOOC", function(ply, msg, chatType)
+    if chatType == "ooc" then print("[OOC]", ply:Nick(), msg) end
+    end)
+
+### `ShouldSpawnClientRagdoll(client)`
+
+    
+    Description:
+    Decides if a corpse ragdoll should spawn for a player.
+    Return false to skip ragdoll creation.
+    
+    Parameters:
+    client (Player) – Player that died.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to skip ragdoll
+    
+    Example Usage:
+    -- Disable ragdolls for bots.
+    hook.Add("ShouldSpawnClientRagdoll", "NoBotRagdoll", function(ply)
+    if ply:IsBot() then return false end
+    end)
+
+### `SaveData()`
+
+    
+    Description:
+    Called when the framework saves persistent data.
+    Modules can store custom information here.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Save a timestamp to file.
+    hook.Add("SaveData", "RecordTime", function()
+    file.Write("lastsave.txt", os.time())
+    end)
+
+### `PersistenceSave()`
+
+    
+    Description:
+    Fires when map persistence should be written to disk.
+    Allows adding extra persistent entities.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Backs up all persistent entities to a data file whenever saving occurs.
+    hook.Add("PersistenceSave", "BackupEntities", function()
+    local entities = {}
+    for _, ent in ents.Iterator() do
+    if ent:GetPersistent() then
+    entities[#entities + 1] = {
+    class = ent:GetClass(),
+    pos = ent:GetPos(),
+    ang = ent:GetAngles()
+    }
+    end
+    end
+    file.Write("backup/entities.txt", util.TableToJSON(entities, true))
+    end)
+
+### `CanPersistEntity(entity)`
+
+    
+    Description:
+    Invoked before an entity is saved as persistent.
+    Return false to disallow persisting the entity.
+    
+    Parameters:
+    entity (Entity) – Entity being considered for persistence.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to prevent the entity from being saved.
+    
+    Example Usage:
+    -- Skip weapons when marking props permanent.
+    hook.Add("CanPersistEntity", "BlockWeapons", function(entity)
+    if entity:IsWeapon() then return false end
+    end)
+
+### `LoadData()`
+
+    
+    Description:
+    Triggered when stored data should be loaded.
+    Modules can restore custom information here.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Restores map props from a saved JSON file on disk.
+    hook.Add("LoadData", "LoadCustomProps", function()
+    if file.Exists("map/props.txt", "DATA") then
+    local props = util.JSONToTable(file.Read("map/props.txt", "DATA")) or {}
+    for _, info in ipairs(props) do
+    local ent = ents.Create(info.class)
+    if IsValid(ent) then
+    ent:SetPos(info.pos)
+    ent:SetAngles(info.ang)
+    ent:Spawn()
+    ent:Activate()
+    end
+    end
+    end
+    end)
+
+### `PostLoadData()`
+
+    
+    Description:
+    Called after all persistent data has loaded.
+    Useful for post-processing.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Spawns a supply crate at a stored position once everything is loaded.
+    hook.Add("PostLoadData", "SpawnCrate", function()
+    local info = lia.data.get("supplyCrate")
+    if info then
+    local crate = ents.Create("prop_physics")
+    crate:SetModel("models/props_junk/wood_crate001a.mdl")
+    crate:SetPos(info.pos)
+    crate:Spawn()
+    end
+    end)
+
+### `ShouldDataBeSaved()`
+
+    
+    Description:
+    Queries if data saving should occur during shutdown.
+    Return false to cancel saving.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to cancel saving
+    
+    Example Usage:
+    -- Skip saving during quick restarts.
+    hook.Add("ShouldDataBeSaved", "NoSave", function()
+    return game.IsDedicated() and os.getenv("NOSAVE")
+    end)
+
+### `OnCharDisconnect(client, character)`
+
+    
+    Description:
+    Called when a player's character disconnects.
+    Provides a last chance to handle data.
+    
+    Parameters:
+    client (Player) – Disconnecting player.
+    character (Character) – Their character.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Store the character's last position so it can be restored later.
+    hook.Add("OnCharDisconnect", "SaveLogoutPos", function(ply, char)
+    char:setData("logoutPos", ply:GetPos())
+    end)
+
+### `SetupBotPlayer(client)`
+
+    
+    Description:
+    Initializes a bot's character when it first joins.
+    Allows custom bot setup.
+    
+    Parameters:
+    client (Player) – Bot player.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Give the bot a starter pistol and set up a small inventory.
+    hook.Add("SetupBotPlayer", "InitBot", function(bot)
+    local char = bot:getChar()
+    char.vars.inv = {lia.inventory.new("GridInv")}
+    bot:Give("weapon_pistol")
+    end)
+
+### `PlayerLiliaDataLoaded(client)`
+
+    
+    Description:
+    Fired after a player's personal data has loaded.
+    Useful for syncing additional info.
+    
+    Parameters:
+    client (Player) – Player that loaded data.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Cache the player's faction color from saved data for use after their character loads.
+    hook.Add("PlayerLiliaDataLoaded", "CacheFactionColor", function(ply)
+    local fid = ply:getData("factionID", 0)
+    local faction = lia.faction.indices[fid]
+    if faction then
+    ply.cachedFactionColor = faction.color
+    end
+    end)
+
+### `PostPlayerInitialSpawn(client)`
+
+    
+    Description:
+    Runs after the player entity has spawned and data is ready.
+    Allows post-initialization logic.
+    
+    Parameters:
+    client (Player) – Newly spawned player.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Initialize some default variables for new players.
+    hook.Add("PostPlayerInitialSpawn", "SetupTutorialState", function(ply)
+    ply:setNetVar("inTutorial", true)
+    ply:ChatPrint("Welcome! Follow the arrows to begin the tutorial.")
+    end)
+
+### `FactionOnLoadout(client)`
+
+    
+    Description:
+    Gives factions a chance to modify player loadouts.
+    Runs before weapons are equipped.
+    
+    Parameters:
+    client (Player) – Player being equipped.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when FactionOnLoadout is triggered
+    hook.Add("FactionOnLoadout", "GiveRadio", function(ply)
+    if ply:getChar():getFaction() == "police" then
+    ply:Give("weapon_radio")
+    end
+    end)
+
+### `ClassOnLoadout(client)`
+
+    
+    Description:
+    Allows classes to modify the player's starting gear.
+    Executed prior to PostPlayerLoadout.
+    
+    Parameters:
+    client (Player) – Player being equipped.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ClassOnLoadout is triggered
+    hook.Add("ClassOnLoadout", "MedicItems", function(ply)
+    if ply:getChar():getClass() == "medic" then
+    ply:Give("medkit")
+    end
+    end)
+
+### `PostPlayerLoadout(client)`
+
+    
+    Description:
+    Called after the player has been equipped.
+    Last chance to modify the loadout.
+    
+    Parameters:
+    client (Player) – Player loaded out.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PostPlayerLoadout is triggered
+    hook.Add("PostPlayerLoadout", "SetColor", function(ply)
+    ply:SetPlayerColor(Vector(0, 1, 0))
+    end)
+
+### `FactionPostLoadout(client)`
+
+    
+    Description:
+    Runs after faction loadout logic completes.
+    Allows post-loadout tweaks.
+    
+    Parameters:
+    client (Player) – Player affected.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when FactionPostLoadout is triggered
+    hook.Add("FactionPostLoadout", "Shout", function(ply)
+    if ply:getChar():getFaction() == "soldier" then
+    ply:EmitSound("npc/combine_soldier/gear6.wav")
+    end
+    end)
+
+### `ClassPostLoadout(client)`
+
+    
+    Description:
+    Runs after class loadout logic completes.
+    Allows post-loadout tweaks for classes.
+    
+    Parameters:
+    client (Player) – Player affected.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ClassPostLoadout is triggered
+    hook.Add("ClassPostLoadout", "Pose", function(ply)
+    ply:ConCommand("act muscle")
+    end)
+
+### `GetDefaultInventoryType(character)`
+
+    
+    Description:
+    Returns the inventory type used for new characters.
+    Modules can override to provide custom types.
+    
+    Parameters:
+    character (Character) – Character being created.
+    
+    Realm:
+    Server
+    
+    Returns:
+    string – Inventory type
+    
+    Example Usage:
+    -- Prints a message when GetDefaultInventoryType is triggered
+    hook.Add("GetDefaultInventoryType", "UseGrid", function()
+    return "GridInv"
+    end)
+
+### `ShouldDeleteSavedItems()`
+
+    
+    Description:
+    Decides whether saved persistent items should be deleted on load.
+    Return true to wipe them from the database.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – True to delete items
+    
+    Example Usage:
+    -- Remove stored items if too many exist on the map.
+    hook.Add("ShouldDeleteSavedItems", "ClearDrops", function()
+    if table.Count(lia.item.instances) > 1000 then
+    return true
+    end
+    end)
+
+### `OnSavedItemLoaded(items)`
+
+    
+    Description:
+    Called after map items have been loaded from storage.
+    Provides the table of created items.
+    
+    Parameters:
+    items (table) – Loaded item entities.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adjusts item collision settings after loading from storage.
+    hook.Add("OnSavedItemLoaded", "PrintCount", function(items)
+    for _, ent in ipairs(items) do
+    ent:SetCollisionGroup(COLLISION_GROUP_WEAPON)
+    end
+    print("Loaded", #items, "items")
+    end)
+
+### `ShouldDrawEntityInfo(entity)`
+
+    
+    Description:
+    Determines if world-space info should be rendered for an entity.
+    Return false to hide the tooltip.
+    
+    Parameters:
+    entity (Entity) – Entity being considered.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to hide info
+    
+    Example Usage:
+    -- Prints a message when ShouldDrawEntityInfo is triggered
+    hook.Add("ShouldDrawEntityInfo", "HideNPCs", function(ent)
+    if ent:IsNPC() then return false end
+    end)
+
+### `DrawEntityInfo(entity, alpha, position)`
+
+    
+    Description:
+    Allows custom drawing of entity information in the world.
+    Drawn every frame while visible.
+    
+    Parameters:
+    entity (Entity) – Entity to draw info for.
+    alpha (number) – Current alpha value.
+    position (table) – Screen position table.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when DrawEntityInfo is triggered
+    hook.Add("DrawEntityInfo", "LabelProps", function(ent, a, pos)
+    draw.SimpleText(ent:GetClass(), "DermaDefault", pos.x, pos.y, Color(255,255,255,a))
+    end)
+
+### `GetInjuredText(client)`
+
+    
+    Description:
+    Provides the health status text and color for a player.
+    Return a table with text and color values.
+    
+    Parameters:
+    client (Player) – Player to check.
+    
+    Realm:
+    Client
+    
+    Returns:
+    table – {text, color} info
+    
+    Example Usage:
+    -- Prints a message when GetInjuredText is triggered
+    hook.Add("GetInjuredText", "SimpleHealth", function(ply)
+    if ply:Health() <= 20 then return {"Critical", Color(255,0,0)} end
+    end)
+
+### `ShouldDrawPlayerInfo(player)`
+
+    
+    Description:
+    Determines if character info should draw above a player.
+    Return false to suppress drawing.
+    
+    Parameters:
+    player (Player) – Player being rendered.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to hide info
+    
+    Example Usage:
+    -- Prints a message when ShouldDrawPlayerInfo is triggered
+    hook.Add("ShouldDrawPlayerInfo", "HideLocal", function(ply)
+    if ply == LocalPlayer() then return false end
+    end)
+
+### `DrawCharInfo(player, character, info)`
+
+    
+    Description:
+    Allows modules to add lines to the character info display.
+    Called when building the info table.
+    
+    Parameters:
+    player (Player) – Player being displayed.
+    character (Character) – Their character data.
+    info (table) – Table to add lines to.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when DrawCharInfo is triggered
+    hook.Add("DrawCharInfo", "JobTitle", function(ply, char, info)
+    info[#info + 1] = {"Job: " .. (char:getClass() or "None")}
+    end)
+
+### `ItemShowEntityMenu(entity)`
+
+    
+    Description:
+    Opens the context menu for a world item when used.
+    Allows replacing the default menu.
+    
+    Parameters:
+    entity (Entity) – Item entity clicked.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ItemShowEntityMenu is triggered
+    hook.Add("ItemShowEntityMenu", "QuickTake", function(ent)
+    print("Opening menu for", ent)
+    end)
+
+### `PreLiliaLoaded()`
+
+    
+    Description:
+    Fired just before the client finishes loading the framework.
+    Useful for setup tasks.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PreLiliaLoaded is triggered
+    hook.Add("PreLiliaLoaded", "Prep", function()
+    print("About to finish loading")
+    end)
+
+### `LiliaLoaded()`
+
+    
+    Description:
+    Indicates the client finished initializing the framework.
+    Modules can start creating panels here.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when LiliaLoaded is triggered
+    hook.Add("LiliaLoaded", "Ready", function()
+    print("Lilia client ready")
+    end)
+
+### `InventoryDataChanged(inventory, key, oldValue, value)`
+
+    
+    Description:
+    Notifies when inventory metadata changes.
+    Provides old and new values.
+    
+    Parameters:
+    inventory (table) – Inventory affected.
+    key (string) – Data key.
+    oldValue (any) – Previous value.
+    value (any) – New value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InventoryDataChanged is triggered
+    hook.Add("InventoryDataChanged", "TrackWeight", function(inv, k, old, new)
+    if k == "weight" then print("Weight changed to", new) end
+    end)
+
+### `ItemInitialized(item)`
+
+    
+    Description:
+    Called when a new item instance is created clientside.
+    Allows additional setup for the item.
+    
+    Parameters:
+    item (table) – Item created.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ItemInitialized is triggered
+    hook.Add("ItemInitialized", "PrintID", function(item)
+    print("Created item", item.uniqueID)
+    end)
+
+### `InventoryInitialized(inventory)`
+
+    
+    Description:
+    Fired when an inventory instance finishes loading.
+    Modules may modify it here.
+    
+    Parameters:
+    inventory (table) – Inventory initialized.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InventoryInitialized is triggered
+    hook.Add("InventoryInitialized", "AnnounceInv", function(inv)
+    print("Inventory", inv:getID(), "ready")
+    end)
+
+### `InventoryItemAdded(inventory, item)`
+
+    
+    Description:
+    Invoked when an item is placed into an inventory.
+    Lets code react to the addition.
+    
+    Parameters:
+    inventory (table) – Inventory receiving the item.
+    item (table) – Item added.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InventoryItemAdded is triggered
+    hook.Add("InventoryItemAdded", "NotifyAdd", function(inv, item)
+    print("Added", item.name)
+    end)
+
+### `InventoryItemRemoved(inventory, item)`
+
+    
+    Description:
+    Called when an item is removed from an inventory.
+    Runs after the item table is updated.
+    
+    Parameters:
+    inventory (table) – Inventory modified.
+    item (table) – Item removed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InventoryItemRemoved is triggered
+    hook.Add("InventoryItemRemoved", "NotifyRemove", function(inv, item)
+    print("Removed", item.name)
+    end)
+
+### `InventoryDeleted(inventory)`
+
+    
+    Description:
+    Signals that an inventory was deleted clientside.
+    Allows cleanup of references.
+    
+    Parameters:
+    inventory (table) – Deleted inventory.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InventoryDeleted is triggered
+    hook.Add("InventoryDeleted", "Clear", function(inv)
+    print("Inventory", inv:getID(), "deleted")
+    end)
+
+### `ItemDeleted(item)`
+
+    
+    Description:
+    Fired when an item is removed entirely.
+    Modules should clear any cached data.
+    
+    Parameters:
+    item (table) – Item that was deleted.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ItemDeleted is triggered
+    hook.Add("ItemDeleted", "Log", function(item)
+    print("Item", item.uniqueID, "gone")
+    end)
+
+### `OnCharVarChanged(character, key, oldValue, value)`
+
+    
+    Description:
+    Runs when a networked character variable changes.
+    Gives both old and new values.
+    
+    Parameters:
+    character (Character) – Affected character.
+    key (string) – Variable name.
+    oldValue (any) – Previous value.
+    value (any) – New value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnCharVarChanged is triggered
+    hook.Add("OnCharVarChanged", "WatchMoney", function(char, k, old, new)
+    if k == "money" then print("Money changed", new) end
+    end)
+
+### `OnCharLocalVarChanged(character, key, oldVar, value)`
+
+    
+    Description:
+    Similar to OnCharVarChanged but for local-only variables.
+    Called after the table updates.
+    
+    Parameters:
+    character (Character) – Affected character.
+    key (string) – Variable name.
+    oldVar (any) – Old value.
+    value (any) – New value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnCharLocalVarChanged is triggered
+    hook.Add("OnCharLocalVarChanged", "WatchFlags", function(char, k, old, new)
+    if k == "flags" then print("Flags changed") end
+    end)
+
+### `ItemDataChanged(item, key, oldValue, value)`
+
+    
+    Description:
+    Called when item data values change clientside.
+    Provides both the old and new values.
+    
+    Parameters:
+    item (table) – Item modified.
+    key (string) – Key that changed.
+    oldValue (any) – Previous value.
+    value (any) – New value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ItemDataChanged is triggered
+    hook.Add("ItemDataChanged", "TrackDurability", function(item, key)
+    if key == "durability" then print("New durability", item.data[key]) end
+    end)
+
+### `ItemQuantityChanged(item, oldQuantity, quantity)`
+
+    
+    Description:
+    Runs when an item's quantity value updates.
+    Allows reacting to stack changes.
+    
+    Parameters:
+    item (table) – Item affected.
+    oldQuantity (number) – Previous quantity.
+    quantity (number) – New quantity.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when ItemQuantityChanged is triggered
+    hook.Add("ItemQuantityChanged", "CountStacks", function(item, old, new)
+    print("Quantity now", new)
+    end)
+
+### `KickedFromChar(id, isCurrentChar)`
+
+    
+    Description:
+    Indicates that a character was forcefully removed.
+    isCurrentChar denotes if it was the active one.
+    
+    Parameters:
+    id (number) – Character identifier.
+    isCurrentChar (boolean) – Was this the active character?
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when KickedFromChar is triggered
+    hook.Add("KickedFromChar", "Notify", function(id, current)
+    print("Kicked from", id, current and "(current)" or "")
+    end)
+
+### `HandleItemTransferRequest(client, itemID, x, y, inventoryID)`
+
+    
+    Description:
+    Server receives a request to move an item.
+    Modules can validate or modify the transfer.
+    
+    Parameters:
+    client (Player) – Requesting player.
+    itemID (number) – Item identifier.
+    x (number) – X position.
+    y (number) – Y position.
+    inventoryID (number|string) – Target inventory ID.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when HandleItemTransferRequest is triggered
+    hook.Add("HandleItemTransferRequest", "LogMove", function(ply, itemID, x, y)
+    print(ply, "moved item", itemID, "to", x, y)
+    end)
+
+### `CharLoaded(id)`
+
+    
+    Description:
+    Fired when a character object is fully loaded.
+    Receives the character ID.
+    
+    Parameters:
+    id (number) – Character identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharLoaded is triggered
+    hook.Add("CharLoaded", "Notify", function(id)
+    print("Character", id, "loaded")
+    end)
+
+### `PreCharDelete(id)`
+
+    
+    Description:
+    Called before a character is removed.
+    Return false to cancel deletion.
+    
+    Parameters:
+    id (number) – Character identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PreCharDelete is triggered
+    hook.Add("PreCharDelete", "Protect", function(id)
+    if id == 1 then return false end
+    end)
+
+### `OnCharDelete(client, id)`
+
+    
+    Description:
+    Fired when a character is deleted.
+    Provides the owning player if available.
+    
+    Parameters:
+    client (Player) – Player who deleted.
+    id (number) – Character identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnCharDelete is triggered
+    hook.Add("OnCharDelete", "Announce", function(ply, id)
+    print(ply, "deleted char", id)
+    end)
+
+### `OnCharCreated(client, character, data)`
+
+    
+    Description:
+    Invoked after a new character is created.
+    Supplies the character table and creation data.
+    
+    Parameters:
+    client (Player) – Owner player.
+    character (table) – New character object.
+    data (table) – Raw creation info.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnCharCreated is triggered
+    hook.Add("OnCharCreated", "Welcome", function(ply, char)
+    print("Created", char:getName())
+    end)
+
+### `OnTransferred(client)`
+
+    
+    Description:
+    Runs when a player transfers to another server.
+    Useful for cleanup.
+    
+    Parameters:
+    client (Player) – Transferring player.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnTransferred is triggered
+    hook.Add("OnTransferred", "Goodbye", function(ply)
+    print(ply, "left the server")
+    end)
+
+### `CharPreSave(character)`
+
+    
+    Description:
+    Executed before a character is saved to disk.
+    Allows writing custom data.
+    
+    Parameters:
+    character (Character) – Character being saved.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharPreSave is triggered
+    hook.Add("CharPreSave", "Record", function(char)
+    char:setData("lastSave", os.time())
+    end)
+
+### `CharListLoaded(newCharList)`
+
+    
+    Description:
+    Called when the character selection list finishes loading.
+    Provides the loaded list table.
+    
+    Parameters:
+    newCharList (table) – Table of characters.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharListLoaded is triggered
+    hook.Add("CharListLoaded", "CountChars", function(list)
+    print("Loaded", #list, "characters")
+    end)
+
+### `CharListUpdated(oldCharList, newCharList)`
+
+    
+    Description:
+    Fires when the character list is refreshed.
+    Gives both old and new tables.
+    
+    Parameters:
+    oldCharList (table) – Previous list.
+    newCharList (table) – Updated list.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharListUpdated is triggered
+    hook.Add("CharListUpdated", "Diff", function(old, new)
+    print("Characters updated")
+    end)
+
+### `getCharMaxStamina(character)`
+
+    
+    Description:
+    Returns the maximum stamina for a character.
+    Override to change stamina capacity.
+    
+    Parameters:
+    character (Character) – Character queried.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when getCharMaxStamina is triggered
+    hook.Add("getCharMaxStamina", "Double", function(char)
+    return 200
+    end)
+
+### `AdjustStaminaOffsetRunning(client, runCost)`
+
+    
+    Description:
+    Alters the stamina offset applied each tick while sprinting.
+    Return a new cost to modify how quickly stamina drains when running.
+    
+    Parameters:
+    client (Player) – Player that is sprinting.
+    runCost (number) – Proposed stamina cost.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    number – Modified stamina cost.
+    
+    Example Usage:
+    -- Prints a message when AdjustStaminaOffsetRunning is triggered
+    hook.Add("AdjustStaminaOffsetRunning", "EnduranceBonus", function(ply, cost)
+    return cost + ply:getChar():getAttrib("stamina", 0) * -0.01
+    end)
+
+### `AdjustStaminaRegeneration(client, regen)`
+
+    
+    Description:
+    Allows changing how quickly stamina regenerates when not sprinting.
+    Return a new amount to modify regeneration speed.
+    
+    Parameters:
+    client (Player) – Player recovering stamina.
+    regen (number) – Default regeneration per tick.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    number – Modified regeneration amount.
+    
+    Example Usage:
+    -- Prints a message when AdjustStaminaRegeneration is triggered
+    hook.Add("AdjustStaminaRegeneration", "RestAreaBoost", function(ply, amount)
+    if ply:isInSafeZone() then
+    return amount * 2
+    end
+    end)
+
+### `AdjustStaminaOffset(client, offset)`
+
+    
+    Description:
+    Final hook for tweaking the calculated stamina offset.
+    Return the modified offset value to apply each tick.
+    
+    Parameters:
+    client (Player) – Player whose stamina is updating.
+    offset (number) – Current offset after other adjustments.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    number – New offset to apply.
+    
+    Example Usage:
+    -- Prints a message when AdjustStaminaOffset is triggered
+    hook.Add("AdjustStaminaOffset", "MinimumDrain", function(ply, off)
+    return math.max(off, -1)
+    end)
+
+### `PostLoadFonts(currentFont, genericFont)`
+
+    
+    Description:
+    Runs after all font files have loaded.
+    Allows registering additional fonts.
+    
+    Parameters:
+    currentFont (string) – Name of the primary UI font.
+    genericFont (string) – Name of the generic fallback font.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PostLoadFonts is triggered
+    hook.Add("PostLoadFonts", "LogoFont", function()
+    surface.CreateFont("Logo", {size = 32, font = "Tahoma"})
+    end)
+
+### `AddBarField(sectionName, fieldName, labelText, minFunc, maxFunc, valueFunc)`
+
+    
+    Description:
+    Called when the F1 menu builds status bars so new fields can be added.
+    
+    Parameters:
+    sectionName (string) – Section identifier.
+    fieldName (string) – Unique field name.
+    labelText (string) – Display label for the bar.
+    minFunc (function) – Returns the minimum value.
+    maxFunc (function) – Returns the maximum value.
+    valueFunc (function) – Returns the current value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Adds a custom thirst bar next to stamina.
+    hook.Add("AddBarField", "AddThirstBar", function(section, id, label, min, max, value)
+    lia.bar.add(value, Color(0, 150, 255), nil, id)
+    end)
+
+### `AddSection(sectionName, color, priority, location)`
+
+    
+    Description:
+    Fired when building the F1 menu so modules can insert additional sections.
+    
+    Parameters:
+    sectionName (string) – Name of the section.
+    color (Color) – Display color.
+    priority (number) – Sort order priority.
+    location (number) – Column/location index.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Add a custom "Settings" tab.
+    hook.Add("AddSection", "AddSettingsSection", function(name, color, priority)
+    if name == "settings" then
+    color = Color(0, 128, 255)
+    priority = 5
+    end
+    end)
+
+### `CanItemBeTransfered(item, oldInventory, newInventory, client)`
+
+    
+    Description:
+    Determines whether an item may move between inventories.
+    
+    Parameters:
+    item (Item) – Item being transferred.
+    oldInventory (Inventory) – Source inventory.
+    newInventory (Inventory) – Destination inventory.
+    client (Player) – Owning player.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean, string – False and reason to block
+    
+    Example Usage:
+    -- Prevent quest items from being dropped.
+    hook.Add("CanItemBeTransfered", "BlockQuestItemDrop", function(item, newInv, oldInv)
+    if item.isQuest then return false, "Quest items cannot be moved" end
+    end)
+
+### `CanOpenBagPanel(item)`
+
+    
+    Description:
+    Called right before a bag inventory UI opens. Return false to block opening.
+    
+    Parameters:
+    item (Item) – Bag item being opened.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to block opening.
+    
+    Example Usage:
+    -- Disallow bag use while fighting.
+    hook.Add("CanOpenBagPanel", "BlockBagInCombat", function(item)
+    if LocalPlayer():getNetVar("inCombat") then return false end
+    end)
+
+### `CanOutfitChangeModel(item)`
+
+    
+    Description:
+    Checks if an outfit is allowed to change the player model.
+    
+    Parameters:
+    item (Item) – Outfit item attempting to change the model.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to block the change.
+    
+    Example Usage:
+    -- Restrict model swaps for certain factions.
+    hook.Add("CanOutfitChangeModel", "RestrictModelSwap", function(item)
+    if item.factionRestricted then return false end
+    end)
+
+### `CanPerformVendorEdit(client, vendor)`
+
+    
+    Description:
+    Determines if a player can modify a vendor's settings.
+    
+    Parameters:
+    client (Player) – Player attempting the edit.
+    vendor (Entity) – Vendor entity targeted.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to disallow editing.
+    
+    Example Usage:
+    -- Allow only admins to edit vendors.
+    hook.Add("CanPerformVendorEdit", "AdminVendorEdit", function(client)
+    return client:IsAdmin()
+    end)
+
+### `CanPickupMoney(client, moneyEntity)`
+
+    
+    Description:
+    Called when a player attempts to pick up a money entity.
+    
+    Parameters:
+    client (Player) – Player attempting to pick up the money.
+    moneyEntity (Entity) – The money entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to disallow pickup.
+    
+    Example Usage:
+    -- Prevent money pickup while handcuffed.
+    hook.Add("CanPickupMoney", "BlockWhileCuffed", function(client)
+    if client:isHandcuffed() then return false end
+    end)
+
+### `CanPlayerAccessDoor(client, door, access)`
+
+    
+    Description:
+    Determines if a player can open or lock a door entity.
+    
+    Parameters:
+    client (Player) – Player attempting access.
+    door (Entity) – Door entity in question.
+    access (number) – Desired access level.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to deny access.
+    
+    Example Usage:
+    -- Only police can unlock jail cells.
+    hook.Add("CanPlayerAccessDoor", "PoliceDoors", function(client, door, access)
+    if door.isJail and not client:isPolice() then return false end
+    end)
+
+### `CanPlayerAccessVendor(client, vendor)`
+
+    
+    Description:
+    Checks if a player is permitted to open a vendor menu.
+    
+    Parameters:
+    client (Player) – Player requesting access.
+    vendor (Entity) – Vendor entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to deny access.
+    
+    Example Usage:
+    -- Block access unless the vendor allows the player's faction.
+    hook.Add("CanPlayerAccessVendor", "CheckVendorFaction", function(client, vendor)
+    if not vendor:isFactionAllowed(client:Team()) then return false end
+    end)
+
+### `CanPlayerHoldObject(client, entity)`
+
+    
+    Description:
+    Determines if the player can pick up an entity with the hands swep.
+    
+    Parameters:
+    client (Player) – Player attempting to hold the entity.
+    entity (Entity) – Target entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to prevent holding.
+    
+    Example Usage:
+    -- Prevent grabbing heavy physics objects.
+    hook.Add("CanPlayerHoldObject", "WeightLimit", function(client, ent)
+    if ent:GetMass() > 50 then return false end
+    end)
+
+### `CanPlayerInteractItem(client, action, item)`
+
+    
+    Description:
+    Called when a player tries to use or drop an item.
+    
+    Parameters:
+    client (Player) – Player interacting with the item.
+    action (string) – Action name such as "use" or "drop".
+    item (Item) – Item being interacted with.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to block the action.
+    
+    Example Usage:
+    -- Block medkit use inside safe zones.
+    hook.Add("CanPlayerInteractItem", "SafeZoneBlock", function(client, action, item)
+    if action == "use" and item.uniqueID == "medkit" and client:isInSafeZone() then
+    return false
+    end
+    end)
+
+### `CanPlayerKnock(client, door)`
+
+    
+    Description:
+    Called when a player attempts to knock on a door.
+    
+    Parameters:
+    client (Player) – Player knocking.
+    door (Entity) – Door being knocked on.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to block knocking.
+    
+    Example Usage:
+    -- Prevent knocking while disguised.
+    hook.Add("CanPlayerKnock", "BlockDisguisedKnock", function(client, door)
+    if client:getNetVar("disguised") then return false end
+    end)
+
+### `CanPlayerSpawnStorage(client, entity, data)`
+
+    
+    Description:
+    Checks if the player is allowed to spawn a storage container.
+    
+    Parameters:
+    client (Player) – Player attempting to spawn.
+    entity (Entity) – Prop that will become storage.
+    data (table) – Storage definition data.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to deny spawning.
+    
+    Example Usage:
+    -- Limit players to one storage crate.
+    hook.Add("CanPlayerSpawnStorage", "LimitStorage", function(client, ent, data)
+    if client.storageSpawned then return false end
+    end)
+
+### `CanPlayerThrowPunch(client)`
+
+    
+    Description:
+    Called when the fists weapon tries to punch.
+    
+    Parameters:
+    client (Player) – Player performing the punch.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean – False to block punching.
+    
+    Example Usage:
+    -- Prevent punching while restrained.
+    hook.Add("CanPlayerThrowPunch", "NoPunchWhenTied", function(client)
+    if client:IsFlagSet(FL_KNOCKED) then return false end
+    end)
+
+### `CanPlayerTradeWithVendor(client, vendor, itemType, selling)`
+
+    
+    Description:
+    Checks whether a vendor trade is allowed.
+    
+    Parameters:
+    client (Player) – Player attempting the trade.
+    vendor (Entity) – Vendor entity involved.
+    itemType (string) – Item identifier.
+    selling (boolean) – True if the player is selling to the vendor.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean, string – False and reason to deny trade
+    
+    Example Usage:
+    -- Block selling stolen goods.
+    hook.Add("CanPlayerTradeWithVendor", "DisallowStolenItems", function(client, vendor, itemType, selling)
+    if lia.stolen[itemType] then return false, "Stolen items" end
+    end)
+
+### `CanPlayerViewInventory()`
+
+    
+    Description:
+    Called before any inventory menu is shown.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – False to prevent opening
+    
+    Example Usage:
+    -- Prevent opening inventory while in a cutscene.
+    hook.Add("CanPlayerViewInventory", "BlockDuringCutscene", function()
+    return not LocalPlayer():getNetVar("cutscene")
+    end)
+
+### `CanSaveData(entity, inventory)`
+
+    
+    Description:
+    Called before persistent storage saves.
+    
+    Parameters:
+    entity (Entity) – Storage entity being saved.
+    inventory (Inventory) – Inventory associated with the entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to cancel saving
+    
+    Example Usage:
+    -- Disable saving during special events.
+    hook.Add("CanSaveData", "NoEventSaves", function(entity, inv)
+    if lia.eventActive then return false end
+    end)
+
+### `CharHasFlags(character, flags)`
+
+    
+    Description:
+    Allows custom checks for a character's permission flags.
+    
+    Parameters:
+    character (Character) – Character to check.
+    flags (string) – Flags being queried.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Grant extra access for characters owned by admins.
+    hook.Add("CharHasFlags", "AdminExtraFlags", function(char, flags)
+    local ply = char:getPlayer()
+    if IsValid(ply) and ply:IsAdmin() and flags == "a" then
+    return true
+    end
+    end)
+
+### `CharPostSave(character)`
+
+    
+    Description:
+    Runs after a character's data has been saved to the database.
+    
+    Parameters:
+    character (Character) – Character that finished saving.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log every time characters save data.
+    hook.Add("CharPostSave", "LogCharSaves", function(char)
+    print(char:getName() .. " saved")
+    end)
+
+### `DatabaseConnected()`
+
+    
+    Description:
+    Fired after the database has been successfully connected.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prepare custom tables once the DB connects.
+    hook.Add("DatabaseConnected", "CreateCustomTables", function()
+    lia.db.query("CREATE TABLE IF NOT EXISTS extras(id INT)")
+    end)
+
+### `DrawItemDescription(entity, x, y, color, alpha)`
+
+    
+    Description:
+    Called when an item entity draws its description text.
+    
+    Parameters:
+    entity (Entity) – Item entity being drawn.
+    x (number) – X screen position.
+    y (number) – Y screen position.
+    color (Color) – Text color.
+    alpha (number) – Current alpha value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Display remaining uses next to item name.
+    hook.Add("DrawItemDescription", "AddUseCount", function(item, x, y, color, alpha)
+    draw.SimpleText("Uses: " .. item:getData("uses", 0), "DermaDefault", x, y + 20, color)
+    end)
+
+### `GetAttributeMax(client, attribute)`
+
+    
+    Description:
+    Returns the maximum value allowed for an attribute.
+    
+    Parameters:
+    client (Player) – Player being queried.
+    attribute (string) – Attribute identifier.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    number – Maximum attribute value
+    
+    Example Usage:
+    -- Increase stamina cap for admins.
+    hook.Add("GetAttributeMax", "AdminStamina", function(client, attrib)
+    if attrib == "stamina" and client:IsAdmin() then
+    return 150
+    end
+    end)
+
+### `GetDefaultInventorySize(client)`
+
+    
+    Description:
+    Returns the default width and height for new inventories.
+    
+    Parameters:
+    client (Player) – Player the inventory belongs to.
+    
+    Realm:
+    Server
+    
+    Returns:
+    number, number – Width and height
+    
+    Example Usage:
+    -- Expand default bags for admins.
+    hook.Add("GetDefaultInventorySize", "AdminBags", function(client)
+    if client:IsAdmin() then
+    return 6, 6
+    end
+    end)
+
+### `GetMoneyModel(amount)`
+
+    
+    Description:
+    Allows overriding the entity model used for dropped money.
+    
+    Parameters:
+    amount (number) – Money amount being dropped.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    string – Model path to use
+    
+    Example Usage:
+    -- Use a golden model for large sums.
+    hook.Add("GetMoneyModel", "GoldMoneyModel", function(amount)
+    if amount > 5000 then return "models/props_lab/box01a.mdl" end
+    end)
+
+### `GetPlayerPunchDamage(client, damage, context)`
+
+    
+    Description:
+    Lets addons modify how much damage the fists weapon deals.
+    
+    Parameters:
+    client (Player) – Punching player.
+    damage (number) – Base damage value.
+    context (table) – Additional context table.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Scale punch damage by strength attribute.
+    hook.Add("GetPlayerPunchDamage", "StrengthPunch", function(client, dmg, context)
+    return dmg * (1 + client:getChar():getAttrib("str", 0) / 100)
+    end)
+
+### `InterceptClickItemIcon(self, itemIcon, keyCode)`
+
+    
+    Description:
+    Allows overriding default clicks on inventory icons.
+    
+    Parameters:
+    self (Panel) – Inventory panel.
+    itemIcon (Panel) – Icon that was clicked.
+    keyCode (number) – Key that was pressed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Shift-click to quickly move items.
+    hook.Add("InterceptClickItemIcon", "ShiftQuickMove", function(panel, icon, key)
+    if key == KEY_LSHIFT then return true end
+    end)
+
+### `ItemCombine(client, item, targetItem)`
+
+    
+    Description:
+    Called when the system attempts to combine one item with another in an inventory.
+    
+    Parameters:
+    client (Player) – Owning player.
+    item (Item) – Item being combined.
+    targetItem (Item) – Item it is being combined with.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – true if combination succeeds and items are consumed, false otherwise.
+    
+    Example Usage:
+    -- Combine two ammo boxes into one stack.
+    hook.Add("ItemCombine", "StackAmmo", function(client, base, other)
+    if base.uniqueID == "ammo" and other.uniqueID == "ammo" then
+    base:setData("amount", base:getData("amount",0) + other:getData("amount",0))
+    client:getChar():getInv():removeItem(other.id)
+    return true
+    end
+    end)
+
+### `ItemDraggedOutOfInventory(client, item)`
+
+    
+    Description:
+    Called when an item icon is dragged completely out of an inventory.
+    
+    Parameters:
+    client (Player) – Player dragging the item.
+    item (Item) – Item being removed.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Drop the item into the world when removed.
+    hook.Add("ItemDraggedOutOfInventory", "DropOnDragOut", function(_, item)
+    item:spawn(LocalPlayer():getItemDropPos())
+    end)
+
+### `ItemFunctionCalled(item, action, client, entity, result)`
+
+    
+    Description:
+    Triggered whenever an item function is executed by a player.
+    
+    Parameters:
+    item (Item) – Item on which the function ran.
+    action (string) – Action identifier.
+    client (Player) – Player performing the action.
+    entity (Entity|nil) – Target entity if any.
+    result (any) – Result returned by the item function.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log item function usage for analytics.
+    hook.Add("ItemFunctionCalled", "TrackItemUse", function(item, action, client, entity, result)
+    lia.log.add(client, "item_use", item.uniqueID, action)
+    end)
+
+### `ItemTransfered(context)`
+
+    
+    Description:
+    Runs after an item successfully moves between inventories.
+    
+    Parameters:
+    context (table) – Transfer context table containing client, item, from and to inventories.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Notify the player about the transfer result.
+    hook.Add("ItemTransfered", "NotifyTransfer", function(context)
+    context.client:notify("Item moved!")
+    end)
+
+### `OnCharAttribBoosted(client, character, key, boostID, amount)`
+
+    
+    Description:
+    Fired when an attribute boost is added or removed.
+    
+    Parameters:
+    client (Player) – Player owning the character.
+    character (Character) – Character affected.
+    key (string) – Attribute identifier.
+    boostID (string) – Unique boost key.
+    amount (number|boolean) – Amount added or true when removed.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Notify the player when they gain a temporary bonus.
+    hook.Add("OnCharAttribBoosted", "BoostNotice", function(client, char, key, id, amount)
+    if amount ~= true then client:notify("Boosted " .. key .. " by " .. amount) end
+    end)
+
+### `OnCharAttribUpdated(client, character, key, value)`
+
+    
+    Description:
+    Fired when a character attribute value is changed.
+    
+    Parameters:
+    client (Player) – Player owning the character.
+    character (Character) – Character updated.
+    key (string) – Attribute identifier.
+    value (number) – New attribute value.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print the changed attribute on the local player's HUD.
+    hook.Add("OnCharAttribUpdated", "PrintAttribChange", function(client, char, key, value)
+    if client == LocalPlayer() then
+    chat.AddText(key .. ": " .. value)
+    end
+    end)
+
+### `OnCharFallover(client, ragdoll, forced)`
+
+    
+    Description:
+    Called when a character ragdolls or is forced to fall over.
+    
+    Parameters:
+    client (Player) – Player being ragdolled.
+    ragdoll (Entity|nil) – Created ragdoll entity if any.
+    forced (boolean) – True when the ragdoll was forced.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Apply a stun effect when knocked down.
+    hook.Add("OnCharFallover", "ApplyStun", function(client, _, forced)
+    if forced then client:setAction("stunned", 3) end
+    end)
+
+### `OnCharKick(character, client)`
+
+    
+    Description:
+    Called when a character is kicked from the server.
+    
+    Parameters:
+    character (Character) – Character that was kicked.
+    client (Player) – Player owning the character.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Record the kick reason.
+    hook.Add("OnCharKick", "LogKickReason", function(char, client)
+    print(char:getName(), "was kicked")
+    end)
+
+### `OnCharPermakilled(character, time)`
+
+    
+    Description:
+    Called when a character is permanently killed.
+    
+    Parameters:
+    character (Character) – Character being permanently killed.
+    time (number|nil) – Ban duration or nil for permanent.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Announce permadeath in chat.
+    hook.Add('OnCharPermakilled', 'AnnouncePK', function(char, time)
+    PrintMessage(HUD_PRINTTALK, char:getName() .. ' has met their end!')
+    end)
+
+### `OnCharRecognized(client)`
+
+    
+    Description:
+    Called clientside when your character recognizes another.
+    
+    Parameters:
+    client (Player) – Player that initiated recognition.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Play a sound whenever someone becomes recognized.
+    hook.Add('OnCharRecognized', 'PlayRecognizeSound', function(client)
+    surface.PlaySound('buttons/button17.wav')
+    end)
+
+### `OnCharTradeVendor(client, vendor, item, selling, character, itemType, failed)`
+
+    
+    Description:
+    Called after a character buys from or sells to a vendor.
+    
+    Parameters:
+    client (Player) – Player completing the trade.
+    vendor (Entity) – Vendor entity involved.
+    item (Item|nil) – Item traded, if any.
+    selling (boolean) – True if selling to the vendor.
+    character (Character) – Player's character.
+    itemType (string|nil) – Item identifier when item is nil.
+    failed (boolean|nil) – True if the trade failed.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log vendor transactions to the console.
+    hook.Add('OnCharTradeVendor', 'LogVendorTrade', function(client, vendor, item, selling)
+    print(client:Nick(), selling and 'sold' or 'bought', item and item:getName() or 'unknown')
+    end)
+
+### `OnCreatePlayerRagdoll(client, entity, dead)`
+
+    
+    Description:
+    Called when a ragdoll entity is created for a player.
+    
+    Parameters:
+    client (Player) – The player the ragdoll belongs to.
+    entity (Entity) – The ragdoll entity.
+    dead (boolean) – True if the player died.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Tint death ragdolls red.
+    hook.Add('OnCreatePlayerRagdoll', 'RedRagdoll', function(client, ent, dead)
+    if dead then ent:SetColor(Color(255,0,0)) end
+    end)
+
+### `OnCreateStoragePanel(localPanel, storagePanel, storage)`
+
+    
+    Description:
+    Called when both the player's inventory and storage panels are created.
+    
+    Parameters:
+    localPanel (Panel) – The player's inventory panel.
+    storagePanel (Panel) – The storage entity's panel.
+    storage (Entity) – The storage entity.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Add a custom tab to storage windows.
+    hook.Add('OnCreateStoragePanel', 'AddSortTab', function(localPanel, storagePanel, storage)
+    storagePanel:AddTab('Sort', function() return vgui.Create('liaStorageSort') end)
+    end)
+
+### `OnItemAdded(client, item)`
+
+    
+    Description:
+    Called when a new item instance is placed into an inventory.
+    
+    Parameters:
+    client (Player|nil) – Owner of the inventory the item was added to.
+    item (Item) – Item that was inserted.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Play a sound when ammo is picked up.
+    hook.Add('OnItemAdded', 'AmmoPickupSound', function(ply, item)
+    if item.category == 'ammo' then
+    ply:EmitSound('items/ammo_pickup.wav')
+    end
+    end)
+
+### `OnItemCreated(itemTable, entity)`
+
+    
+    Description:
+    Called when a new item instance table is initialized.
+    
+    Parameters:
+    itemTable (table) – Item definition table.
+    entity (Entity) – Spawned item entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Set custom data on freshly made items.
+    hook.Add('OnItemCreated', 'InitCustomData', function(item)
+    item:setData('born', os.time())
+    end)
+
+### `OnItemSpawned(entity)`
+
+    
+    Description:
+    Called when an item entity has been spawned in the world.
+    
+    Parameters:
+    entity (Entity) – Spawned item entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Play a sound when rare items appear.
+    hook.Add('OnItemSpawned', 'RareSpawnSound', function(itemEnt)
+    if itemEnt.rare then itemEnt:EmitSound('items/ammo_pickup.wav') end
+    end)
+
+### `OnOpenVendorMenu(panel, vendor)`
+
+    
+    Description:
+    Called when the vendor dialog panel is opened.
+    
+    Parameters:
+    panel (Panel) – The vendor menu panel.
+    vendor (Entity) – The vendor entity.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Automatically switch to the buy tab.
+    hook.Add('OnOpenVendorMenu', 'DefaultBuyTab', function(panel, vendor)
+    panel:openTab('Buy')
+    end)
+
+### `OnPickupMoney(client, moneyEntity)`
+
+    
+    Description:
+    Called after a player picks up a money entity.
+    
+    Parameters:
+    client (Player) – The player picking up the money.
+    moneyEntity (Entity) – The money entity collected.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Reward an achievement for looting money.
+    hook.Add('OnPickupMoney', 'MoneyAchievement', function(client, ent)
+    client:addProgress('rich', ent:getAmount())
+    end)
+
+### `OnPlayerEnterSequence(client, sequence, callback, time, noFreeze)`
+
+    
+    Description:
+    Fired when a scripted animation sequence begins.
+    
+    Parameters:
+    client (Player) – Player starting the sequence.
+    sequence (string) – Sequence name.
+    callback (function) – Completion callback.
+    time (number) – Duration in seconds.
+    noFreeze (boolean) – True if the player should not be frozen.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Freeze the player during the sequence.
+    hook.Add('OnPlayerEnterSequence', 'FreezeDuringSeq', function(client, seq, callback, time, noFreeze)
+    if not noFreeze then client:Freeze(true) end
+    end)
+
+### `OnPlayerInteractItem(client, action, item, result, data)`
+
+    
+    Description:
+    Runs after a player has interacted with an item.
+    
+    Parameters:
+    client (Player) – Player performing the interaction.
+    action (string) – Action key used.
+    item (Item) – Item affected.
+    result (any) – Result returned by the action.
+    data (table|nil) – Additional data table.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Send analytics for item usage.
+    hook.Add('OnPlayerInteractItem', 'Analytics', function(client, action, item, result, data)
+    lia.analytics.log(client, action, item.uniqueID)
+    end)
+
+### `OnPlayerJoinClass(client, class, oldClass)`
+
+    
+    Description:
+    Called when a player changes to a new class.
+    
+    Parameters:
+    client (Player) – The player switching classes.
+    class (table|number) – New class table or index.
+    oldClass (table|number) – Previous class table or index.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Give class specific weapons.
+    hook.Add('OnPlayerJoinClass', 'ClassWeapons', function(client, class, oldClass)
+    for _, wep in ipairs(class.weapons or {}) do client:Give(wep) end
+    end)
+
+### `OnPlayerLeaveSequence(client)`
+
+    
+    Description:
+    Fired when a scripted animation sequence ends for a player.
+    
+    Parameters:
+    client (Player) – Player that finished the sequence.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Unfreeze the player after the sequence.
+    hook.Add('OnPlayerLeaveSequence', 'UnfreezeAfterSeq', function(client)
+    client:Freeze(false)
+    end)
+
+### `OnPlayerLostStackItem(item)`
+
+    
+    Description:
+    Called if a stackable item is removed unexpectedly.
+    
+    Parameters:
+    item (Item) – The item that disappeared.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Warn players when their ammo stack disappears.
+    hook.Add('OnPlayerLostStackItem', 'WarnLostAmmo', function(item)
+    if item.category == 'ammo' then print('Ammo stack lost!') end
+    end)
+
+### `OnPlayerSwitchClass(client, class, oldClass)`
+
+    
+    Description:
+    Occurs right before a player's class changes.
+    
+    Parameters:
+    client (Player) – Player who is switching.
+    class (table|number) – Class being joined.
+    oldClass (table|number) – Class being left.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prevent switching while in combat.
+    hook.Add('OnPlayerSwitchClass', 'NoCombatSwap', function(client, class, oldClass)
+    if client:getNetVar('inCombat') then return false end
+    end)
+
+### `OnRequestItemTransfer(panel, itemID, inventoryID, x, y)`
+
+    
+    Description:
+    Called when the UI asks to move an item between inventories.
+    
+    Parameters:
+    panel (Panel) – Inventory panel requesting the move.
+    itemID (number) – Identifier of the item to move.
+    inventoryID (number|string) – Destination inventory ID.
+    x (number) – Destination X coordinate.
+    y (number) – Destination Y coordinate.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Validate transfers before sending to the server.
+    hook.Add('OnRequestItemTransfer', 'ValidateTransfer', function(panel, itemID, invID, x, y)
+    return itemID ~= 0 -- block invalid ids
+    end)
+
+### `PersistenceLoad(name)`
+
+    
+    Description:
+    Called when map persistence data is loaded.
+    
+    Parameters:
+    name (string) – Name of the persistence file.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Verify entities when the map reloads.
+    hook.Add('PersistenceLoad', 'CheckPersistent', function(name)
+    print('Loading persistence file', name)
+    end)
+
+### `PlayerAccessVendor(client, vendor)`
+
+    
+    Description:
+    Occurs when a player successfully opens a vendor.
+    
+    Parameters:
+    client (Player) – Player accessing the vendor.
+    vendor (Entity) – Vendor entity opened.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Track how often players browse vendors.
+    hook.Add('PlayerAccessVendor', 'VendorAnalytics', function(client, vendor)
+    lia.log.add(client, 'vendor_open', vendor:GetClass())
+    end)
+
+### `PlayerStaminaGained(client)`
+
+    
+    Description:
+    Called when a player regenerates stamina points.
+    
+    Parameters:
+    client (Player) – Player gaining stamina.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print the player's stamina amount whenever it increases.
+    hook.Add('PlayerStaminaGained', 'PrintStaminaGain', function(client)
+    if client == LocalPlayer() then
+    print('Stamina:', client:getLocalVar('stamina'))
+    end
+    end)
+
+### `PlayerStaminaLost(client)`
+
+    
+    Description:
+    Called when a player's stamina decreases.
+    
+    Parameters:
+    client (Player) – Player losing stamina.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Play a sound when the player runs out of stamina.
+    hook.Add('PlayerStaminaLost', 'TiredSound', function(client)
+    if client:getLocalVar('stamina', 0) <= 0 then
+    client:EmitSound('player/suit_denydevice.wav')
+    end
+    end)
+
+### `PlayerThrowPunch(client, trace)`
+
+    
+    Description:
+    Fires when a player lands a punch with the fists weapon.
+    
+    Parameters:
+    client (Player) – Punching player.
+    trace (table) – Trace result of the punch.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Play a custom sound on punch.
+    hook.Add('PlayerThrowPunch', 'PunchSound', function(client, trace)
+    client:EmitSound('npc/vort/claw_swing1.wav')
+    end)
+
+### `PostDrawInventory(panel, parentPanel)`
+
+    
+    Description:
+    Called each frame after the inventory panel draws.
+    
+    Parameters:
+    panel (Panel) – The inventory panel being drawn.
+    parentPanel (Panel|nil) – Parent panel if any.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Draw a watermark over the inventory.
+    hook.Add('PostDrawInventory', 'InventoryWatermark', function(panel)
+    draw.SimpleText('MY SERVER', 'DermaLarge', panel:GetWide()-100, 8, color_white)
+    end)
+
+### `PrePlayerInteractItem(client, action, item)`
+
+    
+    Description:
+    Called just before a player interacts with an item.
+    
+    Parameters:
+    client (Player) – Player performing the action.
+    action (string) – Action identifier.
+    item (Item) – Target item.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Deny using keys on locked chests.
+    hook.Add('PrePlayerInteractItem', 'BlockChestKeys', function(client, action, item)
+    if action == 'use' and item.uniqueID == 'key' and client.lockedChest then return false end
+    end)
+
+### `SetupBagInventoryAccessRules(inventory)`
+
+    
+    Description:
+    Allows modules to define who can access a bag inventory.
+    
+    Parameters:
+    inventory (Inventory) – Bag inventory object.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Only the bag owner may open it.
+    hook.Add('SetupBagInventoryAccessRules', 'OwnerOnlyBags', function(inv)
+    inv:allowAccess('transfer', inv:getOwner())
+    end)
+
+### `SetupDatabase()`
+
+    
+    Description:
+    Runs before the gamemode initializes its database connection.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Register additional tables.
+    hook.Add('SetupDatabase', 'AddExtraTables', function()
+    lia.db.query('CREATE TABLE IF NOT EXISTS mytable(id INT)')
+    end)
+
+### `StorageCanTransferItem(client, storage, item)`
+
+    
+    Description:
+    Determines if an item can move in or out of a storage entity.
+    
+    Parameters:
+    client (Player) – Player moving the item.
+    storage (Entity) – Storage entity.
+    item (Item) – Item being transferred.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – False to disallow transfer
+    
+    Example Usage:
+    -- Prevent weapons from being stored in car trunks.
+    hook.Add('StorageCanTransferItem', 'NoWeaponsInCars', function(client, storage, item)
+    if storage.isCar and item.category == 'weapons' then return false end
+    end)
+
+### `StorageEntityRemoved(entity, inventory)`
+
+    
+    Description:
+    Fired when a storage entity is removed from the world.
+    
+    Parameters:
+    entity (Entity) – The storage entity being removed.
+    inventory (Inventory) – Inventory associated with the entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Drop items when a crate is destroyed.
+    hook.Add('StorageEntityRemoved', 'DropContents', function(entity, inv)
+    inv:dropItems(entity:GetPos())
+    end)
+
+### `StorageInventorySet(entity, inventory, isCar)`
+
+    
+    Description:
+    Called when a storage entity is assigned an inventory.
+    
+    Parameters:
+    entity (Entity) – The storage entity.
+    inventory (Inventory) – Inventory assigned.
+    isCar (boolean) – True if the entity is a vehicle trunk.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Send a notification when storage is initialized.
+    hook.Add('StorageInventorySet', 'NotifyStorage', function(entity, inv, isCar)
+    if isCar then print('Trunk inventory ready') end
+    end)
+
+### `StorageOpen(entity, isCar)`
+
+    
+    Description:
+    Called clientside when a storage menu is opened.
+    
+    Parameters:
+    entity (Entity) – Storage entity opened.
+    isCar (boolean) – True if opening a vehicle trunk.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Display storage name in the chat.
+    hook.Add('StorageOpen', 'AnnounceStorage', function(entity, isCar)
+    chat.AddText('Opened storage:', entity:GetClass())
+    end)
+
+### `StorageRestored(storage, inventory)`
+
+    
+    Description:
+    Called when a storage's contents are loaded from disk.
+    
+    Parameters:
+    storage (Entity) – Storage entity.
+    inventory (Inventory) – Inventory loaded.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log how many items were restored.
+    hook.Add('StorageRestored', 'PrintRestore', function(storage, inv)
+    print('Storage restored with', #inv:getItems(), 'items')
+    end)
+
+### `StorageUnlockPrompt(entity)`
+
+    
+    Description:
+    Called clientside when you must enter a storage password.
+    
+    Parameters:
+    entity (Entity) – Storage entity being opened.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Auto-fill a remembered password.
+    hook.Add('StorageUnlockPrompt', 'AutoFill', function(entity)
+    return '1234' -- automatically send this string
+    end)
+
+### `VendorClassUpdated(vendor, id, allowed)`
+
+    
+    Description:
+    Called when a vendor's allowed classes are updated.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- React to class access changes.
+    hook.Add("VendorClassUpdated", "LogVendorClassChange", function(vendor, id, allowed)
+    print("Vendor class", id, "now", allowed and "allowed" or "blocked")
+    end)
+
+### `VendorEdited(vendor, key)`
+
+    
+    Description:
+    Called after a delay when a vendor's data is edited.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log which key changed.
+    hook.Add("VendorEdited", "PrintVendorEdit", function(vendor, key)
+    print("Vendor", vendor:GetClass(), "edited key", key)
+    end)
+
+### `VendorExited()`
+
+    
+    Description:
+    Called when a player exits from interacting with a vendor.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Notify the player when they leave a vendor.
+    hook.Add("VendorExited", "PrintVendorExit", function()
+    print("Stopped interacting with vendor")
+    end)
+
+### `VendorFactionUpdated(vendor, id, allowed)`
+
+    
+    Description:
+    Called when a vendor's allowed factions are updated.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print updated faction permissions.
+    hook.Add("VendorFactionUpdated", "LogVendorFactionUpdate", function(vendor, id, allowed)
+    print("Vendor faction", id, "now", allowed and "allowed" or "blocked")
+    end)
+
+### `VendorItemMaxStockUpdated(vendor, itemType, value)`
+
+    
+    Description:
+    Called when a vendor's item max stock value changes.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log stock limit changes.
+    hook.Add("VendorItemMaxStockUpdated", "LogVendorStockLimits", function(vendor, itemType, value)
+    print("Vendor stock limit for", itemType, "set to", value)
+    end)
+
+### `VendorItemModeUpdated(vendor, itemType, value)`
+
+    
+    Description:
+    Called when a vendor's item mode is changed.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print the new mode value.
+    hook.Add("VendorItemModeUpdated", "PrintVendorMode", function(vendor, itemType, value)
+    print("Vendor mode for", itemType, "changed to", value)
+    end)
+
+### `VendorItemPriceUpdated(vendor, itemType, value)`
+
+    
+    Description:
+    Called when a vendor's item price is changed.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print the new item price.
+    hook.Add("VendorItemPriceUpdated", "LogVendorItemPrice", function(vendor, itemType, value)
+    print("Vendor price for", itemType, "is now", value)
+    end)
+
+### `VendorItemStockUpdated(vendor, itemType, value)`
+
+    
+    Description:
+    Called when a vendor's item stock value changes.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log remaining stock for the item.
+    hook.Add("VendorItemStockUpdated", "LogVendorItemStock", function(vendor, itemType, value)
+    print("Vendor stock for", itemType, "is now", value)
+    end)
+
+### `VendorMoneyUpdated(vendor, money, oldMoney)`
+
+    
+    Description:
+    Called when a vendor's available money changes.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print the vendor's new money amount.
+    hook.Add("VendorMoneyUpdated", "LogVendorMoney", function(vendor, money, oldMoney)
+    print("Vendor money changed from", oldMoney, "to", money)
+    end)
+
+### `VendorOpened(vendor)`
+
+    
+    Description:
+    Called when a vendor menu is opened on the client.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print which vendor was opened.
+    hook.Add("VendorOpened", "PrintVendorOpened", function(vendor)
+    print("Opened vendor", vendor:GetClass())
+    end)
+
+### `VendorSynchronized(vendor)`
+
+    
+    Description:
+    Called when vendor synchronization data is received.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Print a message when vendor data syncs.
+    hook.Add("VendorSynchronized", "LogVendorSync", function(vendor)
+    print("Vendor", vendor:GetClass(), "synchronized")
+    end)
+
+### `VendorTradeEvent(client, entity, uniqueID, isSellingToVendor)`
+
+    
+    Description:
+    Called when a player attempts to trade with a vendor.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log all vendor trades to the console.
+    hook.Add("VendorTradeEvent", "LogVendorTrades", function(client, entity, uniqueID, isSellingToVendor)
+    local action = isSellingToVendor and "sold" or "bought"
+    print(client:Name() .. " " .. action .. " " .. uniqueID .. " with " .. entity:GetClass())
+    end)
+
+### `getItemDropModel(itemTable, entity)`
+
+    
+    Description:
+    Returns an alternate model path for a dropped item.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    string|nil – Alternate model path or nil for default.
+    
+    Example Usage:
+    -- Replace drop model for weapons.
+    hook.Add("getItemDropModel", "CustomDropModelForWeapons", function(itemTable, entity)
+    if itemTable.category == "Weapon" then
+    return "models/weapons/w_rif_ak47.mdl"
+    end
+    end)
+
+### `getPriceOverride(vendor, uniqueID, price, isSellingToVendor)`
+
+    
+    Description:
+    Allows modules to override a vendor item's price dynamically.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    integer|nil – New price or nil for default.
+    
+    Example Usage:
+    -- Increase price for rare items when buying from the vendor.
+    hook.Add("getPriceOverride", "DynamicPricing", function(vendor, uniqueID, price, isSellingToVendor)
+    if uniqueID == "rare_item" then
+    if isSellingToVendor then
+    return math.floor(price * 0.75)
+    else
+    return math.floor(price * 1.25)
+    end
+    end
+    end)
+
+### `isCharFakeRecognized(character, id)`
+
+    
+    Description:
+    Checks if a character is fake recognized rather than truly known.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Flag suspicious characters as fake.
+    hook.Add("isCharFakeRecognized", "DetectFakeCharacters", function(character, id)
+    if character:getData("suspicious", false) then
+    return true
+    end
+    end)
+
+### `isCharRecognized(character, id)`
+
+    
+    Description:
+    Determines whether one character recognizes another.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Only recognize characters from the same faction.
+    hook.Add("isCharRecognized", "ValidateCharacterRecognition", function(character, id)
+    return character:getFaction() == lia.char.loaded[id]:getFaction()
+    end)
+
+### `isRecognizedChatType(chatType)`
+
+    
+    Description:
+    Determines if a chat type counts toward recognition.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Mark admin chat as recognized to reveal player names.
+    hook.Add("isRecognizedChatType", "ValidateRecognitionChat", function(chatType)
+    local recognized = {"admin", "system", "recognition"}
+    return table.HasValue(recognized, chatType)
+    end)
+
+### `isSuitableForTrunk(entity)`
+
+    
+    Description:
+    Determines whether an entity can be used as trunk storage.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Only vehicles are valid trunk containers.
+    hook.Add("isSuitableForTrunk", "AllowOnlyCars", function(entity)
+    return entity:IsVehicle()
+    end)
+
+### `CanPlayerEarnSalary(client, faction, class)`
+
+    
+    Description:
+    Determines if a player is allowed to earn salary.
+    
+    Parameters:
+    client (Player) – Player to check.
+    faction (table) – Faction data for the player.
+    class (table) – Class table for the player.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Prints a message when CanPlayerEarnSalary is triggered
+    hook.Add("CanPlayerEarnSalary", "RestrictSalaryToActivePlayers", function(client, faction, class)
+    if not client:isActive() then
+    return false -- Inactive players do not earn salary
+    end
+    return true
+    end)
+
+### `CanPlayerJoinClass(client, class, info)`
+
+    
+    Description:
+    Determines whether a player can join a certain class. Return `false` to block.
+    
+    Parameters:
+    client (Player) – Player requesting the class.
+    class (number) – Class index being joined.
+    info (table) – Additional class info table.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean|nil: false to block, nil to allow.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerJoinClass is triggered
+    hook.Add("CanPlayerJoinClass", "RestrictEliteClass", function(client, class, info)
+    if class == CLASS_ELITE and not client:hasPermission("join_elite") then
+    return false
+    end
+    end)
+
+### `CanPlayerUseCommand(client, command)`
+
+    
+    Description:
+    Determines if a player can use a specific command. Return `false` to block usage.
+    
+    Parameters:
+    client (Player) – Player running the command.
+    command (string) – Command name.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean|nil: false to block, nil to allow.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerUseCommand is triggered
+    hook.Add("CanPlayerUseCommand", "BlockSensitiveCommands", function(client, command)
+    local blockedCommands = {"shutdown", "restart"}
+    if table.HasValue(blockedCommands, command) and not client:isSuperAdmin() then
+    return false
+    end
+    end)
+
+### `CanPlayerUseDoor(client, door, access)`
+
+    
+    Description:
+    Determines if a player is allowed to use a door entity, such as opening, locking, or unlocking. Return `false` to prevent the action.
+    
+    Parameters:
+    client (Player) – The player attempting to use the door.
+    door (Entity) – The door entity being used.
+    access (int) – Access type attempted (e.g. DOOR_LOCK).
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean: false to block, nil or true to allow.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerUseDoor is triggered
+    hook.Add("CanPlayerUseDoor", "AllowOnlyOwners", function(client, door, access)
+    if access == DOOR_LOCK and door:getOwner() ~= client then
+    return false -- Only the owner can lock the door
+    end
+    return true
+    end)
+
+### `CharCleanUp(character)`
+
+    
+    Description:
+    Used during character cleanup routines for additional steps when removing or transitioning a character.
+    
+    Parameters:
+    character (Character) – The character being cleaned up.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharCleanUp is triggered
+    hook.Add("CharCleanUp", "RemoveTemporaryItems", function(character)
+    local inventory = character:getInv()
+    for _, item in ipairs(inventory:getItems()) do
+    if item:isTemporary() then
+    inventory:removeItem(item.id)
+    print("Removed temporary item:", item.name)
+    end
+    end
+    end)
+
+### `CharRestored()`
+
+    
+    Description:
+    Called after a character has been restored from the database. Useful for post-restoration logic such as awarding default items or setting up data.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharRestored is triggered
+    hook.Add("CharRestored", "AwardWelcomePackage", function(character)
+    local welcomePackage = {"welcome_pack", "starter_weapon", "basic_armor"}
+    for _, itemID in ipairs(welcomePackage) do
+    character:getInv():addItem(itemID)
+    end
+    print("Welcome package awarded to:", character:getName())
+    end)
+
+### `CreateDefaultInventory()`
+
+    
+    Description:
+    Called when creating a default inventory for a character. Should return a [deferred](https://github.com/Be1zebub/luassert-deferred) (or similar promise) object that resolves with the new inventory.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CreateDefaultInventory is triggered
+    hook.Add("CreateDefaultInventory", "InitializeStarterInventory", function(character)
+    local d = deferred.new()
+    
+    lia.inventory.new("bag")
+    :next(function(inventory)
+    -- Add starter items
+    inventory:addItem("health_potion")
+    inventory:addItem("basic_sword")
+    d:resolve(inventory)
+    end, function(err)
+    print("Failed to create inventory:", err)
+    d:reject(err)
+    end)
+    
+    return d
+    end)
+
+### `CreateInventoryPanel(inventory, parent)`
+
+    
+    Description:
+    Client-side call when creating the graphical representation of an inventory.
+    
+    Parameters:
+    inventory (Inventory) – Inventory instance to draw.
+    parent (Panel) – Parent container panel.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CreateInventoryPanel is triggered
+    hook.Add("CreateInventoryPanel", "CustomInventoryUI", function(inventory, parent)
+    local panel = vgui.Create("DPanel", parent)
+    panel:SetSize(400, 600)
+    panel.Paint = function(self, w, h)
+    draw.RoundedBox(8, 0, 0, w, h, Color(30, 30, 30, 200))
+    end
+    
+    local itemList = vgui.Create("DScrollPanel", panel)
+    itemList:Dock(FILL)
+    
+    for _, item in ipairs(inventory:getItems()) do
+    local itemPanel = vgui.Create("DButton", itemList)
+    itemPanel:SetText(item.name)
+    itemPanel:Dock(TOP)
+    itemPanel:SetTall(40)
+    itemPanel.DoClick = function()
+    print("Selected item:", item.name)
+    end
+    end
+    
+    return panel
+    end)
+
+### `CreateSalaryTimer(client)`
+
+    
+    Description:
+    Creates a timer to manage player salary.
+    
+    Parameters:
+    client (Player) – Player receiving the salary timer.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CreateSalaryTimer is triggered
+    hook.Add("CreateSalaryTimer", "SetupSalaryTimer", function(client)
+    timer.Create("SalaryTimer_" .. client:SteamID(), 60, 0, function()
+    if IsValid(client) and MODULE:CanPlayerEarnSalary(client, client:getFaction(), client:getClass()) then
+    local salary = MODULE:GetSalaryAmount(client, client:getFaction(), client:getClass())
+    client:addMoney(salary)
+    client:ChatPrint("You have received your salary of $" .. salary)
+    print("Salary of $" .. salary .. " awarded to:", client:Name())
+    end
+    end)
+    print("Salary timer created for:", client:Name())
+    end)
+
+### `DoModuleIncludes(path, module)`
+
+    
+    Description:
+    Called when modules include submodules. Useful for advanced module handling or dependency management.
+    
+    Parameters:
+    path (string) – Directory path containing the submodule.
+    module (table) – Module performing the include.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when DoModuleIncludes is triggered
+    hook.Add("DoModuleIncludes", "TrackModuleDependencies", function(path, module)
+    print("Including submodule from path:", path)
+    module.dependencies = module.dependencies or {}
+    table.insert(module.dependencies, "base_module")
+    end)
+
+### `GetDefaultCharDesc(client, faction)`
+
+    
+    Description:
+    Retrieves a default description for a character during creation. Return `(defaultDesc, overrideBool)`.
+    
+    Parameters:
+    client (Player) – Player creating the character.
+    faction (number) – Faction index of the new character.
+    
+    Realm:
+    Server
+    
+    Returns:
+    string: The default description.
+    boolean: Whether to override.
+    
+    Example Usage:
+    -- Prints a message when GetDefaultCharDesc is triggered
+    hook.Add("GetDefaultCharDesc", "CitizenDefaultDesc", function(client, faction)
+    if faction == FACTION_CITIZEN then
+    return "A hardworking member of society.", true
+    end
+    end)
+
+### `GetDefaultCharName(client, faction, data)`
+
+    
+    Description:
+    Retrieves a default name for a character during creation. Return `(defaultName, overrideBool)`.
+    
+    Parameters:
+    client (Player) – Player creating the character.
+    faction (number) – Faction index.
+    data (table) – Additional creation data.
+    
+    Realm:
+    Server
+    
+    Returns:
+    string: The default name.
+    boolean: Whether to override the user-provided name.
+    
+    Example Usage:
+    -- Prints a message when GetDefaultCharName is triggered
+    hook.Add("GetDefaultCharName", "PoliceDefaultName", function(client, faction, data)
+    if faction == FACTION_POLICE then
+    return "Officer " .. data.lastName or "Smith", true
+    end
+    end)
+
+### `GetSalaryAmount(client, faction, class)`
+
+    
+    Description:
+    Retrieves the amount of salary a player should receive.
+    
+    Parameters:
+    client (Player) – Player receiving salary.
+    faction (table) – Player's faction data.
+    class (table) – Player's class data.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    any: The salary amount
+    
+    Example Usage:
+    -- Prints a message when GetSalaryAmount is triggered
+    hook.Add("GetSalaryAmount", "CalculateDynamicSalary", function(client, faction, class)
+    local baseSalary = faction.baseSalary or 1000
+    local classBonus = class.salaryBonus or 0
+    return baseSalary + classBonus
+    end)
+
+### `GetSalaryLimit(client, faction, class)`
+
+    
+    Description:
+    Retrieves the salary limit for a player.
+    
+    Parameters:
+    client (Player) – Player being checked.
+    faction (table) – Player's faction data.
+    class (table) – Player's class data.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    any: The salary limit
+    
+    Example Usage:
+    -- Prints a message when GetSalaryLimit is triggered
+    hook.Add("GetSalaryLimit", "SetSalaryLimitsBasedOnRole", function(client, faction, class)
+    if faction.name == "Police" then
+    return 5000 -- Police have a higher salary limit
+    elseif faction.name == "Citizen" then
+    return 2000
+    end
+    end)
+
+### `InitializedConfig()`
+
+    
+    Description:
+    Called when `lia.config` is fully initialized.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when this hook is triggered
+    function MODULE:InitializedConfig()
+    if lia.config.enableSpecialFeatures then
+    lia.features.enable()
+    print("Special features have been enabled.")
+    else
+    print("Special features are disabled in the config.")
+    end
+    end
+
+### `InitializedItems()`
+
+    
+    Description:
+    Called once all item modules have been loaded from a directory.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InitializedItems is triggered
+    hook.Add("InitializedItems", "SetupSpecialItems", function()
+    local specialItem = lia.item.create({
+    uniqueID = "magic_ring",
+    name = "Magic Ring",
+    description = "A ring imbued with magical properties.",
+    onUse = function(self, player)
+    player:SetNoDraw(true)
+    print(player:Name() .. " has activated the Magic Ring!")
+    end
+    })
+    print("Special items have been set up.")
+    end)
+
+### `InitializedModules()`
+
+    
+    Description:
+    Called after all modules are fully initialized.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InitializedModules is triggered
+    hook.Add("InitializedModules", "FinalizeModuleSetup", function()
+    lia.modules.finalizeSetup()
+    print("All modules have been fully initialized.")
+    end)
+
+### `InitializedOptions()`
+
+    
+    Description:
+    Called when `lia.option` is fully initialized.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when this hook is triggered
+    function MODULE:InitializedOptions()
+    LocalPlayer():ChatPrint("LOADED OPTIONS!")
+    end
+
+### `InitializedSchema()`
+
+    
+    Description:
+    Called after the schema has finished initializing.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InitializedSchema is triggered
+    hook.Add("InitializedSchema", "SchemaReadyNotification", function()
+    print("Schema has been successfully initialized.")
+    lia.notifications.broadcast("Welcome to the server! The schema is now active.")
+    end)
+
+### `KeyLock(owner, entity, time)`
+
+    
+    Description:
+    Called when a player attempts to lock a door.
+    
+    Parameters:
+    owner (Player) – Player locking the door.
+    entity (Entity) – Door entity being locked.
+    time (float) – Duration of the locking animation.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when KeyLock is triggered
+    hook.Add("KeyLock", "LogDoorLock", function(owner, entity, time)
+    entity:setLocked(true)
+    lia.log.write("DoorLock", owner:Name() .. " locked door ID: " .. entity:EntIndex() .. " for " .. time .. " seconds.")
+    print(owner:Name() .. " locked door ID:", entity:EntIndex(), "for", time, "seconds.")
+    end)
+
+### `KeyUnlock(owner, entity, time)`
+
+    
+    Description:
+    Called when a player attempts to unlock a door.
+    
+    Parameters:
+    owner (Player) – Player unlocking the door.
+    entity (Entity) – Door entity being unlocked.
+    time (float) – How long the process took.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when KeyUnlock is triggered
+    hook.Add("KeyUnlock", "LogDoorUnlock", function(owner, entity, time)
+    entity:setLocked(false)
+    lia.log.write("DoorUnlock", owner:Name() .. " unlocked door ID: " .. entity:EntIndex() .. " after " .. time .. " seconds.")
+    print(owner:Name() .. " unlocked door ID:", entity:EntIndex(), "after", time, "seconds.")
+    end)
+
+### `LiliaTablesLoaded()`
+
+    
+    Description:
+    Called after all essential DB tables have been loaded.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when LiliaTablesLoaded is triggered
+    hook.Add("LiliaTablesLoaded", "InitializeGameState", function()
+    lia.gameState = lia.gameState or {}
+    lia.gameState.activeEvents = {}
+    print("All essential Lilia tables have been loaded. Game state initialized.")
+    end)
+
+### `OnItemRegistered(item)`
+
+    
+    Description:
+    Called after an item has been registered. Useful for customizing item behavior or adding properties.
+    
+    Parameters:
+    item (Item) – Item definition being registered.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnItemRegistered is triggered
+    hook.Add("OnItemRegistered", "AddItemDurability", function(item)
+    if item.uniqueID == "sword_basic" then
+    item.durability = 100
+    item.onUse = function(self)
+    self.durability = self.durability - 10
+    if self.durability <= 0 then
+    self:destroy()
+    print("Your sword has broken!")
+    end
+    end
+    print("Durability added to:", item.name)
+    end
+    end)
+
+### `OnLoadTables()`
+
+    
+    Description:
+    Called before the faction tables are loaded. Good spot for data setup prior to factions being processed.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnLoadTables is triggered
+    hook.Add("OnLoadTables", "SetupFactionDefaults", function()
+    lia.factions = lia.factions or {}
+    lia.factions.defaultPermissions = {canUseWeapons = true, canAccessBank = false}
+    print("Faction defaults have been set up.")
+    end)
+
+### `OnMySQLOOConnected()`
+
+    
+    Description:
+    Called when MySQLOO successfully connects to the database. Use to register prepared statements or init DB logic.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnMySQLOOConnected is triggered
+    hook.Add("OnMySQLOOConnected", "PrepareDatabaseStatements", function()
+    lia.db.prepare("insertPlayer", "INSERT INTO lia_players (_steamID, _steamName) VALUES (?, ?)", {MYSQLOO_STRING, MYSQLOO_STRING})
+    lia.db.prepare("updatePlayerStats", "UPDATE lia_players SET kills = ?, deaths = ? WHERE _steamID = ?", {MYSQLOO_NUMBER, MYSQLOO_NUMBER, MYSQLOO_STRING})
+    print("Prepared MySQLOO statements.")
+    end)
+
+### `OnPlayerPurchaseDoor(client, entity, buying, CallOnDoorChild)`
+
+    
+    Description:
+    Called when a player purchases or sells a door.
+    
+    Parameters:
+    client (Player) – Player buying or selling the door.
+    entity (Entity) – Door entity affected.
+    buying (boolean) – True if buying, false if selling.
+    CallOnDoorChild (function) – Optional callback for door children.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnPlayerPurchaseDoor is triggered
+    hook.Add("OnPlayerPurchaseDoor", "HandleDoorPurchase", function(client, entity, buying, CallOnDoorChild)
+    if buying then
+    client:deductMoney(entity:getPrice())
+    lia.log.write("DoorPurchase", client:Name() .. " purchased door ID: " .. entity:EntIndex())
+    print(client:Name() .. " purchased a door.")
+    else
+    client:addMoney(entity:getSellPrice())
+    lia.log.write("DoorSale", client:Name() .. " sold door ID: " .. entity:EntIndex())
+    print(client:Name() .. " sold a door.")
+    end
+    CallOnDoorChild(entity)
+    end)
+
+### `OnServerLog(client, logType, logString, category, color)`
+
+    
+    Description:
+    Called whenever a new log message is added. Allows for custom logic or modifications to log handling.
+    
+    Parameters:
+    client (Player) – Player associated with the log or nil.
+    logType (string) – Type identifier for the log entry.
+    logString (string) – Formatted log text.
+    category (string) – Category name.
+    color (Color) – Display color.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnServerLog is triggered
+    hook.Add("OnServerLog", "AlertAdminsOnHighSeverity", function(client, logType, logString, category, color)
+    if category == "error" then
+    for _, admin in player.Iterator() do
+    if admin:isAdmin() then
+    lia.notifications.send(admin, "Error Log: " .. logString, color)
+    end
+    end
+    end
+    end)
+
+### `OnWipeTables()`
+
+    
+    Description:
+    Called after wiping tables in the DB, typically after major resets/cleanups.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnWipeTables is triggered
+    hook.Add("OnWipeTables", "ReinitializeDefaults", function()
+    lia.db.execute("INSERT INTO lia_factions (name, description) VALUES ('Citizen', 'Regular inhabitants.')")
+    lia.db.execute("INSERT INTO lia_classes (name, faction) VALUES ('Warrior', 'Citizen')")
+    print("Database tables wiped and defaults reinitialized.")
+    end)
+
+### `PlayerMessageSend(speaker, chatType, message, anonymous)`
+
+    
+    Description:
+    Called before a chat message is sent. Return `false` to cancel, or modify the message if returning a string.
+    
+    Parameters:
+    speaker (Player) – Player sending the message.
+    chatType (string) – Chat type key.
+    message (string) – Message contents.
+    anonymous (boolean) – True if the speaker is hidden.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean|nil|modifiedString: false to cancel, or return a modified string to change the message.
+    
+    Example Usage:
+    -- Prints a message when PlayerMessageSend is triggered
+    hook.Add("PlayerMessageSend", "FilterProfanity", function(speaker, chatType, message, anonymous)
+    local filteredMessage = string.gsub(message, "badword", "****")
+    if filteredMessage ~= message then
+    return filteredMessage
+    end
+    end)
+
+### `PlayerModelChanged(client, model)`
+
+    
+    Description:
+    Called when a player's model changes.
+    
+    Parameters:
+    client (Player) – The player whose model changed.
+    model (string) – The new model path.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PlayerModelChanged is triggered
+    hook.Add("PlayerModelChanged", "UpdatePlayerAppearance", function(client, model)
+    print(client:Name() .. " changed their model to " .. model)
+    -- Update related appearance settings
+    client:setBodygroup(1, 2) -- Example of setting a bodygroup based on the new model
+    end)
+
+### `PlayerUseDoor(client, entity)`
+
+    
+    Description:
+    Called when a player attempts to use a door entity.
+    
+    Parameters:
+    client (Player) – Player using the door.
+    entity (Entity) – Door entity targeted.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil: false to disallow, true to allow, or nil to let other hooks decide.
+    
+    Example Usage:
+    -- Prints a message when PlayerUseDoor is triggered
+    hook.Add("PlayerUseDoor", "LogDoorUsage", function(client, entity)
+    print(client:Name() .. " is attempting to use door ID:", entity:EntIndex())
+    -- Allow or disallow based on custom conditions
+    if client:isBanned() then
+    return false -- Disallow use if the player is banned
+    end
+    end)
+
+### `RegisterPreparedStatements()`
+
+    
+    Description:
+    Called for registering DB prepared statements post-MySQLOO connection.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Set up a prepared SQL statement for later use.
+    hook.Add("RegisterPreparedStatements", "InitLogStatement", function()
+    lia.db.prepare("insert_log", "INSERT INTO logs(text) VALUES(?)")
+    end)
+
+### `ShouldBarDraw(barName)`
+
+    
+    Description:
+    Determines whether a specific HUD bar should be drawn.
+    
+    Parameters:
+    barName (string) – HUD bar identifier, e.g. "health" or "armor".
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean|nil: false to hide, nil to allow.
+    
+    Example Usage:
+    -- Prints a message when ShouldBarDraw is triggered
+    hook.Add("ShouldBarDraw", "HideArmorHUD", function(barName)
+    if barName == "armor" then
+    return false
+    end
+    end)
+
+### `ShouldDisableThirdperson(client)`
+
+    
+    Description:
+    Checks if third-person view is allowed or disabled.
+    
+    Parameters:
+    client (Player) – Player to test.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean (true if 3rd-person should be disabled)
+    
+    Example Usage:
+    -- Prints a message when ShouldDisableThirdperson is triggered
+    hook.Add("ShouldDisableThirdperson", "DisableForInvisibles", function(client)
+    if client:isInvisible() then
+    return true -- Disable third-person view when invisible
+    end
+    end)
+
+### `ShouldHideBars()`
+
+    
+    Description:
+    Determines whether all HUD bars should be hidden.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean|nil: true to hide, nil to allow rendering.
+    
+    Example Usage:
+    -- Prints a message when ShouldHideBars is triggered
+    hook.Add("ShouldHideBars", "HideHUDInCinematic", function()
+    if gui.IsInCinematicMode() then
+    return true
+    end
+    end)
+
+### `thirdPersonToggled(state)`
+
+    
+    Description:
+    Called when third-person mode is toggled on or off. Allows for custom handling of third-person mode changes.
+    
+    Parameters:
+    state (boolean) – true if third-person is enabled, false if disabled.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when thirdPersonToggled is triggered
+    hook.Add("thirdPersonToggled", "NotifyThirdPersonChange", function(state)
+    if state then
+    chat.AddText(Color(0,255,0), "Third-person view enabled.")
+    else
+    chat.AddText(Color(255,0,0), "Third-person view disabled.")
+    end
+    print("Third-person mode toggled to:", state)
+    end)
+
+### `AddTextField(sectionName, fieldName, labelText, valueFunc)`
+
+    
+    Description:
+    Called when a text field is added to an F1 menu information section.
+    Allows modules to modify or monitor the field being inserted.
+    
+    Parameters:
+    sectionName (string) – Target section name.
+    fieldName (string) – Unique field identifier.
+    labelText (string) – Text shown for the field.
+    valueFunc (function) – Function returning the value string.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Change the money field label.
+    hook.Add("AddTextField", "RenameMoneyField", function(section, name, label, value)
+    if name == "money" then
+    return section, name, "Credits", value
+    end
+    end)
+
+### `F1OnAddTextField(sectionName, fieldName, labelText, valueFunc)`
+
+    
+    Description:
+    Fired after AddTextField so other modules can react to new fields.
+    
+    Parameters:
+    sectionName (string) – Section name that received the field.
+    fieldName (string) – Identifier of the new field.
+    labelText (string) – Field label.
+    valueFunc (function) – Function returning the field value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Log newly added fields.
+    hook.Add("F1OnAddTextField", "LogFields", function(section, name)
+    print("Added field", name, "to section", section)
+    end)
+
+### `F1OnAddBarField(sectionName, fieldName, labelText, minFunc, maxFunc, valueFunc)`
+
+    
+    Description:
+    Triggered after AddBarField inserts a status bar into the F1 menu.
+    
+    Parameters:
+    sectionName (string) – Section identifier.
+    fieldName (string) – Bar field name.
+    labelText (string) – Bar label text.
+    minFunc (function) – Function returning the minimum value.
+    maxFunc (function) – Function returning the maximum value.
+    valueFunc (function) – Function returning the current value.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when F1OnAddBarField is triggered
+    hook.Add("F1OnAddBarField", "TrackBars", function(section, name)
+    print("Added bar", name)
+    end)
+
+### `CreateInformationButtons(pages)`
+
+    
+    Description:
+    Called while building the F1 information menu to populate navigation buttons.
+    
+    Parameters:
+    pages (table) – Table to add page definitions into.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CreateInformationButtons is triggered
+    hook.Add("CreateInformationButtons", "AddHelpPage", function(pages)
+    table.insert(pages, {name = "Help", drawFunc = function(parent) end})
+    end)
+
+### `PopulateConfigurationButtons(pages)`
+
+    
+    Description:
+    Invoked when the settings tab is constructed allowing new configuration pages.
+    
+    Parameters:
+    pages (table) – Table to populate with config pages.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PopulateConfigurationButtons is triggered
+    hook.Add("PopulateConfigurationButtons", "AddControlsPage", function(pages)
+    table.insert(pages, {name = "Controls", drawFunc = function(p) end})
+    end)
+
+### `InitializedKeybinds()`
+
+    
+    Description:
+    Called after keybinds have been loaded from disk.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when InitializedKeybinds is triggered
+    hook.Add("InitializedKeybinds", "NotifyKeybinds", function()
+    chat.AddText("Keybinds loaded")
+    end)
+
+### `getOOCDelay(client)`
+
+    
+    Description:
+    Allows modification of the cooldown delay between OOC messages.
+    
+    Parameters:
+    client (Player) – Player sending OOC chat.
+    
+    Realm:
+    Server
+    
+    Returns:
+    number|nil – Custom cooldown in seconds.
+    
+    Example Usage:
+    -- Prints a message when getOOCDelay is triggered
+    hook.Add("getOOCDelay", "AdminOOC", function(ply)
+    if ply:IsAdmin() then
+    return 5
+    end
+    end)
+
+### `OnChatReceived(client, chatType, text, anonymous)`
+
+    
+    Description:
+    Runs on the client when chat text is received before display.
+    Returning modified text will replace the message.
+    
+    Parameters:
+    client (Player) – Player that sent the chat.
+    chatType (string) – Chat type identifier.
+    text (string) – Message text.
+    anonymous (boolean) – True if anonymous chat.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string|nil – Replacement text.
+    
+    Example Usage:
+    -- Prints a message when OnChatReceived is triggered
+    hook.Add("OnChatReceived", "CensorChat", function(ply, type, msg)
+    return msg:gsub("badword", "****")
+    end)
+
+### `getAdjustedPartData(wearer, id)`
+
+    
+    Description:
+    Requests PAC3 part data after adjustments have been applied.
+    
+    Parameters:
+    wearer (Entity) – Entity wearing the outfit.
+    id (string) – Part identifier.
+    
+    Realm:
+    Client
+    
+    Returns:
+    table|nil – Adjusted part data.
+    
+    Example Usage:
+    -- Prints a message when getAdjustedPartData is triggered
+    hook.Add("getAdjustedPartData", "DebugParts", function(ply, partID)
+    print("Requesting part", partID)
+    end)
+
+### `AdjustPACPartData(wearer, id, data)`
+
+    
+    Description:
+    Allows modules to modify PAC3 part data before it is attached.
+    
+    Parameters:
+    wearer (Entity) – Entity wearing the part.
+    id (string) – Part identifier.
+    data (table) – Part data table.
+    
+    Realm:
+    Client
+    
+    Returns:
+    table|nil – Modified data table.
+    
+    Example Usage:
+    -- Prints a message when AdjustPACPartData is triggered
+    hook.Add("AdjustPACPartData", "ColorParts", function(ply, partID, d)
+    d.Color = Vector(1,0,0)
+    return d
+    end)
+
+### `attachPart(client, id)`
+
+    
+    Description:
+    Called when a PAC3 part should be attached to a player.
+    
+    Parameters:
+    client (Player) – Player receiving the part.
+    id (string) – Part identifier.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when attachPart is triggered
+    hook.Add("attachPart", "AnnouncePart", function(ply, partID)
+    print(ply, "received part", partID)
+    end)
+
+### `removePart(client, id)`
+
+    
+    Description:
+    Triggered when a PAC3 part is removed from a player.
+    
+    Parameters:
+    client (Player) – Player losing the part.
+    id (string) – Part identifier being removed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when removePart is triggered
+    hook.Add("removePart", "LogPartRemoval", function(ply, partID)
+    print(partID, "removed from", ply)
+    end)
+
+### `OnPAC3PartTransfered(part)`
+
+    
+    Description:
+    Fired when a PAC3 outfit part transfers ownership to a ragdoll.
+    
+    Parameters:
+    part (Entity) – The outfit part being transferred.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnPAC3PartTransfered is triggered
+    hook.Add("OnPAC3PartTransfered", "TrackTransfers", function(p)
+    print("Part transferred", p)
+    end)
+
+### `DrawPlayerRagdoll(entity)`
+
+    
+    Description:
+    Allows custom rendering of a player's ragdoll created by PAC3.
+    
+    Parameters:
+    entity (Entity) – Ragdoll entity to draw.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when DrawPlayerRagdoll is triggered
+    hook.Add("DrawPlayerRagdoll", "TintRagdoll", function(ent)
+    render.SetColorModulation(1,0,0)
+    end)
+
+### `setupPACDataFromItems()`
+
+    
+    Description:
+    Initializes PAC3 outfits from equipped items after modules load.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when setupPACDataFromItems is triggered
+    hook.Add("setupPACDataFromItems", "InitPAC", function()
+    print("Equipped PAC data loaded")
+    end)
+
+### `TryViewModel(entity)`
+
+    
+    Description:
+    Allows PAC3 to swap the view model entity for event checks.
+    
+    Parameters:
+    entity (Entity) – The view model entity.
+    
+    Realm:
+    Client
+    
+    Returns:
+    Entity – Replacement entity.
+    
+    Example Usage:
+    -- Prints a message when TryViewModel is triggered
+    hook.Add("TryViewModel", "UsePlayerViewModel", function(ent)
+    return ent == LocalPlayer():GetViewModel() and LocalPlayer() or ent
+    end)
+
+### `WeaponCycleSound()`
+
+    
+    Description:
+    Lets modules provide a custom sound when cycling weapons in the selector.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    string|nil – Sound path.
+    number|nil – Playback pitch.
+    
+    Example Usage:
+    -- Prints a message when WeaponCycleSound is triggered
+    hook.Add("WeaponCycleSound", "SilentCycle", function()
+    return "buttons/button15.wav", 100
+    end)
+
+### `WeaponSelectSound()`
+
+    
+    Description:
+    Similar to WeaponCycleSound but used when confirming a weapon choice.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    string|nil – Sound path.
+    number|nil – Playback pitch.
+    
+    Example Usage:
+    -- Prints a message when WeaponSelectSound is triggered
+    hook.Add("WeaponSelectSound", "CustomSelectSound", function()
+    return "buttons/button24.wav", 90
+    end)
+
+### `ShouldDrawWepSelect(client)`
+
+    
+    Description:
+    Determines if the weapon selection UI should be visible.
+    
+    Parameters:
+    client (Player) – Player whose UI is drawing.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Prints a message when ShouldDrawWepSelect is triggered
+    hook.Add("ShouldDrawWepSelect", "HideInVehicles", function(ply)
+    return not ply:InVehicle()
+    end)
+
+### `CanPlayerChooseWeapon(weapon)`
+
+    
+    Description:
+    Checks whether the active weapon can be selected via the weapon wheel.
+    
+    Parameters:
+    weapon (Weapon) – Weapon to name.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean|nil – false to block selection.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerChooseWeapon is triggered
+    hook.Add("CanPlayerChooseWeapon", "BlockPhysgun", function(wep)
+    if IsValid(wep) and wep:GetClass() == "weapon_physgun" then
+    return false
+    end
+    end)
+
+### `OverrideSpawnTime(client, baseTime)`
+
+    
+    Description:
+    Allows modules to modify the respawn delay after death.
+    
+    Parameters:
+    client (Player) – Respawning player.
+    baseTime (number) – Default respawn delay.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number|nil – New respawn time.
+    
+    Example Usage:
+    -- Prints a message when OverrideSpawnTime is triggered
+    hook.Add("OverrideSpawnTime", "ShortRespawns", function(ply, time)
+    if ply:IsAdmin() then return 2 end
+    end)
+
+### `ShouldRespawnScreenAppear()`
+
+    
+    Description:
+    Lets modules suppress the respawn HUD from showing.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean|nil – false to hide.
+    
+    Example Usage:
+    -- Prints a message when ShouldRespawnScreenAppear is triggered
+    hook.Add("ShouldRespawnScreenAppear", "NoRespawnHUD", function()
+    return false
+    end)
+
+### `VoiceToggled(enabled)`
+
+    
+    Description:
+    Fired when voice chat is enabled or disabled via config.
+    
+    Parameters:
+    enabled (boolean) – Current voice chat state.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when VoiceToggled is triggered
+    hook.Add("VoiceToggled", "AnnounceVoice", function(state)
+    print("Voice chat set to", state)
+    end)
+
+### `DermaSkinChanged(skin)`
+
+    
+    Description:
+    Fired when the Derma UI skin configuration value changes.
+    Allows modules to react to the UI skin being switched.
+    
+    Parameters:
+    skin (string) – Name of the new Derma skin.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Reload custom panels when the skin changes
+    hook.Add("DermaSkinChanged", "UpdatePanels", function(skin)
+    MyPanel:ReloadSkin(skin)
+    end)
+
+### `RefreshFonts()`
+
+    
+    Description:
+    Requests recreation of all registered UI fonts.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when RefreshFonts is triggered
+    hook.Add("RefreshFonts", "ReloadFonts", function()
+    print("Fonts refreshed")
+    end)
+
+### `AdjustCreationData(client, data, newData, originalData)`
+
+    
+    Description:
+    Allows modification of character creation data before the character is saved.
+    
+    Parameters:
+    client (Player) – Player creating the character.
+    data (table) – Sanitized creation data.
+    newData (table) – Table to modify.
+    originalData (table) – Raw data before adjustments.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when AdjustCreationData is triggered
+    hook.Add("AdjustCreationData", "EnforceName", function(ply, data, newData)
+    if data.name == "" then newData.name = "Unnamed" end
+    end)
+
+### `CanCharBeTransfered(character, newFaction, oldFaction)`
+
+    
+    Description:
+    Determines if a character may switch factions.
+    
+    Parameters:
+    character (table) – Character being transferred.
+    newFaction (table) – Faction to join.
+    oldFaction (number) – Index of the current faction.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to block.
+    
+    Example Usage:
+    -- Prints a message when CanCharBeTransfered is triggered
+    hook.Add("CanCharBeTransfered", "BlockRestrictedFactions", function(char, faction)
+    if faction.isRestricted then return false end
+    end)
+
+### `CanPlayerUseChar(client, character)`
+
+    
+    Description:
+    Called when a player attempts to load one of their characters.
+    
+    Parameters:
+    client (Player) – Player loading the character.
+    character (table) – Character being loaded.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to deny.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerUseChar is triggered
+    hook.Add("CanPlayerUseChar", "CheckBans", function(ply, char)
+    if char:isBanned() then return false, "Character banned" end
+    end)
+
+### `CanPlayerSwitchChar(client, currentChar, newChar)`
+
+    
+    Description:
+    Checks if a player can switch from their current character to another.
+    
+    Parameters:
+    client (Player) – Player attempting the switch.
+    currentChar (table) – Currently loaded character.
+    newChar (table) – Character to switch to.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to block the switch.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerSwitchChar is triggered
+    hook.Add("CanPlayerSwitchChar", "NoSwitchInCombat", function(ply)
+    if ply:isInCombat() then return false end
+    end)
+
+### `CanPlayerLock(client, door)`
+
+    
+    Description:
+    Determines whether the player may lock the given door or vehicle.
+    
+    Parameters:
+    client (Player) – Player attempting to lock.
+    door (Entity) – Door or vehicle entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to disallow.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerLock is triggered
+    hook.Add("CanPlayerLock", "AdminsAlwaysLock", function(ply)
+    if ply:IsAdmin() then return true end
+    end)
+
+### `CanPlayerUnlock(client, door)`
+
+    
+    Description:
+    Determines whether the player may unlock the given door or vehicle.
+    
+    Parameters:
+    client (Player) – Player attempting to unlock.
+    door (Entity) – Door or vehicle entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to disallow.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerUnlock is triggered
+    hook.Add("CanPlayerUnlock", "AdminsAlwaysUnlock", function(ply)
+    if ply:IsAdmin() then return true end
+    end)
+
+### `CanPlayerModifyConfig(client, key)`
+
+    
+    Description:
+    Called when a player attempts to change a configuration value.
+    
+    Parameters:
+    client (Player) – Player attempting the change.
+    key (string) – Config key being modified.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean|nil – false to deny modification.
+    
+    Example Usage:
+    -- Prints a message when CanPlayerModifyConfig is triggered
+    hook.Add("CanPlayerModifyConfig", "RestrictConfig", function(ply, k)
+    return ply:IsSuperAdmin()
+    end)
+
+### `CharDeleted(client, character)`
+
+    
+    Description:
+    Fired after a character is permanently removed.
+    
+    Parameters:
+    client (Player) – Player who owned the character.
+    character (table) – Character that was deleted.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when CharDeleted is triggered
+    hook.Add("CharDeleted", "LogDeletion", function(ply, char)
+    print(ply:Name(), "deleted character", char:getName())
+    end)
+
+### `CheckFactionLimitReached(faction, character, client)`
+
+    
+    Description:
+    Allows custom logic for determining if a faction has reached its player limit.
+    
+    Parameters:
+    faction (table) – Faction being checked.
+    character (table) – Character requesting to join.
+    client (Player) – Owning player.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    boolean
+    
+    Example Usage:
+    -- Prints a message when CheckFactionLimitReached is triggered
+    hook.Add("CheckFactionLimitReached", "IgnoreAdmins", function(faction, char, ply)
+    if ply:IsAdmin() then
+    return false
+    end
+    end)
+
+### `F1OnAddSection(sectionName, color, priority, location)`
+
+    
+    Description:
+    Triggered after AddSection inserts a new information section.
+    
+    Parameters:
+    sectionName (string) – Name of the inserted section.
+    color (Color) – Display color for the section.
+    priority (number) – Sorting priority.
+    location (number) – Column index.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when F1OnAddSection is triggered
+    hook.Add("F1OnAddSection", "PrintSection", function(name)
+    print("Added section", name)
+    end)
+
+### `GetWeaponName(weapon)`
+
+    
+    Description:
+    Allows overriding of the displayed weapon name in the selector.
+    
+    Parameters:
+    weapon (Weapon) – Weapon to name.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string|nil – Replacement name.
+    
+    Example Usage:
+    -- Prints a message when GetWeaponName is triggered
+    hook.Add("GetWeaponName", "UppercaseName", function(wep)
+    return wep:GetClass():upper()
+    end)
+
+### `OnCharGetup(client, entity)`
+
+    
+    Description:
+    Called when a ragdolled character finishes getting up.
+    
+    Parameters:
+    client (Player) – Player getting up.
+    entity (Entity) – Ragdoll entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnCharGetup is triggered
+    hook.Add("OnCharGetup", "NotifyGetup", function(ply)
+    ply:ChatPrint("You stood up")
+    end)
+
+### `OnLocalizationLoaded()`
+
+    
+    Description:
+    Fired once language files finish loading.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnLocalizationLoaded is triggered
+    hook.Add("OnLocalizationLoaded", "PrintLang", function()
+    print("Localization ready")
+    end)
+
+### `OnPlayerObserve(client, state)`
+
+    
+    Description:
+    Called when a player's observe mode is toggled.
+    
+    Parameters:
+    client (Player) – Player toggling observe mode.
+    state (boolean) – True to enable observing.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when OnPlayerObserve is triggered
+    hook.Add("OnPlayerObserve", "AnnounceObserve", function(ply, s)
+    print(ply, s and "entered" or "left", "observe mode")
+    end)
+
+### `PlayerLoadedChar(client, character, previousChar)`
+
+    
+    Description:
+    Runs after a character has been loaded and set up for a player.
+    
+    Parameters:
+    client (Player) – Player who loaded the character.
+    character (table) – New character object.
+    previousChar (table|nil) – Previously active character.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PlayerLoadedChar is triggered
+    hook.Add("PlayerLoadedChar", "WelcomeBack", function(ply, char)
+    ply:ChatPrint("Welcome, " .. char:getName())
+    end)
+
+### `PrePlayerLoadedChar(client, newChar, oldChar)`
+
+    
+    Description:
+    Fired right before a player switches to a new character.
+    
+    Parameters:
+    client (Player) – Player switching characters.
+    newChar (table) – Character being loaded.
+    oldChar (table|nil) – Character being left.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PrePlayerLoadedChar is triggered
+    hook.Add("PrePlayerLoadedChar", "SaveStuff", function(ply, new, old)
+    print("Switching characters")
+    end)
+
+### `PostPlayerLoadedChar(client, character, previousChar)`
+
+    
+    Description:
+    Called after PlayerLoadedChar to allow post-load operations.
+    
+    Parameters:
+    client (Player) – Player that finished loading.
+    character (table) – Active character table.
+    previousChar (table|nil) – Previous character if any.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PostPlayerLoadedChar is triggered
+    hook.Add("PostPlayerLoadedChar", "GiveItems", function(ply, char)
+    -- Give starter items here
+    end)
+
+### `PlayerSay(client, text)`
+
+    
+    Description:
+    Custom hook executed when a player sends a chat message server-side.
+    
+    Parameters:
+    client (Player) – Speaking player.
+    text (string) – Message content.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PlayerSay is triggered
+    hook.Add("PlayerSay", "LogChat", function(ply, msg)
+    print(ply:Name() .. ": " .. msg)
+    end)
+
+### `PopulateAdminStick(menu, target)`
+
+    
+    Description:
+    Called after the admin stick menu is created so additional commands can be added.
+    
+    Parameters:
+    menu (DermaPanel) – Context menu panel.
+    target (Entity) – Target entity of the admin stick.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when PopulateAdminStick is triggered
+    hook.Add("PopulateAdminStick", "AddCustomOption", function(menu, ent)
+    menu:AddOption("Wave", function() RunConsoleCommand("act", "wave") end)
+    end)
+
+### `TicketSystemClaim(admin, requester)`
+
+    
+    Description:
+    Fired when a staff member claims a help ticket.
+    
+    Parameters:
+    admin (Player) – Staff member claiming the ticket.
+    requester (Player) – Player who opened the ticket.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when TicketSystemClaim is triggered
+    hook.Add("TicketSystemClaim", "NotifyClaim", function(staff, ply)
+    staff:ChatPrint("Claimed ticket from " .. ply:Name())
+    end)
+
+### `liaOptionReceived(client, key, value)`
+
+    
+    Description:
+    Triggered when a shared option value is changed.
+    
+    Parameters:
+    client (Player|nil) – Player that changed the option or nil if server.
+    key (string) – Option identifier.
+    value (any) – New value.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- Prints a message when liaOptionReceived is triggered
+    hook.Add("liaOptionReceived", "PrintOptionChange", function(_, k, v)
+    print("Option", k, "set to", v)
+    end)
+

--- a/docs/docs/framework/libraries/.pages
+++ b/docs/docs/framework/libraries/.pages
@@ -26,7 +26,7 @@ arrange:
   - lia.networking.md
   - lia.notice.md
   - lia.option.md
-  - lia.pac.md
   - lia.time.md
   - lia.util.md
   - lia.workshop.md
+  - lia.webimage.md

--- a/docs/docs/framework/libraries/lia.attributes.md
+++ b/docs/docs/framework/libraries/lia.attributes.md
@@ -1,0 +1,43 @@
+### `lia.attribs.loadFromDir(directory)`
+
+    
+    Description:
+    Loads attribute definitions from the given folder. Files prefixed
+    with "sh_" are treated as shared and loaded on both client and
+    server. The ATTRIBUTE table returned from each file is stored in
+    lia.attribs.list using the filename, without prefix or extension,
+    as the key.
+    
+    Parameters:
+    directory (string) – Path to the folder containing attribute Lua files.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.attribs.loadFromDir
+    lia.attribs.loadFromDir("schema/attributes")
+
+### `lia.attribs.setup(client)`
+
+    
+    Description:
+    Initializes attribute data for a client's character. Each attribute in
+    lia.attribs.list is read from the character and, if the attribute has
+    an OnSetup callback, it is executed with the current value.
+    
+    Parameters:
+    client (Player) – The player whose character attributes should be set up.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.attribs.setup
+    lia.attribs.setup(client)

--- a/docs/docs/framework/libraries/lia.bars.md
+++ b/docs/docs/framework/libraries/lia.bars.md
@@ -1,0 +1,136 @@
+### `lia.bar.get(identifier)`
+
+    
+    Description:
+    Retrieves a bar object from the list by its unique identifier.
+    
+    Parameters:
+    identifier (string) – The unique identifier of the bar to retrieve.
+    
+    Realm:
+    Client
+    
+    Returns:
+    table or nil – The bar table if found, or nil if not found.
+    
+    Example Usage:
+    -- Retrieve the health bar and change its color at runtime
+    local bar = lia.bar.get("health")
+    if bar then
+    bar.color = Color(0, 200, 0) -- make the bar green
+    end
+
+### `lia.bar.add(getValue, color, priority, identifier)`
+
+    
+    Description:
+    Adds a new bar or replaces an existing one in the bar list.
+    If the identifier matches an existing bar, the old bar is removed first.
+    Bars are drawn in order of ascending priority.
+    
+    Parameters:
+    getValue (function) – A callback that returns the current value of the bar.
+    color (Color) – The fill color for the bar. Defaults to a random pastel color.
+    priority (number) – Determines drawing order; lower values draw first. Defaults to end of list.
+    identifier (string) – Optional unique identifier for the bar.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number – The priority assigned to the added bar.
+    
+    Example Usage:
+    -- Calculates the player's current health as a fraction of their maximum health.
+    -- Uses a custom color (RGB 200, 50, 40) for the bar's fill.
+    -- Assigns priority 1 so this bar draws before lower-priority bars.
+    lia.bar.add(function()
+    local client = LocalPlayer()
+    return client:Health() / client:GetMaxHealth()
+    end, Color(200, 50, 40), 1, "health")
+
+### `lia.bar.remove(identifier)`
+
+    
+    Description:
+    Removes a bar from the list based on its unique identifier.
+    
+    Parameters:
+    identifier (string) – The unique identifier of the bar to remove.
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.bar.remove
+    lia.bar.remove("example")
+
+### `lia.bar.drawBar(x, y, w, h, pos, max, color)`
+
+    
+    Description:
+    Draws a single horizontal bar at the specified screen coordinates,
+    filling it proportionally based on pos and max.
+    
+    Parameters:
+    x (number) – The x-coordinate of the bar's top-left corner.
+    y (number) – The y-coordinate of the bar's top-left corner.
+    w (number) – The total width of the bar (including padding).
+    h (number) – The total height of the bar.
+    pos (number) – The current value to display (will be clamped to max).
+    max (number) – The maximum possible value for the bar.
+    color (Color) – The color to fill the bar.
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.bar.drawBar
+    lia.bar.drawBar(10, 10, 200, 20, 0.5, 1, Color(255,0,0))
+
+### `lia.bar.drawAction(text, duration)`
+
+    
+    Description:
+    Displays a temporary action progress bar with accompanying text
+    for the specified duration on the HUD.
+    
+    Parameters:
+    text (string) – The text to display above the progress bar.
+    duration (number) – Duration in seconds for which the bar is displayed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.bar.drawAction
+    lia.bar.drawAction("Reloading", 2)
+
+### `lia.bar.drawAll()`
+
+    
+    Description:
+    Iterates through all registered bars, applies smoothing to their values,
+    and draws them on the HUD according to their priority and visibility rules.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of hook.Add
+    hook.Add("HUDPaintBackground", "liaBarDraw", lia.bar.drawAll)

--- a/docs/docs/framework/libraries/lia.character.md
+++ b/docs/docs/framework/libraries/lia.character.md
@@ -1,0 +1,320 @@
+### `lia.char.new(data, id, client, steamID)`
+
+    
+    Description:
+    Creates a new character instance with default variables and metatable.
+    
+    Parameters:
+    data (table) – Table of character variables.
+    id (number) – Character ID.
+    client (Player) – Player entity.
+    steamID (string) – SteamID64 string if client is not valid.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    character (table) – New character object.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.new
+    local char = lia.char.new({name = "John"}, 1, client)
+
+### `lia.char.hookVar(varName, hookName, func)`
+
+    
+    Description:
+    Registers a hook function for when a character variable changes.
+    
+    Parameters:
+    varName (string) – Variable name to hook.
+    hookName (string) – Unique hook identifier.
+    func (function) – Function to call on variable change.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.hookVar
+    lia.char.hookVar("name", "PrintName", function(old, new) print(new) end)
+
+### `lia.char.registerVar(key, data)`
+
+    
+    Description:
+    Registers a character variable with metadata and generates accessor methods.
+    
+    Parameters:
+    key (string) – Variable key.
+    data (table) – Variable metadata including default, validation, networking, etc.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.registerVar
+    lia.char.registerVar("age", {field = "_age", default = 20})
+
+### `lia.char.getCharData(charID, key)`
+
+    
+    Description:
+    Retrieves character data JSON from the database as a Lua table.
+    
+    Parameters:
+    charID (number|string) – Character ID.
+    key (string) – Specific data key to return (optional).
+    
+    Realm:
+    Shared
+    
+    Returns:
+    value (any) – Data value or full table if no key provided.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.getCharData
+    local age = lia.char.getCharData(1, "age")
+
+### `lia.char.getCharDataRaw(charID, key)`
+
+    
+    Description:
+    Retrieves raw character database row or specific column.
+    
+    Parameters:
+    charID (number|string) – Character ID.
+    key (string) – Specific column name to return (optional).
+    
+    Realm:
+    Shared
+    
+    Returns:
+    row (table|any) – Full row table or column value.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.getCharDataRaw
+    local row = lia.char.getCharDataRaw(1)
+
+### `lia.char.getOwnerByID(ID)`
+
+    
+    Description:
+    Finds the player entity that owns the character with the given ID.
+    
+    Parameters:
+    ID (number|string) – Character ID.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    Player – Player entity or nil if not found.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.getOwnerByID
+    local ply = lia.char.getOwnerByID(1)
+
+### `lia.char.getBySteamID(steamID)`
+
+    
+    Description:
+    Retrieves a character object by SteamID or SteamID64.
+    
+    Parameters:
+    steamID (string) – SteamID or SteamID64.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    Character – Character object or nil.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.getBySteamID
+    local char = lia.char.getBySteamID("STEAM_0:0:11101")
+
+### `lia.char.getAll()`
+
+    
+    Description:
+    Returns a table mapping all players to their loaded character objects.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    table – Map of Player to Character.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of pairs
+    for ply, char in pairs(lia.char.getAll()) do print(ply, char:getName()) end
+
+### `lia.char.GetTeamColor(client)`
+
+    
+    Description:
+    Determines the team color for a client based on their character class or default team.
+    
+    Parameters:
+    client (Player) – Player entity.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    Color – Team or class color.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.GetTeamColor
+    local color = lia.char.GetTeamColor(client)
+
+### `lia.char.create(data, callback)`
+
+    
+    Description:
+    Inserts a new character into the database and sets up default inventory.
+    
+    Parameters:
+    data (table) – Character creation data.
+    callback (function) – Callback receiving new character ID.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.create
+    lia.char.create({name = "John"}, function(id) print("Created", id) end)
+
+### `lia.char.restore(client, callback, id)`
+
+    
+    Description:
+    Loads characters for a client from the database, optionally filtering by ID.
+    
+    Parameters:
+    client (Player) – Player entity.
+    callback (function) – Callback receiving list of character IDs.
+    id (number) – Specific character ID to restore (optional).
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.restore
+    lia.char.restore(client, print)
+
+### `lia.char.cleanUpForPlayer(client)`
+
+    
+    Description:
+    Cleans up loaded characters and inventories for a player on disconnect.
+    
+    Parameters:
+    client (Player) – Player entity.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.cleanUpForPlayer
+    lia.char.cleanUpForPlayer(client)
+
+### `lia.char.delete(id, client)`
+
+    
+    Description:
+    Deletes a character by ID from the database, cleans up and notifies players.
+    
+    Parameters:
+    id (number) – Character ID to delete.
+    client (Player) – Player entity reference.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.delete
+    lia.char.delete(1, client)
+
+### `lia.char.setCharData(charID, key, val)`
+
+    
+    Description:
+    Updates a character's JSON data field in the database and loaded object.
+    
+    Parameters:
+    charID (number|string) – Character ID.
+    key (string) – Data key.
+    val (any) – New value.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – True on success, false on failure.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.setCharData
+    lia.char.setCharData(1, "age", 25)
+
+### `lia.char.setCharName(charID, name)`
+
+    
+    Description:
+    Updates the character's name in the database and loaded object.
+    
+    Parameters:
+    charID (number|string) – Character ID.
+    name (string) – New character name.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – True on success, false on failure.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.setCharName
+    lia.char.setCharName(1, "NewName")
+
+### `lia.char.setCharModel(charID, model, bg)`
+
+    
+    Description:
+    Updates the character's model and bodygroups in the database and in-game.
+    
+    Parameters:
+    charID (number|string) – Character ID.
+    model (string) – Model path.
+    bg (table) – Bodygroup table list.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – True on success, false on failure.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.char.setCharModel
+    lia.char.setCharModel(1, "models/player.mdl", {})

--- a/docs/docs/framework/libraries/lia.chatbox.md
+++ b/docs/docs/framework/libraries/lia.chatbox.md
@@ -1,0 +1,92 @@
+### `lia.chat.timestamp(ooc)`
+
+    
+    Description:
+    Returns a formatted timestamp if chat timestamps are enabled.
+    
+    Parameters:
+    ooc (boolean) – True for out-of-character messages.
+    
+    Returns:
+    string – Formatted time string or an empty string.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.chat.timestamp
+    local ts = lia.chat.timestamp(false)
+
+### `lia.chat.register(chatType, data)`
+
+    
+    Description:
+    Registers a new chat class and sets up command aliases.
+    
+    Parameters:
+    chatType (string) – Identifier for the chat class.
+    data (table) – Table of chat class properties.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Register a simple "/me" chat command that prints actions in purple
+    lia.chat.register("me", {
+    onChatAdd = function(_, speaker, text)
+    chat.AddText(Color(200, 100, 255), "* " .. speaker:Name() .. " " .. text)
+    end,
+    prefix = {"/me"}
+    })
+
+### `lia.chat.parse(client, message, noSend)`
+
+    
+    Description:
+    Parses chat text for the proper chat type and optionally sends it.
+    
+    Parameters:
+    client (Player) – Player sending the message.
+    message (string) – The chat text.
+    noSend (boolean) – Suppress sending when true.
+    
+    Returns:
+    chatType (string), text (string), anonymous (boolean)
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Parse chat messages and log "/me" actions to the console
+    hook.Add("PlayerSay", "LogActions", function(ply, text)
+    local class, parsed = lia.chat.parse(ply, text)
+    if class == "me" then
+    print(ply:Name() .. " performs action: " .. parsed)
+    end
+    end)
+
+### `lia.chat.send(speaker, chatType, text, anonymous, receivers)`
+
+    
+    Description:
+    Broadcasts a chat message to all eligible receivers.
+    
+    Parameters:
+    speaker (Player) – The message sender.
+    chatType (string) – Chat class identifier.
+    text (string) – Message text.
+    anonymous (boolean) – Whether the sender is anonymous.
+    receivers (table) – Optional list of target players.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.chat.send
+    lia.chat.send(client, "ic", "Hello")

--- a/docs/docs/framework/libraries/lia.classes.md
+++ b/docs/docs/framework/libraries/lia.classes.md
@@ -1,0 +1,135 @@
+### `lia.class.loadFromDir(directory)`
+
+    
+    Description:
+    Loads all class definitions from the given directory and stores them in lia.class.list.
+    
+    Parameters:
+    directory (string) – Folder path containing class Lua files.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.loadFromDir
+    lia.class.loadFromDir("schema/classes")
+
+### `lia.class.canBe(client, class)`
+
+    
+    Description:
+    Determines if the given client may become the specified class.
+    
+    Parameters:
+    client (Player) – Player attempting to join.
+    class (string|number) – Class identifier.
+    
+    Returns:
+    boolean – False with a message if denied; default status when allowed.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.canBe
+    local allowed = lia.class.canBe(client, classID)
+
+### `lia.class.get(identifier)`
+
+    
+    Description:
+    Retrieves the class table associated with the given identifier.
+    
+    Parameters:
+    identifier (string|number) – Unique identifier for the class.
+    
+    Returns:
+    table|nil – Class table if found.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.get
+    local classData = lia.class.get(1)
+
+### `lia.class.getPlayers(class)`
+
+    
+    Description:
+    Returns a table of players whose characters belong to the given class.
+    
+    Parameters:
+    class (string|number) – Class identifier.
+    
+    Returns:
+    table – List of player objects.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.getPlayers
+    local players = lia.class.getPlayers(classID)
+
+### `lia.class.getPlayerCount(class)`
+
+    
+    Description:
+    Counts how many players belong to the given class.
+    
+    Parameters:
+    class (string|number) – Class identifier.
+    
+    Returns:
+    number – Player count.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.getPlayerCount
+    local count = lia.class.getPlayerCount(classID)
+
+### `lia.class.retrieveClass(class)`
+
+    
+    Description:
+    Searches the class list for a class whose ID or name matches the given text.
+    
+    Parameters:
+    class (string) – Search text.
+    
+    Returns:
+    string|nil – Matching class identifier or nil.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.retrieveClass
+    local id = lia.class.retrieveClass("police")
+
+### `lia.class.hasWhitelist(class)`
+
+    
+    Description:
+    Returns whether the specified class requires a whitelist.
+    
+    Parameters:
+    class (string|number) – Class identifier.
+    
+    Returns:
+    boolean – True if the class is whitelisted.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.class.hasWhitelist
+    if lia.class.hasWhitelist(classID) then
+    print("Whitelist required")
+    end

--- a/docs/docs/framework/libraries/lia.color.md
+++ b/docs/docs/framework/libraries/lia.color.md
@@ -1,0 +1,61 @@
+### `lia.color.register(name, color)`
+
+    
+    Description:
+    Registers a named color for later lookup.
+    
+    Parameters:
+    name (string) – Key used to reference the color.
+    color (Color) – Color object or table.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.color.register
+    lia.color.register("myRed", Color(255,0,0))
+
+### `lia.color.Adjust(color, rOffset, gOffset, bOffset, aOffset)`
+
+    
+    Description:
+    Creates a new color by applying offsets to each channel.
+    
+    Parameters:
+    color (Color) – Base color.
+    rOffset (number) – Red channel delta.
+    gOffset (number) – Green channel delta.
+    bOffset (number) – Blue channel delta.
+    aOffset (number) – Alpha channel delta (optional).
+    
+    Returns:
+    Color – Adjusted color.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.color.Adjust
+    local lighter = lia.color.Adjust(Color(50,50,50), 10,10,10)
+
+### `lia.color.ReturnMainAdjustedColors()`
+
+    
+    Description:
+    Returns a table of commonly used UI colors derived from the base config color.
+    
+    Parameters:
+    None
+    
+    Returns:
+    table – Mapping of UI color keys to Color objects.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.color.ReturnMainAdjustedColors
+    local uiColors = lia.color.ReturnMainAdjustedColors()

--- a/docs/docs/framework/libraries/lia.commands.md
+++ b/docs/docs/framework/libraries/lia.commands.md
@@ -1,0 +1,160 @@
+### `lia.command.add(command, data)`
+
+    
+    Description:
+    Registers a new command with its associated data.
+    
+    Parameters:
+    command (string) – Command name.
+    data (table) – Table containing command properties.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+
+### `lia.command.hasAccess(client, command, data)`
+
+    
+    Description:
+    Determines if a player may run the specified command.
+    
+    Parameters:
+    client (Player) – Command caller.
+    command (string) – Command name.
+    data (table) – Command data table.
+    
+    Returns:
+    boolean – Whether access is granted.
+    string – Privilege checked.
+    
+    Realm:
+    Shared
+
+### `lia.command.extractArgs`
+
+    
+    Description:
+    Splits the provided text into arguments, respecting quotes.
+    Quoted sections are treated as single arguments.
+    
+    Parameters:
+    text (string) – The raw input text to parse.
+    
+    Returns:
+    table – A list of arguments extracted from the text.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.command.extractArgs
+    local args = lia.command.extractArgs('/mycommand "quoted arg" anotherArg')
+    -- args = {"quoted arg", "anotherArg"}
+
+### `lia.command.parseSyntaxFields`
+
+    
+    Description:
+    Parses a command syntax string into an ordered list of field tables.
+    Each field contains a name and a type derived from the syntax.
+    
+    Parameters:
+    syntax (string) – The syntax string, e.g. "[string Name] [number Time]".
+    
+    Returns:
+    table – List of fields in call order.
+    boolean – Whether the syntax strictly used the "[type Name]" format.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Extract field data from a syntax string
+    local fields, valid = lia.command.parseSyntaxFields("[string Name] [number Time]")
+
+### `lia.command.run`
+
+    
+    Description:
+    Executes a command by its name, passing the provided arguments.
+    If the command returns a string, it notifies the client (if valid).
+    
+    Parameters:
+    client (Player) – The player or console running the command.
+    command (string) – The name of the command to run.
+    arguments (table) – A list of arguments for the command.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.command.run
+    lia.command.run(player, "mycommand", {"arg1", "arg2"})
+
+### `lia.command.parse`
+
+    
+    Description:
+    Attempts to parse the input text as a command, optionally using realCommand
+    and arguments if provided. If parsed successfully, the command is executed.
+    
+    Parameters:
+    client (Player) – The player or console issuing the command.
+    text (string) – The raw text that may contain the command name and arguments.
+    realCommand (string) – If provided, use this as the command name instead of parsing text.
+    arguments (table) – If provided, use these as the command arguments instead of parsing text.
+    
+    Returns:
+    boolean – True if the text was parsed as a valid command, false otherwise.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.command.parse
+    lia.command.parse(player, "/mycommand arg1 arg2")
+
+### `lia.command.send`
+
+    
+    Description:
+    Sends a command (and optional arguments) from the client to the server using the
+    Garry's Mod net library. The server will then execute the command.
+    
+    Parameters:
+    command (string) – The name of the command to send.
+    ... (vararg) – Any additional arguments to pass to the command.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.command.send
+    lia.command.send("mycommand", "arg1", "arg2")
+
+### `lia.command.openArgumentPrompt`
+
+    
+    Description:
+    Opens a window asking the player to fill in any arguments that were
+    omitted or left as placeholders when running a chat command. The
+    prompt only appears if the command's syntax fields were valid.
+    
+    Parameters:
+    cmd (string) – The command name.
+    fields (table) – Table of field names to their types.
+    prefix (table) – Arguments that were already supplied before the prompt.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client

--- a/docs/docs/framework/libraries/lia.config.md
+++ b/docs/docs/framework/libraries/lia.config.md
@@ -1,0 +1,191 @@
+### `lia.config.add(key, name, value, callback, data)`
+
+    
+    Description:
+    Registers a new config option with the given key, display name, default value, and optional callback/data.
+    
+    Parameters:
+    key (string) — The unique key identifying the config.
+    name (string) — The display name of the config option.
+    value (any) — The default value of this config option.
+    callback (function) — A function called when the value changes (optional).
+    data (table) — Additional data for this config option, including config type, category, description, etc.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Register a config option with a callback that prints when it changes
+    lia.config.add(
+    "maxPlayers",                 -- unique key
+    "Maximum Players",            -- name shown in the menu
+    64,                            -- default value
+    function(old, new)
+    print("Player limit updated from", old, "to", new)
+    end,
+    {category = "Server"}
+    )
+
+### `lia.config.setDefault(key, value)`
+
+    
+    Description:
+    Overrides the default value of an existing config.
+    
+    Parameters:
+    key (string) — The key identifying the config.
+    value (any) — The new default value.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.setDefault
+    lia.config.setDefault("maxPlayers", 32)
+
+### `lia.config.forceSet(key, value, noSave)`
+
+    
+    Description:
+    Forces a config value without triggering networking or callback if 'noSave' is true, then optionally saves.
+    
+    Parameters:
+    key (string) — The key identifying the config.
+    value (any) — The new value to set.
+    noSave (boolean) — If true, does not save to disk.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.forceSet
+    lia.config.forceSet("someSetting", true, true)
+
+### `lia.config.set(key, value)`
+
+    
+    Description:
+    Sets a config value, runs callback, and handles networking (if on server). Also saves the config.
+    
+    Parameters:
+    key (string) — The key identifying the config.
+    value (any) — The new value to set.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.set
+    lia.config.set("maxPlayers", 24)
+
+### `lia.config.get(key, default)`
+
+    
+    Description:
+    Retrieves the current value of a config, or returns a default if neither value nor default is set.
+    
+    Parameters:
+    key (string) — The key identifying the config.
+    default (any) — Fallback value if the config is not found.
+    
+    Returns:
+    (any) The config's value or the provided default.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.get
+    local players = lia.config.get("maxPlayers", 64)
+
+### `lia.config.load()`
+
+    
+    Description:
+    Loads the config data from storage (server-side) and updates the stored config values.
+    Triggers "InitializedConfig" hook once done.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.load
+    lia.config.load()
+
+### `lia.config.getChangedValues()`
+
+    
+    Description:
+    Returns a table of all config entries where the current value differs from the default.
+    
+    Parameters:
+    None
+    
+    Returns:
+    (table) Key-value pairs of changed config entries.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.getChangedValues
+    local changed = lia.config.getChangedValues()
+
+### `lia.config.send(client)`
+
+    
+    Description:
+    Sends current changed config values to a specified client.
+    
+    Parameters:
+    client (player) — The player to receive the config data.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.send
+    lia.config.send(client)
+
+### `lia.config.save()`
+
+    
+    Description:
+    Saves all changed config values to persistent storage.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.config.save
+    lia.config.save()

--- a/docs/docs/framework/libraries/lia.currency.md
+++ b/docs/docs/framework/libraries/lia.currency.md
@@ -1,0 +1,42 @@
+### `lia.currency.get`
+
+    
+    Description:
+    Formats a numeric amount into a currency string using the defined symbol,
+    singular, and plural names. If the amount is exactly 1, it returns the singular
+    form; otherwise, it returns the plural form.
+    
+    Parameters:
+    amount (number) – The amount to format.
+    
+    Returns:
+    string – The formatted currency string.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.currency.get
+    lia.currency.get(10)  -- e.g., "$10 dollars"
+
+### `lia.currency.spawn`
+
+    
+    Description:
+    Spawns a currency entity at the specified position with a given amount and optional angle.
+    Validates the position and ensures the amount is a non-negative number.
+    
+    Parameters:
+    pos (Vector) – The spawn position for the currency entity.
+    amount (number) – The monetary value for the entity.
+    angle (Angle, optional) – The orientation for the entity (defaults to Angle(0, 0, 0)).
+    
+    Returns:
+    Entity – The spawned currency entity if successful; nil otherwise.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.currency.spawn
+    lia.currency.spawn(Vector(0, 0, 0), 100)

--- a/docs/docs/framework/libraries/lia.darkrp.md
+++ b/docs/docs/framework/libraries/lia.darkrp.md
@@ -1,0 +1,148 @@
+### `lia.darkrp.isEmpty(position, entitiesToIgnore)`
+
+    
+    Description:
+    Checks whether the specified position is free from players, NPCs,
+    and props.
+    
+    Parameters:
+    position (Vector) – World position to test.
+    entitiesToIgnore (table) – Entities ignored during the check.
+    
+    Realm:
+    Server
+    
+    Returns:
+    boolean – True if the position is clear, false otherwise.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.isEmpty
+    if lia.darkrp.isEmpty(Vector(0,0,0)) then
+    print("Spawn point is clear")
+    end
+
+### `lia.darkrp.findEmptyPos(startPos, entitiesToIgnore, maxDistance, searchStep, checkArea)`
+
+    
+    Description:
+    Finds a nearby position that is unobstructed by players or props.
+    
+    Parameters:
+    startPos (Vector) – The initial position to search from.
+    entitiesToIgnore (table) – Entities ignored during the search.
+    maxDistance (number) – Maximum distance to search in units.
+    searchStep (number) – Step increment when expanding the search radius.
+    checkArea (Vector) – Additional offset tested for clearance.
+    
+    Realm:
+    Server
+    
+    Returns:
+    Vector – A position considered safe for spawning.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.findEmptyPos
+    local pos = lia.darkrp.findEmptyPos(Vector(0,0,0), nil, 128, 16, Vector(0,0,32))
+
+### `lia.darkrp.notify(client, _, _, message)`
+
+    
+    Description:
+    Forwards a notification message to the given client using
+    lia's notify system.
+    
+    Parameters:
+    client (Player) – The player to receive the message.
+    message (string) – Text of the notification.
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.notify
+    lia.darkrp.notify(player.GetAll()[1], nil, nil, "Hello!")
+
+### `lia.darkrp.textWrap(text, fontName, maxLineWidth)`
+
+    
+    Description:
+    Wraps a text string so that it fits within the specified width
+    when drawn with the given font.
+    
+    Parameters:
+    text (string) – The text to wrap.
+    fontName (string) – The font used to measure width.
+    maxLineWidth (number) – Maximum pixel width before wrapping occurs.
+    
+    Realm:
+    Client
+    
+    Returns:
+    string – The wrapped text with newline characters inserted.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.textWrap
+    local wrapped = lia.darkrp.textWrap("Some very long text", "DermaDefault", 150)
+
+### `lia.darkrp.formatMoney(amount)`
+
+    
+    Description:
+    Converts a numeric amount to a formatted currency string.
+    
+    Parameters:
+    amount (number) – The value of money to format.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    string – The formatted currency value.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of print
+    print(lia.darkrp.formatMoney(2500))
+
+### `lia.darkrp.createEntity(name, data)`
+
+    
+    Description:
+    Registers a new DarkRP entity as an item so that it can be spawned
+    through lia's item system.
+    
+    Parameters:
+    name (string) – Display name of the entity.
+    data (table) – Table containing entity definition fields such as
+    model, description, and price.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.createEntity
+    lia.darkrp.createEntity("Fuel", {model = "models/props_c17/oildrum001.mdl", price = 50})
+
+### `lia.darkrp.createCategory()`
+
+    
+    Description:
+    Placeholder for DarkRP category creation. Currently unused.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.darkrp.createCategory
+    lia.darkrp.createCategory()

--- a/docs/docs/framework/libraries/lia.data.md
+++ b/docs/docs/framework/libraries/lia.data.md
@@ -1,0 +1,79 @@
+### `lia.data.set(key, value, global, ignoreMap)`
+
+    
+    Description:
+    Saves the provided value under the specified key to persistent storage.
+    The data is written to a file whose path is constructed based on the folder, map, and flags.
+    Also caches the value in lia.data.stored.
+    
+    Parameters:
+    key (string) – The key under which the data is stored.
+    value (any) – The value to store.
+    global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+    ignoreMap (boolean) – If true, ignores the map directory.
+    
+    Returns:
+    string – The path where the data was saved.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Save the admin's position as the global spawn point with a command
+    concommand.Add("save_spawn", function(ply)
+    if ply:IsAdmin() then
+    lia.data.set("spawn_pos", ply:GetPos(), true)
+    end
+    end)
+
+### `lia.data.delete(key, global, ignoreMap)`
+
+    
+    Description:
+    Deletes the stored data file corresponding to the specified key.
+    Also removes the value from the cached storage.
+    
+    Parameters:
+    key (string) – The key corresponding to the data to be deleted.
+    global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+    ignoreMap (boolean) – If true, ignores the map directory.
+    
+    Returns:
+    boolean – True if the file was deleted, false otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.data.delete
+    lia.data.delete("spawn_pos")
+
+### `lia.data.get(key, default, global, ignoreMap, refresh)`
+
+    
+    Description:
+    Retrieves the stored data for the specified key.
+    If refresh is not set and data exists in cache, returns the cached data.
+    Otherwise, reads from the file, decodes, and caches the value.
+    
+    Parameters:
+    key (string) – The key corresponding to the data.
+    default (any) – The default value to return if no data is found.
+    global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+    ignoreMap (boolean) – If true, ignores the map directory.
+    refresh (boolean) – If true, forces reading from file instead of cache.
+    
+    Returns:
+    any – The stored value, or the default if not found.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Teleport players to the saved spawn point when they spawn
+    hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
+    local pos = lia.data.get("spawn_pos", Vector(0, 0, 0), true)
+    if pos then
+    ply:SetPos(pos)
+    end
+    end)

--- a/docs/docs/framework/libraries/lia.database.md
+++ b/docs/docs/framework/libraries/lia.database.md
@@ -1,0 +1,249 @@
+### `lia.db.connect(callback, reconnect)`
+
+    
+    Description:
+    Establishes a connection to the configured database module. If the database
+    is not already connected or if reconnect is true, it will initiate a new connection
+    or re-establish one.
+    
+    Parameters:
+    callback (function) – The function to call when the database connection is established.
+    reconnect (boolean) – Whether to reconnect using an existing database object or not.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.connect
+    lia.db.connect(function()
+    print("Database connected")
+    end)
+
+### `lia.db.wipeTables(callback)`
+
+    
+    Description:
+    Wipes all Lilia data tables from the database, dropping the specified
+    tables. This action is irreversible and will remove all stored data.
+    
+    Parameters:
+    callback (function) – The function to call when the wipe operation is completed.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.wipeTables
+    lia.db.wipeTables(function()
+    print("Tables wiped")
+    end)
+
+### `lia.db.loadTables()`
+
+    
+    Description:
+    Creates the required database tables if they do not already exist for
+    storing Lilia data. This ensures the schema is properly set up.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.loadTables
+    lia.db.loadTables()
+
+### `lia.db.waitForTablesToLoad()`
+
+    
+    Description:
+    Returns a deferred object that resolves once the database tables are fully loaded.
+    This allows asynchronous code to wait for table creation before proceeding.
+    
+    Parameters:
+    None
+    
+    Returns:
+    deferred – Resolves when the tables are loaded.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.waitForTablesToLoad
+    lia.db.waitForTablesToLoad():next(function()
+    print("Tables loaded")
+    end)
+
+### `lia.db.convertDataType(value, noEscape)`
+
+    
+    Description:
+    Converts a Lua value into a string suitable for database insertion,
+    handling strings, tables, and NULL values. Escaping is optionally applied
+    unless noEscape is set.
+    
+    Parameters:
+    value (any) – The value to be converted.
+    noEscape (boolean) – If true, the returned string is not escaped.
+    
+    Returns:
+    string – The converted data type as a string.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.convertDataType
+    local str = lia.db.convertDataType({name = "Lilia"})
+
+### `lia.db.insertTable(value, callback, dbTable)`
+
+    
+    Description:
+    Inserts a new row into the specified database table with the given key-value pairs.
+    The callback is invoked after the insert query is complete.
+    
+    Parameters:
+    value (table) – Key-value pairs representing the columns and values to insert.
+    callback (function) – The function to call when the insert operation is complete.
+    dbTable (string) – The name of the table (without the 'lia_' prefix).
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.insertTable
+    lia.db.insertTable({name = "Test"}, function(id)
+    print("Inserted", id)
+    end, "characters")
+
+### `lia.db.updateTable(value, callback, dbTable, condition)`
+
+    
+    Description:
+    Updates one or more rows in the specified database table according to the
+    provided condition. The callback is invoked once the update query finishes.
+    
+    Parameters:
+    value (table) – Key-value pairs representing columns to update and their new values.
+    callback (function) – The function to call after the update query is complete.
+    dbTable (string) – The name of the table (without the 'lia_' prefix).
+    condition (string) – The SQL condition to determine which rows to update.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.updateTable
+    lia.db.updateTable({name = "Updated"}, function()
+    print("Row updated")
+    end, "characters", "id = 1")
+
+### `lia.db.select(fields, dbTable, condition, limit)`
+
+    
+    Description:
+    Retrieves rows from the specified database table, optionally filtered by
+    a condition and limited to a specified number of results. Returns a deferred
+    object that resolves with the query results.
+    
+    Parameters:
+    fields (table|string) – The columns to select, either as a table or a comma-separated string.
+    dbTable (string) – The name of the table (without the 'lia_' prefix).
+    condition (string) – The SQL condition to filter results.
+    limit (number) – Maximum number of rows to return.
+    
+    Returns:
+    deferred – Resolves with query results and last insert ID.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.select
+    lia.db.select("*", "characters", "id = 1"):next(function(rows)
+    PrintTable(rows)
+    end)
+
+### `lia.db.upsert(value, dbTable)`
+
+    
+    Description:
+    Inserts or updates a row in the specified database table. If a row with
+    the same unique key exists, it updates it; otherwise, it inserts a new row.
+    Returns a deferred object that resolves when the operation completes.
+    
+    Parameters:
+    value (table) – Key-value pairs representing the columns and values.
+    dbTable (string) – The name of the table (without the 'lia_' prefix).
+    
+    Returns:
+    deferred – Resolves to a table of results and last insert ID.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.upsert
+    lia.db.upsert({id = 1, name = "John"}, "characters")
+
+### `lia.db.delete(dbTable, condition)`
+
+    
+    Description:
+    Deletes rows from the specified database table that match the provided condition.
+    If no condition is specified, all rows are deleted. Returns a deferred object.
+    
+    Parameters:
+    dbTable (string) – The name of the table (without the 'lia_' prefix).
+    condition (string) – The SQL condition that determines which rows to delete.
+    
+    Returns:
+    deferred – Resolves to the results of the deletion.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.delete
+    lia.db.delete("characters", "id = 1"):next(function()
+    print("Row deleted")
+    end)
+
+### `lia.db.GetCharacterTable(callback)`
+
+    
+    Description:
+    Fetches a list of column names from the ``lia_characters`` table.
+    This is useful for debugging or database maintenance tasks.
+    
+    Parameters:
+    callback (function) – Function executed with the table of column names.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.db.GetCharacterTable
+    lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)

--- a/docs/docs/framework/libraries/lia.factions.md
+++ b/docs/docs/framework/libraries/lia.factions.md
@@ -1,0 +1,259 @@
+### `lia.faction.loadFromDir`
+
+    
+    Description:
+    Loads all Lua faction files (*.lua) from the specified directory,
+    includes them as shared files, and registers the factions.
+    Each faction file should define a FACTION table with properties such as name, desc, color, etc.
+    
+    Parameters:
+    directory (string) – The path to the directory containing faction files.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.loadFromDir
+    lia.faction.loadFromDir("path/to/factions")
+
+### `lia.faction.get`
+
+    
+    Description:
+    Retrieves a faction by its index or unique identifier.
+    
+    Parameters:
+    identifier (number or string) – The faction's index or unique identifier.
+    
+    Returns:
+    table|nil – The faction table if found; nil otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.get
+    local faction = lia.faction.get("citizen")
+
+### `lia.faction.getIndex`
+
+    
+    Description:
+    Retrieves the index of a faction by its unique identifier.
+    
+    Parameters:
+    uniqueID (string) – The unique identifier of the faction.
+    
+    Returns:
+    number|nil – The faction index if found; nil otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getIndex
+    local index = lia.faction.getIndex("citizen")
+
+### `lia.faction.getClasses`
+
+    
+    Description:
+    Retrieves a list of classes associated with the specified faction.
+    
+    Parameters:
+    faction (string) – The faction unique identifier.
+    
+    Returns:
+    table – A table containing class tables that belong to the faction.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getClasses
+    local classes = lia.faction.getClasses("citizen")
+
+### `lia.faction.getPlayers`
+
+    
+    Description:
+    Retrieves all player entities whose characters belong to the specified faction.
+    
+    Parameters:
+    faction (string) – The faction unique identifier.
+    
+    Returns:
+    table – A table of player entities in the faction.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getPlayers
+    local players = lia.faction.getPlayers("citizen")
+
+### `lia.faction.getPlayerCount`
+
+    
+    Description:
+    Counts the number of players whose characters belong to the specified faction.
+    
+    Parameters:
+    faction (string) – The faction unique identifier.
+    
+    Returns:
+    number – The number of players in the faction.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getPlayerCount
+    local count = lia.faction.getPlayerCount("citizen")
+
+### `lia.faction.isFactionCategory`
+
+    
+    Description:
+    Checks if the specified faction is a member of a given category.
+    Parameters:
+    faction (string) – The faction unique identifier.
+    categoryFactions (table) – A table containing faction identifiers that define the category.
+    
+    Returns:
+    boolean – True if the faction is in the category; false otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.isFactionCategory
+    local isMember = lia.faction.isFactionCategory("citizen", {"citizen", "veteran"})
+
+### `lia.faction.jobGenerate`
+
+    
+    Description:
+    Generates a new faction (job) based on provided parameters.
+    Creates a faction table with index, name, description, color, models, and registers it with the team system.
+    Pre-caches the faction models.
+    
+    Parameters:
+    index (number) – The team index for the faction.
+    name (string) – The faction name.
+    color (Color) – The faction color.
+    default (boolean) – Whether the faction is default.
+    models (table) – A table of model paths or model data for the faction.
+    
+    Returns:
+    table – The newly generated faction table.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.jobGenerate
+    local faction = lia.faction.jobGenerate(2, "Police", Color(0, 0, 255), false, {"models/player/police.mdl"})
+
+### `lia.faction.formatModelData`
+
+    
+    Description:
+    Processes and formats model data for all registered factions.
+    Iterates through each faction's model data and applies formatting to ensure proper grouping.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.formatModelData
+    lia.faction.formatModelData()
+
+### `lia.faction.getCategories`
+
+    
+    Description:
+    Retrieves a list of model categories for a given faction.
+    Categories are determined by keys in the faction's models table that are strings.
+    
+    Parameters:
+    teamName (string) – The unique identifier of the faction.
+    
+    Returns:
+    table – A list of category names.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getCategories
+    local categories = lia.faction.getCategories("citizen")
+
+### `lia.faction.getModelsFromCategory`
+
+    
+    Description:
+    Retrieves models from a specified category for a given faction.
+    
+    Parameters:
+    teamName (string) – The unique identifier of the faction.
+    category (string) – The model category to retrieve.
+    
+    Returns:
+    table – A table of models in the specified category.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getModelsFromCategory
+    local models = lia.faction.getModelsFromCategory("citizen", "special")
+
+### `lia.faction.getDefaultClass`
+
+    
+    Description:
+    Retrieves the default class for a specified faction.
+    Searches through the class list for the first class that is marked as default for the faction.
+    
+    Parameters:
+    id (string) – The unique identifier of the faction.
+    
+    Returns:
+    table|nil – The default class table if found; nil otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.getDefaultClass
+    local defaultClass = lia.faction.getDefaultClass("citizen")
+
+### `lia.faction.hasWhitelist`
+
+    
+    Description:
+    Determines if the local player has whitelist access for a given faction.
+    Checks the local whitelist data against the faction's uniqueID.
+    
+    Parameters:
+    faction (string) – The unique identifier of the faction.
+    
+    Returns:
+    boolean – True if the player is whitelisted; false otherwise.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.faction.hasWhitelist
+    local whitelisted = lia.faction.hasWhitelist("citizen")

--- a/docs/docs/framework/libraries/lia.flags.md
+++ b/docs/docs/framework/libraries/lia.flags.md
@@ -1,0 +1,41 @@
+### `lia.flag.add`
+
+    
+    Description:
+    Registers a new flag by adding it to the flag list.
+    Each flag has a description and an optional callback that is executed when the flag is applied to a player.
+    
+    Parameters:
+    flag (string) – The unique flag identifier.
+    desc (string) – A description of what the flag does.
+    callback (function) – An optional callback function executed when the flag is applied to a player.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.flag.add
+    lia.flag.add("C", "Spawn vehicles.")
+
+### `lia.flag.onSpawn`
+
+    
+    Description:
+    Called when a player spawns. This function checks the player's character flags and triggers
+    the associated callbacks for each flag that the character possesses.
+    
+    Parameters:
+    client (Player) – The player who spawned.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.flag.onSpawn
+    lia.flag.onSpawn(player)

--- a/docs/docs/framework/libraries/lia.fonts.md
+++ b/docs/docs/framework/libraries/lia.fonts.md
@@ -1,0 +1,58 @@
+### `lia.font.register(fontName, fontData)`
+
+    
+    Description:
+    Creates and stores a font using surface.CreateFont for later refresh.
+    
+    Parameters:
+    fontName (string) – Font identifier.
+    fontData (table) – Font properties table.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.font.register
+    lia.font.register("MyFont", {font = "Arial", size = 16})
+
+### `lia.font.getAvailableFonts()`
+
+    
+    Description:
+    Returns a sorted list of font names that have been registered.
+    
+    Parameters:
+    None
+    
+    Returns:
+    table – Array of font name strings.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.font.getAvailableFonts
+    local fonts = lia.font.getAvailableFonts()
+    PrintTable(fonts)
+
+### `lia.font.refresh()`
+
+    
+    Description:
+    Recreates all stored fonts. Called when font related config values change.
+    
+    Parameters:
+    None
+    
+    Returns:
+    None
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.font.refresh
+    lia.font.refresh()

--- a/docs/docs/framework/libraries/lia.inventory.md
+++ b/docs/docs/framework/libraries/lia.inventory.md
@@ -1,0 +1,171 @@
+### `lia.inventory.newType(typeID, invTypeStruct)`
+
+    
+    Description:
+    Registers a new inventory type.
+    
+    Parameters:
+    typeID (string) — unique identifier
+    invTypeStruct (table) — definition matching InvTypeStructType
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.newType
+    lia.inventory.newType("bag", {className = "liaBag"})
+
+### `lia.inventory.new(typeID)`
+
+    
+    Description:
+    Instantiates a new inventory instance.
+    
+    Parameters:
+    typeID (string)
+    
+    Realm:
+    Shared
+    
+    Returns:
+    table
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.new
+    local inv = lia.inventory.new("bag")
+
+### `lia.inventory.loadByID(id, noCache)`
+
+    
+    Description:
+    Loads an inventory by ID (cached or via custom loader).
+    
+    Parameters:
+    id (number), noCache? (boolean)
+    
+    Realm:
+    Server
+    
+    Returns:
+    deferred
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.loadByID
+    lia.inventory.loadByID(1):next(function(inv) print(inv) end)
+
+### `lia.inventory.loadFromDefaultStorage(id, noCache)`
+
+    
+    Description:
+    Default database loader.
+    
+    Parameters:
+    id (number), noCache? (boolean)
+    
+    Realm:
+    Server
+    
+    Returns:
+    deferred
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.loadFromDefaultStorage
+    lia.inventory.loadFromDefaultStorage(1)
+
+### `lia.inventory.instance(typeID, initialData)`
+
+    
+    Description:
+    Creates & persists a new inventory instance.
+    
+    Parameters:
+    typeID (string), initialData? (table)
+    
+    Realm:
+    Server
+    
+    Returns:
+    deferred
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.instance
+    lia.inventory.instance("bag", {charID = 1})
+
+### `lia.inventory.loadAllFromCharID(charID)`
+
+    
+    Description:
+    Loads all inventories for a character.
+    
+    Parameters:
+    charID (number)
+    
+    Realm:
+    Server
+    
+    Returns:
+    deferred
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.loadAllFromCharID
+    lia.inventory.loadAllFromCharID(client:getChar():getID())
+
+### `lia.inventory.deleteByID(id)`
+
+    
+    Description:
+    Deletes an inventory and its data.
+    
+    Parameters:
+    id (number)
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.deleteByID
+    lia.inventory.deleteByID(1)
+
+### `lia.inventory.cleanUpForCharacter(character)`
+
+    
+    Description:
+    Destroys all inventories for a character.
+    
+    Parameters:
+    character
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.cleanUpForCharacter
+    lia.inventory.cleanUpForCharacter(client:getChar())
+
+### `lia.inventory.show(inventory, parent)`
+
+    
+    Description:
+    Displays inventory UI client‑side.
+    
+    Parameters:
+    inventory, parent
+    
+    Realm:
+    Client
+    
+    Returns:
+    Panel
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.inventory.show
+    local panel = lia.inventory.show(inv)

--- a/docs/docs/framework/libraries/lia.item.md
+++ b/docs/docs/framework/libraries/lia.item.md
@@ -1,0 +1,434 @@
+### `lia.item.get`
+
+    
+    Description:
+    Retrieves an item definition by its identifier, checking both lia.item.base and lia.item.list.
+    
+    Parameters:
+    identifier (string) – The unique identifier of the item.
+    
+    Returns:
+    The item table if found, otherwise nil.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.get
+    local itemDef = lia.item.get("testItem")
+
+### `lia.item.getItemByID`
+
+    
+    Description:
+    Retrieves an item instance by its numeric item ID. Also determines whether it's in an inventory
+    or in the world.
+    
+    Parameters:
+    itemID (number) – The numeric item ID.
+    
+    Returns:
+    A table containing 'item' (the item object) and 'location' (the string location) if found,
+    otherwise nil and an error message.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.getItemByID
+    local result = lia.item.getItemByID(42)
+    if result then
+    print("Item location: " .. result.location)
+    end
+
+### `lia.item.getInstancedItemByID`
+
+    
+    Description:
+    Retrieves the item instance table itself by its numeric ID without additional location info.
+    
+    Parameters:
+    itemID (number) – The numeric item ID.
+    
+    Returns:
+    The item instance table if found, otherwise nil and an error message.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.getInstancedItemByID
+    local itemInstance = lia.item.getInstancedItemByID(42)
+    if itemInstance then
+    print("Got item: " .. itemInstance.name)
+    end
+
+### `lia.item.getItemDataByID`
+
+    
+    Description:
+    Retrieves the 'data' table of an item instance by its numeric item ID.
+    
+    Parameters:
+    itemID (number) – The numeric item ID.
+    
+    Returns:
+    The data table if found, otherwise nil and an error message.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.getItemDataByID
+    local data = lia.item.getItemDataByID(42)
+    if data then
+    print("Item data found.")
+    end
+
+### `lia.item.load`
+
+    
+    Description:
+    Processes the item file path to generate a uniqueID, and calls lia.item.register
+    to register the item. Used for loading items from directory structures.
+    
+    Parameters:
+    path (string) – The path to the Lua file for the item.
+    baseID (string) – The base item's uniqueID to inherit from.
+    isBaseItem (boolean) – Whether this item is a base item.
+    
+    Returns:
+    None
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.load
+    lia.item.load("items/base/sh_item_base.lua", nil, true)
+
+### `lia.item.isItem`
+
+    
+    Description:
+    Checks if the given object is recognized as an item (via isItem flag).
+    
+    Parameters:
+    object (any) – The object to check.
+    
+    Returns:
+    true if the object is an item, false otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.isItem
+    local result = lia.item.isItem(myObject)
+    if result then
+    print("It's an item!")
+    end
+
+### `lia.item.getInv`
+
+    
+    Description:
+    Retrieves an inventory table by its ID from lia.item.inventories.
+    
+    Parameters:
+    id (number) – The ID of the inventory to retrieve.
+    
+    Returns:
+    The inventory table if found, otherwise nil.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.getInv
+    local inv = lia.item.getInv(5)
+    if inv then
+    print("Got inventory with ID 5")
+    end
+
+### `lia.item.register`
+
+    
+    Description:
+    Registers a new item or base item with a unique ID. This sets up the meta table
+    and merges data from the specified base. Optionally includes the file if provided.
+    
+    Parameters:
+    uniqueID (string) – The unique identifier for the item.
+    baseID (string) – The unique identifier of the base item.
+    isBaseItem (boolean) – Whether this should be registered as a base item.
+    path (string) – The optional path to the item file for inclusion.
+    luaGenerated (boolean) – True if the item is generated in code without file.
+    
+    Returns:
+    The registered item table.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.register
+    lia.item.register("special_item", "base_item", false, "path/to/item.lua")
+
+### `lia.item.loadFromDir`
+
+    
+    Description:
+    Loads item Lua files from a specified directory. Base items are loaded first,
+    then any folders (with base_ prefix usage), and finally any loose Lua files.
+    
+    Parameters:
+    directory (string) – The path to the directory containing item files.
+    
+    Returns:
+    None
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.loadFromDir
+    lia.item.loadFromDir("lilia/gamemode/items")
+
+### `lia.item.new`
+
+    
+    Description:
+    Creates an item instance (not in the database) from a registered item definition.
+    The new item is stored in lia.item.instances using the provided item ID.
+    
+    Parameters:
+    uniqueID (string) – The unique identifier of the item definition.
+    id (number) – The numeric ID for this new item instance.
+    
+    Returns:
+    The newly created item instance.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.new
+    local newItem = lia.item.new("testItem", 101)
+    print(newItem.id) -- 101
+
+### `lia.item.registerInv`
+
+    
+    Description:
+    Registers an inventory type with a given width and height. The inventory type
+    becomes accessible for creation or usage in the system.
+    
+    Parameters:
+    invType (string) – The inventory type name (identifier).
+    w (number) – The width of this inventory type.
+    h (number) – The height of this inventory type.
+    
+    Returns:
+    None
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.registerInv
+    lia.item.registerInv("smallInv", 4, 4)
+
+### `lia.item.newInv`
+
+    
+    Description:
+    Asynchronously creates a new inventory (with a specific invType) and associates it
+    with the given character owner. Once created, it syncs the inventory to the owner if online.
+    
+    Parameters:
+    owner (number) – The character ID who owns this inventory.
+    invType (string) – The inventory type (must be registered first).
+    callback (function) – Optional callback function receiving the new inventory.
+    
+    Returns:
+    None (asynchronous, uses a deferred internally).
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.newInv
+    lia.item.newInv(10, "smallInv", function(inventory)
+    print("New inventory created:", inventory.id)
+    end)
+
+### `lia.item.createInv`
+
+    
+    Description:
+    Creates a new GridInv instance with a specified width, height, and ID,
+    then caches it in lia.inventory.instances.
+    
+    Parameters:
+    w (number) – The width of the inventory.
+    h (number) – The height of the inventory.
+    id (number) – The numeric ID to assign to this inventory.
+    
+    Returns:
+    The newly created GridInv instance.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.createInv
+    local inv = lia.item.createInv(6, 6, 200)
+    print("Created inventory with ID:", inv.id)
+
+### `lia.item.setItemDataByID`
+
+    
+    Description:
+    Sets a specific key-value in the data table of an item instance by its numeric ID.
+    Optionally notifies receivers about the change.
+    
+    Parameters:
+    itemID (number) – The numeric item ID.
+    key (string) – The data key to set.
+    value (any) – The value to set for the specified key.
+    receivers (table) – Optional table of players to receive the update.
+    noSave (boolean) – If true, won't save the data to the database immediately.
+    noCheckEntity (boolean) – If true, won't check if the item entity is valid.
+    
+    Returns:
+    true if successful, false and error message if item not found.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.setItemDataByID
+    local success, err = lia.item.setItemDataByID(50, "durability", 90)
+    if not success then
+    print("Error:", err)
+    end
+
+### `lia.item.instance`
+
+    
+    Description:
+    Asynchronously creates a new item in the database, optionally assigned to an inventory.
+    Once the item is created, a new item object is constructed and returned via a deferred.
+    
+    Parameters:
+    index (number) – The inventory ID to place the item into (or 0/NULL if none).
+    uniqueID (string) – The item definition's unique ID.
+    itemData (table) – The data table to store on the item.
+    x (number) – Optional grid X position (for grid inventories).
+    y (number) – Optional grid Y position.
+    callback (function) – Optional callback with the newly created item.
+    
+    Returns:
+    A deferred object that resolves to the new item.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.instance
+    lia.item.instance(1, "testItem", {someKey = "someValue"}):next(function(item)
+    print("Item created with ID:", item.id)
+    end)
+
+### `lia.item.deleteByID`
+
+    
+    Description:
+    Deletes an item from the system (database and memory) by its numeric ID.
+    
+    Parameters:
+    id (number) – The numeric item ID to delete.
+    
+    Returns:
+    None
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.deleteByID
+    lia.item.deleteByID(42)
+
+### `lia.item.loadItemByID`
+
+    
+    Description:
+    Loads items from the database by a given ID or set of IDs, creating the corresponding
+    item instances in memory. This is commonly used during inventory or character loading.
+    
+    Parameters:
+    itemIndex (number or table) – Either a single numeric item ID or a table of numeric item IDs.
+    
+    Returns:
+    None (asynchronous query).
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.loadItemByID
+    lia.item.loadItemByID(42)
+    -- or
+    lia.item.loadItemByID({10, 11, 12})
+
+### `lia.item.spawn`
+
+    
+    Description:
+    Creates a new item instance (not in an inventory) and spawns a corresponding
+    entity in the world at the specified position/angles.
+    
+    Parameters:
+    uniqueID (string) – The unique ID of the item definition.
+    position (Vector) – The spawn position in the world.
+    callback (function) – Optional callback when the item and entity are created.
+    angles (Angle) – Optional spawn angles.
+    data (table) – Additional data to set on the item.
+    
+    Returns:
+    A deferred object if callback is not given, otherwise none.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- Spawn an item and use a callback to access the spawned entity
+    lia.item.spawn("testItem", Vector(0, 0, 0), function(item, ent)
+    print("Spawned", item.uniqueID, "at", ent:GetPos())
+    end)
+
+### `lia.item.restoreInv`
+
+    
+    Description:
+    Restores an existing inventory by loading it through lia.inventory.loadByID,
+    then sets its width/height data, optionally providing a callback once loaded.
+    
+    Parameters:
+    invID (number) – The inventory ID to restore.
+    w (number) – Width to set for the inventory.
+    h (number) – Height to set for the inventory.
+    callback (function) – Optional function to call once the inventory is restored.
+    
+    Returns:
+    None (asynchronous call).
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.item.restoreInv
+    lia.item.restoreInv(101, 5, 5, function(inv)
+    print("Restored inventory with ID 101.")
+    end)

--- a/docs/docs/framework/libraries/lia.keybind.md
+++ b/docs/docs/framework/libraries/lia.keybind.md
@@ -1,0 +1,96 @@
+### `lia.keybind.add(k, d, cb, rcb)`
+
+    
+    Description:
+    Registers a new keybind for a given action.
+    Converts the provided key identifier to its corresponding key constant (if it's a string),
+    and stores the keybind settings including the default key, press callback, and release callback.
+    Also maps the key code back to the action identifier for reverse lookup.
+    
+    Parameters:
+    k (string or number) – The key identifier, either as a string (to be converted) or as a key code.
+    d (string) – The unique identifier for the keybind action.
+    cb (function) – The callback function to be executed when the key is pressed.
+    rcb (function) – The callback function to be executed when the key is released.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.keybind.add
+    lia.keybind.add("space", "jump", function() print("Jump pressed!") end, function() print("Jump released!") end)
+
+### `lia.keybind.get(a, df)`
+
+    
+    Description:
+    Retrieves the current key code for a specified keybind action.
+    If the keybind has a set value, that value is returned; otherwise, it falls back to the default key
+    or an optionally provided fallback value.
+    
+    Parameters:
+    a (string) – The unique identifier for the keybind action.
+    df (number) – An optional default key code to return if the keybind is not set.
+    
+    Returns:
+    number – The key code associated with the keybind action, or the default/fallback value if not set.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.keybind.get
+    local jumpKey = lia.keybind.get("jump", KEY_SPACE)
+
+### `lia.keybind.save()`
+
+    
+    Description:
+    Saves the current keybind settings to a file.
+    The function creates a directory specific to the active gamemode, constructs a filename based on the server's IP address,
+    and writes the keybind mapping (action identifiers to key codes) in JSON format.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.keybind.save
+    lia.keybind.save()
+
+### `lia.keybind.load()`
+
+    
+    Description:
+    Loads keybind settings from a file.
+    The function reads a JSON file from a gamemode-specific directory, applies the saved keybind values to the stored keybinds,
+    and if no saved file is found, it resets the keybinds to their default values and saves them.
+    It also sets up a reverse mapping from key codes to keybind action identifiers.
+    Finally, it triggers the "InitializedKeybinds" hook.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.keybind.load
+    lia.keybind.load()

--- a/docs/docs/framework/libraries/lia.languages.md
+++ b/docs/docs/framework/libraries/lia.languages.md
@@ -1,0 +1,46 @@
+### `lia.lang.loadFromDir(directory)`
+
+    
+    Description:
+    Loads all Lua language files (*.lua) from the specified directory,
+    includes them as shared files, and merges any defined LANGUAGE table
+    into the stored language data. If a language name (NAME) is provided in the file,
+    it is registered in lia.lang.names.
+    
+    Parameters:
+    directory (string) – The path to the directory containing language files.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.lang.loadFromDir
+    lia.lang.loadFromDir("languages")
+
+### `lia.lang.AddTable(name, tbl)`
+
+    
+    Description:
+    Adds or merges a table of language key-value pairs into the stored language table
+    for a specified language. If the language already exists in the storage, the new values
+    will be merged with the existing ones.
+    
+    Parameters:
+    name (string) – The name of the language to update.
+    tbl (table) – A table containing language key-value pairs to add.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.lang.AddTable
+    lia.lang.AddTable("english", {greeting = "Hello"})

--- a/docs/docs/framework/libraries/lia.logger.md
+++ b/docs/docs/framework/libraries/lia.logger.md
@@ -1,0 +1,92 @@
+### `lia.log.loadTables()`
+
+    
+    Description:
+    Creates the logs directory for the current active gamemode under "lilia/logs".
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.log.loadTables
+    lia.log.loadTables()
+
+### `lia.log.addType(logType, func, category)`
+
+    
+    Description:
+    Registers a new log type by associating a log generating function and a category with the log type identifier.
+    The registered function will be used later to generate log messages for that type.
+    
+    Parameters:
+    logType (string) – The unique identifier for the log type.
+    func (function) – A function that takes a client and additional parameters, returning a log string.
+    category (string) – The category for the log type, used for organizing log files.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.log.addType
+    lia.log.addType("mytype", function(client)
+    return client:Name() .. " did something"
+    end, "actions")
+
+### `lia.log.getString(client, logType, ...)`
+
+    
+    Description:
+    Retrieves the log string and its associated category for a given client and log type.
+    It calls the registered log function with the provided parameters.
+    
+    Parameters:
+    client (Player) – The client for which the log is generated.
+    logType (string) – The identifier for the log type.
+    ... (vararg) – Additional parameters passed to the log function.
+    
+    Returns:
+    string, string – The generated log string and its category if successful; otherwise, nil.
+    
+    Realm:
+    Server
+    
+    Internal Function:
+    true
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.log.getString
+    local str, category = lia.log.getString(client, "mytype", "info")
+
+### `lia.log.add(client, logType, ...)`
+
+    
+    Description:
+    Generates a log string using the registered log type function, triggers the "OnServerLog" hook,
+    and appends the log string to a log file corresponding to its category in the logs directory.
+    
+    Parameters:
+    client (Player) – The client associated with the log event.
+    logType (string) – The identifier for the log type.
+    ... (vararg) – Additional parameters passed to the log type function.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.log.add
+    lia.log.add(client, "mytype", "info")

--- a/docs/docs/framework/libraries/lia.markup.md
+++ b/docs/docs/framework/libraries/lia.markup.md
@@ -1,0 +1,21 @@
+### `lia.markup.parse(text, maxwidth)`
+
+    
+    Description:
+    Parses the provided markup text and returns a markup object representing
+    the formatted content. When maxwidth is provided, the text will
+    automatically wrap at that width.
+    
+    Parameters:
+    text (string) – String containing markup to be parsed.
+    maxwidth (number|nil) – Optional maximum width for wrapping.
+    
+    Realm:
+    Client
+    
+    Returns:
+    MarkupObject – The parsed markup object with size information.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.markup.parse
+    local object = lia.markup.parse("<color=255,0,0>Hello</color>", 200)

--- a/docs/docs/framework/libraries/lia.md
+++ b/docs/docs/framework/libraries/lia.md
@@ -1,0 +1,183 @@
+This file documents lia functions defined within the codebase.
+    
+    Generated automatically.
+
+### `lia.include(fileName, state)`
+
+    
+    Description:
+    Includes a Lua file based on its realm. It determines the realm from the file name or provided state, and handles server/client inclusion logic.
+    
+    Parameters:
+    fileName (string) – The path to the Lua file.
+    state    (string) – The realm state ("server", "client", "shared", etc.).
+    
+    Realm:
+    Depends on the file realm.
+    
+    Returns:
+    The result of the include, if applicable.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.include
+    lia.include("lilia/gamemode/core/libraries/util.lua", "shared")
+
+### `lia.includeDir(directory, fromLua, recursive, realm)`
+
+    
+    Description:
+    Includes all Lua files in a specified directory. If recursive is true, it traverses subdirectories. It determines the base directory based on the active schema or gamemode.
+    
+    Parameters:
+    directory (string) – The directory path to include.
+    fromLua   (boolean) – Whether to use the raw Lua directory path.
+    recursive (boolean) – Whether to include files recursively.
+    realm     (string) – The realm state to use ("client", "server", "shared").
+    
+    Realm:
+    Depends on file inclusion.
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.includeDir
+    lia.includeDir("lilia/gamemode/core/libraries/shared/thirdparty", true, true)
+
+### `lia.includeGroupedDir(dir, raw, recursive, forceRealm)`
+
+    
+    Description:
+    Recursively includes all Lua files in a specified directory, preserving alphabetical order within each folder. Determines each file’s realm by override or filename prefix, then calls lia.include on each file.
+    
+    Parameters:
+    dir        (string) – Directory path to load files from (relative if raw is false).
+    raw        (boolean) – If true, uses dir as the literal filesystem path.
+    recursive  (boolean) – Whether to traverse subdirectories recursively.
+    forceRealm (string) – Optional override for the realm of all included files ("client", "server", or "shared").
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.includeGroupedDir
+    lia.includeGroupedDir("core/modules", false, true, "shared")
+
+### `lia.error(msg)`
+
+    
+    Description:
+    Prints a colored error message prefixed with "[Lilia]" to the console.
+    
+    Parameters:
+    msg (string) – Error text to display.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.error
+    lia.error("Invalid configuration detected")
+
+### `lia.deprecated(methodName, callback)`
+
+    
+    Description:
+    Notifies that a method is deprecated and optionally runs a callback.
+    
+    Parameters:
+    methodName (string) – Name of the deprecated method.
+    callback   (function) – Optional function executed after warning.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.deprecated
+    lia.deprecated("OldFunction", function() print("Called fallback") end)
+
+### `lia.updater(msg)`
+
+    
+    Description:
+    Prints an updater message in cyan to the console with the Lilia prefix.
+    
+    Parameters:
+    msg (string) – Update text to display.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.updater
+    lia.updater("Loading additional content...")
+
+### `lia.information(msg)`
+
+    
+    Description:
+    Prints an informational message with the Lilia prefix.
+    
+    Parameters:
+    msg (string) – Text to print to the console.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.information
+    lia.information("Server started successfully")
+
+### `lia.bootstrap(section, msg)`
+
+    
+    Description:
+    Logs a bootstrap message with a colored section tag for clarity.
+    
+    Parameters:
+    section (string) – Category or stage of bootstrap.
+    msg     (string) – Message describing the bootstrap step.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.bootstrap
+    lia.bootstrap("Database", "Connection established")
+
+### `lia.includeEntities(path)`
+
+    
+    Description:
+    Includes entity files from the specified directory. It checks for standard entity files ("init.lua", "shared.lua", "cl_init.lua"), handles inclusion and registration of entities, weapons, tools, and effects, and supports recursive inclusion within entity folders.
+    
+    Parameters:
+    path (string) – The directory path containing entity files.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.includeEntities
+    lia.includeEntities("lilia/entities")

--- a/docs/docs/framework/libraries/lia.menu.md
+++ b/docs/docs/framework/libraries/lia.menu.md
@@ -1,0 +1,84 @@
+### `lia.menu.add(opts, pos, onRemove)`
+
+    
+    Description:
+    Creates a new world or entity menu using the entries provided in 'opts'.
+    Keys are display text and values are callback functions executed when
+    selected. The menu may be positioned at a world Vector or anchored to
+    an entity.
+    
+    Parameters:
+    opts (table) – Table of label/callback pairs.
+    pos (Vector|Entity|nil) – World position or entity to attach the menu to.
+    onRemove (function|nil) – Called when the menu is removed.
+    
+    Realm:
+    Client
+    
+    Returns:
+    number – Identifier for the created menu entry.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.menu.add
+    lia.menu.add({["Hello"] = function() print("Hi") end})
+
+### `lia.menu.drawAll()`
+
+    
+    Description:
+    Draws all active menus on the player's screen. Typically called from
+    HUDPaint.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of hook.Add
+    hook.Add("HUDPaint", "DrawMenus", lia.menu.drawAll)
+
+### `lia.menu.getActiveMenu()`
+
+    
+    Description:
+    Returns the ID and callback of the menu item currently being hovered
+    or selected by the player.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Client
+    
+    Returns:
+    id (number|nil) – Index of the active menu.
+    callback (function|nil) – Callback for the hovered item.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.menu.getActiveMenu
+    local id, callback = lia.menu.getActiveMenu()
+
+### `lia.menu.onButtonPressed(id, callback)`
+
+    
+    Description:
+    Removes the specified menu and runs its callback if provided.
+    
+    Parameters:
+    id (number) – Identifier returned by lia.menu.add.
+    callback (function|nil) – Function to execute after removal.
+    
+    Realm:
+    Client
+    
+    Returns:
+    boolean – True if a callback was executed.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.menu.onButtonPressed
+    lia.menu.onButtonPressed(id)

--- a/docs/docs/framework/libraries/lia.modularity.md
+++ b/docs/docs/framework/libraries/lia.modularity.md
@@ -1,0 +1,84 @@
+### `lia.module.load`
+
+    
+    Description:
+    Loads a module from a specified path. If the module is a single file, it includes it directly;
+    if it is a directory, it loads the core file (or its extended version), applies permissions, workshop content, dependencies, extras, and submodules.
+    It also registers the module in the module list if applicable.
+    
+    Parameters:
+    uniqueID – The unique identifier of the module.
+    path – The file system path where the module is located.
+    isSingleFile – Boolean indicating if the module is a single file.
+    variable – A global variable name used to temporarily store the module.
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.module.load
+    lia.module.load("example", "lilia/modules/example", false)
+
+### `lia.module.initialize`
+
+    
+    Description:
+    Initializes the module system by loading the schema and various module directories,
+    then running the appropriate hooks after modules have been loaded.
+    
+    Parameters:
+    None
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.module.initialize
+    lia.module.initialize()
+
+### `lia.module.loadFromDir`
+
+    
+    Description:
+    Loads modules from a specified directory. It iterates over all subfolders and .lua files in the directory.
+    Each subfolder is treated as a multi-file module, and each .lua file as a single-file module.
+    Non-Lua files are ignored.
+    
+    Parameters:
+    directory – The directory path from which to load modules.
+    group – A string representing the module group (e.g., "schema" or "module").
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.module.loadFromDir
+    lia.module.loadFromDir("lilia/modules/core", "module")
+
+### `lia.module.get`
+
+    
+    Description:
+    Retrieves a module table by its identifier.
+    
+    Parameters:
+    identifier – The unique identifier of the module to retrieve.
+    
+    Realm:
+    Server
+    
+    Returns:
+    The module table if found, or nil if the module is not registered.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.module.get
+    local mod = lia.module.get("schema")

--- a/docs/docs/framework/libraries/lia.networking.md
+++ b/docs/docs/framework/libraries/lia.networking.md
@@ -1,0 +1,51 @@
+### `setNetVar(key, value, receiver)`
+
+    
+    Description:
+    Stores a global networked variable and broadcasts it to clients. When a
+    receiver is specified the update is only sent to those players.
+    
+    Parameters:
+    key (string) – Name of the variable.
+    value (any) – Value to store.
+    receiver (Player|table|nil) – Optional receiver(s) for the update.
+    
+    Realm:
+    Server
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- Start a new round and only inform the winner
+    local round = getNetVar("round", 0) + 1
+    setNetVar("round", round)
+    local winner = DetermineWinner()
+    setNetVar("last_winner", winner, winner)
+    hook.Run("RoundStarted", round)
+
+### `getNetVar(key, default)`
+
+    
+    Description:
+    Retrieves a global networked variable previously set by setNetVar.
+    
+    Parameters:
+    key (string) – Variable name.
+    default (any) – Fallback value if the variable is not set.
+    
+    Realm:
+    Shared
+    
+    Returns:
+    any – Stored value or default.
+    
+    Example Usage:
+    -- Inform a joining player of the current round and last winner
+    hook.Add("PlayerInitialSpawn", "ShowRound", function(ply)
+    ply:ChatPrint("Current round: " .. getNetVar("round", 0))
+    local winner = getNetVar("last_winner")
+    if IsValid(winner) then
+    ply:ChatPrint("Last round won by " .. winner:Name())
+    end
+    end)

--- a/docs/docs/framework/libraries/lia.notice.md
+++ b/docs/docs/framework/libraries/lia.notice.md
@@ -1,0 +1,79 @@
+### `lia.notices.notify(message, recipient)`
+
+    
+    Description:
+    Sends a notification message to a specific player or all players.
+    
+    Parameters:
+    message (string) – Message text to send.
+    recipient (Player|nil) – Target player, or nil to broadcast.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.notices.notify
+    lia.notices.notify("Server restarting", nil)
+
+### `lia.notices.notifyLocalized(key, recipient, ...)`
+
+    
+    Description:
+    Sends a localized notification to a player or all players.
+    
+    Parameters:
+    key (string) – Localization key.
+    recipient (Player|nil) – Target player or nil to broadcast.
+    ... (any) – Formatting arguments for the localization string.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
+    lia.notices.notifyLocalized("welcome", client)
+
+### `lia.notices.notify(message)`
+
+    
+    Description:
+    Creates a visual notification panel on the client's screen.
+    
+    Parameters:
+    message (string) – Message text to display.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.notices.notify
+    lia.notices.notify("Item picked up")
+
+### `lia.notices.notifyLocalized(key, ...)`
+
+    
+    Description:
+    Displays a localized notification on the client's screen.
+    
+    Parameters:
+    key (string) – Localization key.
+    ... (any) – Formatting arguments for the localization string.
+    
+    Realm:
+    Client
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
+    lia.notices.notifyLocalized("item_picked_up")

--- a/docs/docs/framework/libraries/lia.option.md
+++ b/docs/docs/framework/libraries/lia.option.md
@@ -1,0 +1,101 @@
+### `lia.option.add(key, name, desc, default, callback, data)`
+
+    
+    Description:
+    Adds a configuration option to the lia.option system.
+    
+    Parameters:
+    key (string) — The unique key for the option.
+    name (string) — The display name of the option.
+    desc (string) — A brief description of the option's purpose.
+    default (any) — The default value for this option.
+    callback (function) — A function to call when the option’s value changes (optional).
+    data (table) — Additional data describing the option (e.g., min, max, type, category, visible, shouldNetwork).
+    
+    Returns:
+    nil
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.option.add
+    lia.option.add("showHints", "Show Hints", "Display hints", true)
+
+### `lia.option.set(key, value)`
+
+    
+    Description:
+    Sets the value of a specified option, saves locally, and optionally networks to the server.
+    
+    Parameters:
+    key (string) — The unique key identifying the option.
+    value (any) — The new value to assign to this option.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.option.set
+    lia.option.set("showHints", false)
+
+### `lia.option.get(key, default)`
+
+    
+    Description:
+    Retrieves the value of a specified option, or returns a default if it doesn't exist.
+    
+    Parameters:
+    key (string) — The unique key identifying the option.
+    default (any) — The value to return if the option is not found.
+    
+    Returns:
+    (any) The current value of the option or the provided default.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.option.get
+    local show = lia.option.get("showHints", true)
+
+### `lia.option.save()`
+
+    
+    Description:
+    Saves all current option values to a file, named based on the server IP, within the active gamemode folder.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.option.save
+    lia.option.save()
+
+### `lia.option.load()`
+
+    
+    Description:
+    Loads saved option values from disk based on server IP and applies them to lia.option.stored.
+    
+    Parameters:
+    None
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.option.load
+    lia.option.load()

--- a/docs/docs/framework/libraries/lia.time.md
+++ b/docs/docs/framework/libraries/lia.time.md
@@ -1,0 +1,111 @@
+### `lia.time.TimeSince`
+
+    Description:
+    Returns a human-readable string indicating how long ago a given time occurred (e.g., "5 minutes ago").
+    
+    Parameters:
+    strTime (string or number) — The time in string or timestamp form.
+    
+    Returns:
+    (string) The time since the given date/time in a readable format.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Greet players with the time since they last joined using persistence data
+    hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
+    -- Retrieve the time this player last joined from persistent data
+    local key = "lastLogin_" .. ply:SteamID64()
+    local last = lia.data.get(key, nil, true)
+    
+    if last then
+    ply:ChatPrint("Welcome back! You last joined " .. lia.time.TimeSince(last) .. ".")
+    else
+    ply:ChatPrint("Welcome for the first time!")
+    end
+    
+    -- Store the current time for the next login
+    lia.data.set(key, os.time(), true)
+    end)
+
+### `lia.time.toNumber`
+
+    
+    Description:
+    Converts a string timestamp (YYYY-MM-DD HH:MM:SS) to a table with numeric fields:
+    year, month, day, hour, min, sec. Defaults to current time if not provided.
+    
+    Parameters:
+    str (string) — The time string to convert (optional).
+    
+    Returns:
+    (table) A table with numeric year, month, day, hour, min, sec.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Schedule an event at a custom date and time using the parsed table
+    local targetInfo = lia.time.toNumber("2025-04-01 12:30:00")
+    local delay = os.time(targetInfo) - os.time()
+    if delay > 0 then
+    timer.Simple(delay, function()
+    print("It's now April 1st, 2025, 12:30 PM!")
+    end)
+    end
+
+### `lia.time.GetDate`
+
+    
+    Description:
+    Returns the full current date and time formatted based on the
+    "AmericanTimeStamps" configuration flag:
+    • If enabled: "Weekday, Month DD, YYYY, HH:MM:SSam/pm"
+    • If disabled: "Weekday, DD Month YYYY, HH:MM:SS"
+    
+    Parameters:
+    None
+    
+    Returns:
+    (string) Formatted date and time string.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Announce the current server date and time to all players every hour
+    timer.Create("ServerTimeAnnounce", 3600, 0, function()
+    local dateString = lia.time.GetDate()
+    for _, ply in player.Iterator() do
+    ply:ChatPrint("Server time: " .. dateString)
+    end
+    end)
+
+### `lia.time.GetHour`
+
+    
+    Description:
+    Returns the current hour formatted based on the
+    "AmericanTimeStamps" configuration flag:
+    • If enabled: "Ham" or "Hpm" (12-hour with am/pm)
+    • If disabled: H (0–23, 24-hour)
+    
+    Parameters:
+    None
+    
+    Returns:
+    (string|number) Current hour string with suffix when AmericanTimeStamps
+    is enabled, otherwise numeric hour in 24-hour format.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- Toggle an NPC's shop based on the in-game hour
+    local hour = lia.time.GetHour()
+    if hour >= 9 and hour < 17 then
+    npc:SetNWBool("ShopOpen", true)
+    else
+    npc:SetNWBool("ShopOpen", false)
+    end

--- a/docs/docs/framework/libraries/lia.util.md
+++ b/docs/docs/framework/libraries/lia.util.md
@@ -1,0 +1,609 @@
+### `lia.util.FindPlayersInSphere`
+
+    
+    Description:
+    Finds and returns a table of players within a given spherical radius from an origin.
+    
+    Parameters:
+    origin (Vector) — The center of the sphere.
+    radius (number) — The radius of the sphere.
+    
+    Returns:
+    table — A table of valid player entities.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.FindPlayersInSphere
+    local players = lia.util.FindPlayersInSphere(Vector(0, 0, 0), 200)
+    for _, ply in ipairs(players) do
+    print(ply:Name())
+    end
+
+### `lia.util.findPlayer`
+
+    
+    Description:
+    Attempts to find a player by identifier. The identifier can be STEAMID, SteamID64, "^" (self), "@" (looking at target), or partial name.
+    
+    Parameters:
+    client (Player) — The player requesting the find (used for notifications).
+    identifier (string) — The identifier to search by.
+    
+    Returns:
+    Player|nil — The found player, or nil if not found.
+    
+    Realm:
+    Shared
+    
+    Alias:
+    lia.util.findPlayer
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayer
+    local foundPly = lia.util.findPlayer(someAdmin, "Bob")
+    if foundPly then
+    print("Found player: " .. foundPly:Name())
+    end
+
+### `lia.util.findPlayerItems`
+
+    
+    Description:
+    Finds all item entities in the world created by the specified player.
+    
+    Parameters:
+    client (Player) — The player whose items to find.
+    
+    Returns:
+    table — A table of valid item entities.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayerItems
+    local items = lia.util.findPlayerItems(LocalPlayer())
+    for _, item in ipairs(items) do
+    print("Found item entity: " .. item:GetClass())
+    end
+
+### `lia.util.findPlayerItemsByClass`
+
+    
+    Description:
+    Finds all item entities in the world created by the specified player with a specific class ID.
+    
+    Parameters:
+    client (Player) — The player whose items to find.
+    class (string) — The class ID to filter by.
+    
+    Returns:
+    table — A table of valid item entities matching the class.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayerItemsByClass
+    local items = lia.util.findPlayerItemsByClass(LocalPlayer(), "food_banana")
+    for _, item in ipairs(items) do
+    print("Found item entity: " .. item:GetClass())
+    end
+
+### `lia.util.findPlayerEntities`
+
+    
+    Description:
+    Finds all entities in the world created by or associated with the specified player. An optional class filter can be applied.
+    
+    Parameters:
+    client (Player) — The player whose entities to find.
+    class (string|nil) — The class name to filter by (optional).
+    
+    Returns:
+    table — A table of valid entities.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayerEntities
+    local entities = lia.util.findPlayerEntities(LocalPlayer(), "prop_physics")
+    for _, ent in ipairs(entities) do
+    print("Found player entity: " .. ent:GetClass())
+    end
+
+### `lia.util.stringMatches`
+
+    
+    Description:
+    Checks if string a matches string b (case-insensitive, partial matches).
+    
+    Parameters:
+    a (string) — The first string to check.
+    b (string) — The second string to match against.
+    
+    Returns:
+    boolean — True if they match, false otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.stringMatches
+    if lia.util.stringMatches("Hello", "he") then
+    print("Strings match!")
+    end
+
+### `lia.util.getAdmins`
+
+    
+    Description:
+    Returns all players considered staff or admins, as determined by client:isStaff().
+    
+    Returns:
+    table — A table of player entities who are staff.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.getAdmins
+    local admins = lia.util.getAdmins()
+    for _, admin in ipairs(admins) do
+    print("Staff: " .. admin:Name())
+    end
+
+### `lia.util.findPlayerBySteamID64`
+
+    
+    Description:
+    Finds a player currently on the server by their SteamID64.
+    
+    Parameters:
+    SteamID64 (string) — The SteamID64 to search for.
+    
+    Returns:
+    Player|nil — The found player or nil if not found.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID64
+    local ply = lia.util.findPlayerBySteamID64("76561198000000000")
+    if ply then
+    print("Found player: " .. ply:Name())
+    end
+
+### `lia.util.findPlayerBySteamID`
+
+    
+    Description:
+    Finds a player currently on the server by their SteamID.
+    
+    Parameters:
+    SteamID (string) — The SteamID to search for (e.g. "STEAM_0:1:23456789").
+    
+    Returns:
+    Player|nil — The found player or nil if not found.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID
+    local ply = lia.util.findPlayerBySteamID("STEAM_0:1:23456789")
+    if ply then
+    print("Found player: " .. ply:Name())
+    end
+
+### `lia.util.canFit`
+
+    
+    Description:
+    Checks if a hull (defined by mins and maxs) can fit at the given position without intersecting obstacles.
+    
+    Parameters:
+    pos (Vector) — The position to test.
+    mins (Vector) — The minimum corner of the hull (defaults to Vector(16, 16, 0) if nil).
+    maxs (Vector) — The maximum corner of the hull (defaults to same as mins if nil).
+    filter (table|Entity|function) — Optional filter for the trace.
+    
+    Returns:
+    boolean — True if it can fit, false otherwise.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.canFit
+    local canStand = lia.util.canFit(somePos, Vector(-16, -16, 0), Vector(16, 16, 72))
+    if canStand then
+    print("The player can stand here.")
+    end
+
+### `lia.util.playerInRadius`
+
+    
+    Description:
+    Finds and returns a table of players within a given radius from a position.
+    
+    Parameters:
+    pos (Vector) — The center position.
+    dist (number) — The radius to search within.
+    
+    Returns:
+    table — A table of player entities within the radius.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.playerInRadius
+    local playersNearby = lia.util.playerInRadius(Vector(0, 0, 0), 250)
+    for _, ply in ipairs(playersNearby) do
+    print("Nearby player: " .. ply:Name())
+    end
+
+### `lia.util.formatStringNamed`
+
+    
+    Description:
+    Formats a string with named or indexed placeholders. If a table is passed, uses named keys. Otherwise uses ordered arguments.
+    
+    Parameters:
+    format (string) — The format string with placeholders like "{key}".
+    ... (vararg|table) — Either a table or vararg arguments to fill placeholders.
+    
+    Returns:
+    string — The formatted string.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.formatStringNamed
+    local result = lia.util.formatStringNamed("Hello, {name}!", {name = "Bob"})
+    print(result) -- "Hello, Bob!"
+
+### `lia.util.getMaterial`
+
+    
+    Description:
+    Retrieves a cached Material for the specified path and parameters, to avoid repeated creation.
+    
+    Parameters:
+    materialPath (string) — The file path to the material.
+    materialParameters (string|nil) — Optional material parameters.
+    
+    Returns:
+    Material — The requested material.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.getMaterial
+    local mat = lia.util.getMaterial("path/to/material", "noclamp smooth")
+    surface.SetMaterial(mat)
+    surface.DrawTexturedRect(0, 0, 100, 100)
+
+### `lia.util.findFaction`
+
+    
+    Description:
+    Finds a faction by name or uniqueID. If an exact identifier is found in lia.faction.teams, returns that. Otherwise checks for partial match.
+    
+    Parameters:
+    client (Player) — The player requesting the search (used for notifications).
+    name (string) — The name or uniqueID of the faction to find.
+    
+    Returns:
+    table|nil — The found faction table, or nil if not found.
+    
+    Realm:
+    Shared
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findFaction
+    local faction = lia.util.findFaction(client, "citizen")
+    if faction then
+    print("Found faction: " .. faction.name)
+    end
+
+### `lia.util.CreateTableUI`
+
+    
+    Description:
+    Sends a net message to the client to create a table UI with given data.
+    
+    Parameters:
+    client (Player) — The player to whom the UI will be sent.
+    title (string) — The title of the table UI.
+    columns (table) — The columns of the table.
+    data (table) — The row data.
+    options (table|nil) — Additional options for the table actions.
+    characterID (number|nil) — An optional character ID to pass along.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.CreateTableUI
+    lia.util.CreateTableUI(somePlayer, "My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, someData, someOptions, charID)
+
+### `lia.util.findEmptySpace`
+
+    
+    Description:
+    Finds potential empty space positions around an entity using a grid-based approach.
+    
+    Parameters:
+    entity (Entity) — The entity around which to search.
+    filter (table|function|Entity) — The filter for the trace or the entity to ignore.
+    spacing (number) — The spacing between each point in the grid (default 32).
+    size (number) — The grid size in each direction (default 3).
+    height (number) — The height of the bounding box (default 36).
+    tolerance (number) — The trace tolerance (default 5).
+    
+    Returns:
+    table — A sorted table of valid positions found.
+    
+    Realm:
+    Server
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.findEmptySpace
+    local positions = lia.util.findEmptySpace(someEntity, someFilter, 32, 3, 36, 5)
+    for _, pos in ipairs(positions) do
+    print("Empty space at: " .. tostring(pos))
+    end
+
+### `lia.util.ShadowText`
+
+    
+    Description:
+    Draws text with a shadow offset.
+    
+    Parameters:
+    text (string) — The text to draw.
+    font (string) — The font used.
+    x (number) — The x position.
+    y (number) — The y position.
+    colortext (Color) — The color of the text.
+    colorshadow (Color) — The shadow color.
+    dist (number) — The distance offset for the shadow.
+    xalign (number) — The horizontal alignment (TEXT_ALIGN_*).
+    yalign (number) — The vertical alignment (TEXT_ALIGN_*).
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.ShadowText
+    lia.util.ShadowText("Hello!", "DermaDefault", 100, 100, color_white, color_black, 2, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+
+### `lia.util.DrawTextOutlined`
+
+    
+    Description:
+    Draws text with an outlined border.
+    
+    Parameters:
+    text (string) — The text to draw.
+    font (string) — The font used.
+    x (number) — The x position.
+    y (number) — The y position.
+    colour (Color) — The text color.
+    xalign (number) — The horizontal alignment.
+    outlinewidth (number) — The outline thickness.
+    outlinecolour (Color) — The outline color.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.DrawTextOutlined
+    lia.util.DrawTextOutlined("Outlined Text", "DermaLarge", 100, 200, color_white, TEXT_ALIGN_CENTER, 2, color_black)
+
+### `lia.util.DrawTip`
+
+    
+    Description:
+    Draws a tooltip-like shape with text in the center.
+    
+    Parameters:
+    x (number) — The x position.
+    y (number) — The y position.
+    w (number) — The width of the tip.
+    h (number) — The height of the tip.
+    text (string) — The text to display.
+    font (string) — The font for the text.
+    textCol (Color) — The text color.
+    outlineCol (Color) — The outline color.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.DrawTip
+    lia.util.DrawTip(100, 100, 200, 60, "This is a tip!", "DermaDefault", color_white, color_black)
+
+### `lia.util.drawText`
+
+    
+    Description:
+    Draws text with a subtle shadow effect.
+    
+    Parameters:
+    text (string) — The text to draw.
+    x (number) — The x position.
+    y (number) — The y position.
+    color (Color) — The text color.
+    alignX (number) — Horizontal alignment (TEXT_ALIGN_*).
+    alignY (number) — Vertical alignment (TEXT_ALIGN_*).
+    font (string) — The font to use (defaults to "liaGenericFont").
+    alpha (number) — The shadow alpha multiplier.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.drawText
+    lia.util.drawText("Hello World", 200, 300, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, "liaGenericFont", 100)
+
+### `lia.util.drawTexture`
+
+    
+    Description:
+    Draws a textured rectangle with the specified material.
+    
+    Parameters:
+    material (string) — The material path.
+    color (Color) — The draw color.
+    x (number) — The x position.
+    y (number) — The y position.
+    w (number) — The width.
+    h (number) — The height.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.drawTexture
+    lia.util.drawTexture("path/to/material", color_white, 50, 50, 64, 64)
+
+### `lia.util.skinFunc`
+
+    
+    Description:
+    Calls a skin function by name, passing the panel and any extra arguments.
+    
+    Parameters:
+    name (string) — The name of the skin function.
+    panel (Panel) — The panel to apply the skin function to.
+    a, b, c, d, e, f, g — Additional arguments passed to the skin function.
+    
+    Returns:
+    any — The result of the skin function call, if any.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.skinFunc
+    lia.util.skinFunc("PaintButton", someButton, 10, 20)
+
+### `lia.util.wrapText`
+
+    
+    Description:
+    Wraps text to a maximum width, returning a table of lines and the maximum line width found.
+    
+    Parameters:
+    text (string) — The text to wrap.
+    width (number) — The maximum width in pixels.
+    font (string) — The font name to use for measuring.
+    
+    Returns:
+    table, number — A table of wrapped lines and the maximum line width found.
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.wrapText
+    local lines, maxW = lia.util.wrapText("Some long string that needs wrapping...", 200, "liaChatFont")
+    for _, line in ipairs(lines) do
+    print(line)
+    end
+    print("Max width: " .. maxW)
+
+### `lia.util.drawBlur`
+
+    
+    Description:
+    Draws a blur effect over the specified panel.
+    
+    Parameters:
+    panel (Panel) — The panel to blur.
+    amount (number) — The blur strength.
+    passes (number) — The number of passes (optional).
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.drawBlur
+    lia.util.drawBlur(somePanel, 5, 1)
+
+### `lia.util.drawBlurAt`
+
+    
+    Description:
+    Draws a blur effect at a specified rectangle on the screen.
+    
+    Parameters:
+    x (number) — The x position.
+    y (number) — The y position.
+    w (number) — The width of the rectangle.
+    h (number) — The height of the rectangle.
+    amount (number) — The blur strength.
+    passes (number) — The number of passes (optional).
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.drawBlurAt
+    lia.util.drawBlurAt(100, 100, 200, 150, 5, 1)
+
+### `lia.util.CreateTableUI`
+
+    
+    Description:
+    Creates and displays a table UI with given columns and data on the client side.
+    
+    Parameters:
+    title (string) — The title of the table.
+    columns (table) — The columns, each being {name=..., field=..., width=...}.
+    data (table) — The row data, each row is a table of field values.
+    options (table|nil) — Table of options for right-click actions, each containing {name=..., net=..., ExtraFields=...}.
+    charID (number|nil) — Optional character ID.
+    
+    Returns:
+    nil
+    
+    Realm:
+    Client
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.util.CreateTableUI
+    lia.util.CreateTableUI("My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, myData, myOptions, 1)

--- a/docs/docs/framework/libraries/lia.webimage.md
+++ b/docs/docs/framework/libraries/lia.webimage.md
@@ -1,0 +1,59 @@
+### `lia.webimage.register(name, url, callback, flags)`
+
+    
+    Description:
+    Downloads an image from the specified URL and caches it within the
+    data folder. Once available, the provided callback receives the
+    resulting Material.
+    
+    Parameters:
+    name (string) – Unique file name including extension.
+    url (string) – HTTP address of the image.
+    callback (function|nil) – Called with (Material, fromCache, err).
+    flags (string|nil) – Optional material flags for Material().
+    
+    Realm:
+    Client
+    
+    Returns:
+    nil
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.webimage.register
+    lia.webimage.register("logo.png", "https://example.com/logo.png")
+
+### `lia.webimage.get(name, flags)`
+
+    
+    Description:
+    Retrieves a Material for a previously registered image if it exists in
+    the cache.
+    
+    Parameters:
+    name (string) – File name used during registration.
+    flags (string|nil) – Optional material flags.
+    
+    Realm:
+    Client
+    
+    Returns:
+    Material|nil – The image material or nil if missing.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.webimage.get
+    local mat = lia.webimage.get("logo.png")
+
+HTTPS URL Handling
+    
+    Description:
+    The library extends Garry's Mod's `Material()` and `DImage:SetImage()`
+    functions so they accept direct HTTP or HTTPS image URLs. The image is
+    automatically downloaded via `lia.webimage.register` and cached before
+    the material is returned or applied.
+    
+    Example Usage:
+    -- Load a material directly from the web
+    local mat = Material("https://example.com/icon.png")
+    
+    -- Apply a remote image to a button
+    button:SetImage("https://example.com/icon.png")

--- a/docs/docs/framework/libraries/lia.workshop.md
+++ b/docs/docs/framework/libraries/lia.workshop.md
@@ -1,0 +1,34 @@
+### `lia.workshop.gather()`
+
+    
+    Description:
+    Collects workshop IDs from installed addons and registered modules.
+    
+    Realm:
+    Server
+    
+    Returns:
+    ids (table) – Table of workshop IDs to download.
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.workshop.gather
+    local ids = lia.workshop.gather()
+
+### `lia.workshop.send(ply)`
+
+    
+    Description:
+    Sends the collected workshop IDs to a connecting player.
+    
+    Parameters:
+    ply (Player) – Player to send the download list to.
+    
+    Realm:
+    Server
+    
+    Returns:
+    None
+    
+    Example Usage:
+    -- This snippet demonstrates a common usage of lia.workshop.send
+    lia.workshop.send(ply)

--- a/docs/docs/framework/meta/.pages
+++ b/docs/docs/framework/meta/.pages
@@ -1,9 +1,9 @@
 arrange:
-  - character_meta.md
-  - entity_meta.md
-  - inventory_meta.md
-  - item_meta.md
-  - player_meta.md
-  - panel_meta.md
-  - tool_meta.md
-  - vector_meta.md
+  - character.md
+  - entity.md
+  - inventory.md
+  - item.md
+  - player.md
+  - panel.md
+  - tool.md
+  - vector.md

--- a/docs/docs/framework/meta/character.md
+++ b/docs/docs/framework/meta/character.md
@@ -1,0 +1,370 @@
+### `tostring()`
+
+    Description:
+        Returns a printable identifier for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Format "character[id]".
+
+    Example Usage:
+        -- Print a readable identifier when saving debug logs
+        print("Active char: " .. char:tostring())
+
+### `eq(other)`
+
+    Description:
+        Compares two characters by ID for equality.
+
+    Parameters:
+        other (Character) – Character to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both share the same ID.
+
+    Example Usage:
+        -- Check if the player is controlling the door owner
+        if char:eq(door:getNetVar("ownChar")) then
+            door:Fire("unlock", "", 0)
+        end
+
+### `getID()`
+
+    Description:
+        Returns the unique database ID for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Character identifier.
+
+    Example Usage:
+        -- Store the character ID for later reference
+        local id = char:getID()
+        session.lastCharID = id
+
+### `getPlayer()`
+
+    Description:
+        Returns the player entity currently controlling this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|None – Owning player or None.
+
+    Example Usage:
+        -- Notify the controlling player that the character loaded
+        local ply = char:getPlayer()
+        if IsValid(ply) then
+            ply:ChatPrint("Character ready")
+        end
+
+### `getDisplayedName(client)`
+
+    Description:
+        Returns the character's name as it should be shown to the given player.
+
+    Parameters:
+        client (Player) – Player requesting the name.
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Localized or recognized character name.
+
+    Example Usage:
+        -- Announce the character's name to a viewer
+        client:ChatPrint("You see " .. char:getDisplayedName(client))
+
+### `hasMoney(amount)`
+
+    Description:
+        Checks if the character has at least the given amount of money.
+
+    Parameters:
+        amount (number) – Amount to check for.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the character's funds are sufficient.
+
+    Example Usage:
+        -- Verify the character can pay for an item before buying
+        if char:hasMoney(item.price) then
+            char:takeMoney(item.price)
+        end
+
+### `getFlags()`
+
+    Description:
+        Retrieves the string of permission flags for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Concatenated flag characters.
+
+    Example Usage:
+        -- Look for the admin flag on this character
+        if char:getFlags():find("A") then
+            print("Admin privileges detected")
+        end
+
+### `hasFlags(flags)`
+
+    Description:
+        Checks if the character possesses any of the specified flags.
+
+    Parameters:
+        flags (string) – String of flag characters to check.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if at least one flag is present.
+
+    Example Usage:
+        -- Allow special command if any required flag is present
+        if char:hasFlags("abc") then
+            performSpecialAction()
+        end
+
+### `getItemWeapon(requireEquip)`
+
+    Description:
+        Checks the player's active weapon against items in the inventory.
+
+    Parameters:
+        requireEquip (boolean) – Only match equipped items if true.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the active weapon corresponds to an item.
+
+    Example Usage:
+        -- Determine if the equipped weapon is linked to an item
+        local match = char:getItemWeapon(true)
+        if match then print("Using weapon item") end
+
+### `getMaxStamina()`
+
+    Description:
+        Returns the maximum stamina value for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Maximum stamina points.
+
+    Example Usage:
+        -- Calculate the proportion of stamina remaining
+        local pct = char:getStamina() / char:getMaxStamina()
+
+### `getStamina()`
+
+    Description:
+        Retrieves the character's current stamina value.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Current stamina.
+
+    Example Usage:
+        -- Display current stamina in the HUD
+        local stamina = char:getStamina()
+        drawStaminaBar(stamina)
+
+### `hasClassWhitelist(class)`
+
+    Description:
+        Checks if the character has whitelisted the given class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the class is whitelisted.
+
+    Example Usage:
+        -- Decide if the player may choose the medic class
+        if char:hasClassWhitelist(CLASS_MEDIC) then
+            print("You may become a medic")
+        end
+
+### `isFaction(faction)`
+
+    Description:
+        Returns true if the character's faction matches.
+
+    Parameters:
+        faction (number) – Faction index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the faction matches.
+
+    Example Usage:
+        -- Restrict access to citizens only
+        if char:isFaction(FACTION_CITIZEN) then
+            door:keysOwn(char:getPlayer())
+        end
+
+### `isClass(class)`
+
+    Description:
+        Returns true if the character's class equals the specified class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the classes match.
+
+    Example Usage:
+        -- Provide a bonus if the character is currently an engineer
+        if char:isClass(CLASS_ENGINEER) then
+            char:restoreStamina(10)
+        end
+
+### `getAttrib(key, default)`
+
+    Description:
+        Retrieves the value of an attribute including boosts.
+
+    Parameters:
+        key (string) – Attribute identifier.
+        default (number) – Default value when attribute is missing.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Final attribute value.
+
+    Example Usage:
+        -- Calculate damage using the strength attribute
+        local strength = char:getAttrib("str", 0)
+        dmg = baseDamage + strength * 0.5
+
+### `getBoost(attribID)`
+
+    Description:
+        Returns the boost table for the given attribute.
+
+    Parameters:
+        attribID (string) – Attribute identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        table|None – Table of boosts or None.
+
+    Example Usage:
+        -- Inspect active boosts on agility
+        PrintTable(char:getBoost("agi"))
+
+### `getBoosts()`
+
+    Description:
+        Retrieves all attribute boosts for this character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Mapping of attribute IDs to boost tables.
+
+    Example Usage:
+        -- Print all attribute boosts for debugging
+        for id, data in pairs(char:getBoosts()) do
+            print(id, data)
+        end
+
+### `doesRecognize(id)`
+
+    Description:
+        Determines if this character recognizes another character.
+
+    Parameters:
+        id (number|Character) – Character ID or object to check.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if recognized.
+
+    Example Usage:
+        -- Reveal names in chat only if recognized
+        if char:doesRecognize(targetChar) then
+            print("Known: " .. targetChar:getName())
+        end
+
+### `doesFakeRecognize(id)`
+
+    Description:
+        Checks if the character has a fake recognition entry for another.
+
+    Parameters:
+        id (number|Character) – Character identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if fake recognized.
+
+    Example Usage:
+        -- See if recognition was forced by a disguise item
+        if char:doesFakeRecognize(targetChar) then
+            print("Recognition is fake")
+        end
+

--- a/docs/docs/framework/meta/entity.md
+++ b/docs/docs/framework/meta/entity.md
@@ -1,0 +1,532 @@
+### `isProp()`
+
+    Description:
+        Returns true if the entity is a physics prop.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the entity is a physics prop.
+
+    Example Usage:
+        -- Apply physics damage only if this is a prop
+        if ent:isProp() then
+            ent:TakeDamage(50)
+        end
+
+### `isItem()`
+
+    Description:
+        Checks if the entity is an item entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the entity represents an item.
+
+    Example Usage:
+        -- Attempt to pick up the entity as an item
+        if ent:isItem() then
+            lia.item.pickup(client, ent)
+        end
+
+### `isMoney()`
+
+    Description:
+        Checks if the entity is a money entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the entity represents money.
+
+    Example Usage:
+        -- Collect money dropped on the ground
+        if ent:isMoney() then
+            char:addMoney(ent:getAmount())
+        end
+
+### `isSimfphysCar()`
+
+    Description:
+        Checks if the entity is a simfphys car.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if this is a simfphys vehicle.
+
+    Example Usage:
+        -- Show a custom HUD when entering a simfphys vehicle
+        if ent:isSimfphysCar() then
+            OpenCarHUD(ent)
+        end
+
+### `isLiliaPersistent()`
+
+    Description:
+        Determines if the entity is persistent in Lilia.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the entity should persist.
+
+    Example Usage:
+        -- Save this entity across map resets if persistent
+        if ent:isLiliaPersistent() then
+            lia.persist.saveEntity(ent)
+        end
+
+### `checkDoorAccess(client, access)`
+
+    Description:
+        Checks if a player has the given door access level.
+
+    Parameters:
+        client (Player) – The player to check.
+        access (number, optional) – Door permission level.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the player has access.
+
+    Example Usage:
+        -- Block a player from opening the door without access
+        if not door:checkDoorAccess(client, DOOR_ACCESS_OPEN) then
+            client:notify("The door is locked.")
+        end
+
+### `keysOwn(client)`
+
+    Description:
+        Assigns the entity to the specified player.
+
+    Parameters:
+        client (Player) – Player to set as owner.
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Assign ownership when a player buys the door
+        door:keysOwn(buyer)
+
+### `keysLock()`
+
+    Description:
+        Locks the entity if it is a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Lock the vehicle after the driver exits
+        car:keysLock()
+
+### `keysUnLock()`
+
+    Description:
+        Unlocks the entity if it is a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Unlock the vehicle when the owner presses a key
+        car:keysUnLock()
+
+### `getDoorOwner()`
+
+    Description:
+        Returns the player that owns this door if available.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|None – Door owner or None.
+
+    Example Usage:
+        -- Print the name of the door owner when inspecting
+        local owner = door:getDoorOwner()
+        if owner then
+            print("Owned by", owner:Name())
+        end
+
+### `isLocked()`
+
+    Description:
+        Returns the locked state stored in net variables.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the door is locked.
+
+    Example Usage:
+        -- Display a lock icon if the door is networked as locked
+        if door:isLocked() then
+            DrawLockedIcon(door)
+        end
+
+### `isDoorLocked()`
+
+    Description:
+        Checks the internal door locked state.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the door is locked.
+
+    Example Usage:
+        -- Play a sound when trying to open a locked door server-side
+        if door:isDoorLocked() then
+            door:EmitSound("doors/door_locked2.wav")
+        end
+
+### `getEntItemDropPos(offset)`
+
+    Description:
+        Calculates a drop position in front of the entity's eyes.
+
+    Parameters:
+        offset (number) – Distance from the player eye position.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – Drop position and angle.
+
+    Example Usage:
+        -- Spawn an item drop in front of the entity's eyes
+        local pos, ang = ent:getEntItemDropPos(16)
+        lia.item.spawn("item_water", pos, ang)
+
+### `isNearEntity(radius, otherEntity)`
+
+    Description:
+        Checks for another entity of the same class nearby.
+
+    Parameters:
+        radius (number) – Sphere radius in units.
+        otherEntity (Entity, optional) – Specific entity to look for.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if another entity is within radius.
+
+    Example Usage:
+        -- Prevent building too close to another chest
+        if ent:isNearEntity(128, otherChest) then
+            client:notify("Too close to another chest!")
+        end
+
+### `GetCreator()`
+
+    Description:
+        Returns the entity creator player.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|None – Creator player if stored.
+
+    Example Usage:
+        -- Credit the creator when the entity is removed
+        local creator = ent:GetCreator()
+        if IsValid(creator) then
+            creator:notify("Your prop was removed.")
+        end
+
+### `SetCreator(client)`
+
+        Description:
+            Stores the creator player on the entity.
+
+        Parameters:
+            client (Player) – Creator of the entity.
+
+        Realm:
+            Server
+
+        Returns:
+            None – This function does not return a value.
+
+        Example Usage:
+            -- Record the spawner for cleanup tracking
+            ent:SetCreator(client)
+
+### `sendNetVar(key, receiver)`
+
+        Description:
+            Sends a network variable to recipients.
+
+        Parameters:
+            key (string) – Identifier of the variable.
+            receiver (Player|None) – Who to send to.
+
+        Realm:
+            Server
+
+        Internal:
+            Used by the networking system.
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Broadcast the "doorState" variable to every connected player
+        for _, ply in player.Iterator() do
+            ent:sendNetVar("doorState", ply)
+        end
+
+### `clearNetVars(receiver)`
+
+        Description:
+            Clears all network variables on this entity.
+
+        Parameters:
+            receiver (Player|None) – Receiver to notify.
+
+        Realm:
+            Server
+
+        Returns:
+            None – This function does not return a value.
+
+    Example Usage:
+        -- Force reinitialization by clearing all variables for this receiver
+        ent:clearNetVars(client)
+        ent:sendNetVar("initialized", client)
+
+### `removeDoorAccessData()`
+
+        Description:
+            Clears all stored door access information.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Wipe door permissions during cleanup
+        local result = ent:removeDoorAccessData()
+
+### `setLocked(state)`
+
+        Description:
+            Stores the door locked state in network variables.
+
+        Parameters:
+            state (boolean) – New locked state.
+
+        Realm:
+            Server
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Toggle the door lock and play a latch sound for everyone
+        door:setLocked(true)
+        door:EmitSound("doors/door_latch3.wav")
+
+### `isDoor()`
+
+        Description:
+            Returns true if the entity's class indicates a door.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+        Returns:
+            boolean – Whether the entity is a door.
+
+    Example Usage:
+        -- Check if the entity behaves like a door
+        local result = ent:isDoor()
+
+### `getDoorPartner()`
+
+        Description:
+            Returns the partner door linked with this entity.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+
+        Returns:
+            Entity|None – The partnered door.
+
+    Example Usage:
+        -- Unlock both doors when opening a double-door setup
+        local partner = ent:getDoorPartner()
+        if IsValid(partner) then
+            partner:setLocked(false)
+        end
+
+### `setNetVar(key, value, receiver)`
+
+        Description:
+            Updates a network variable and sends it to recipients.
+
+        Parameters:
+            key (string) – Variable name.
+            value (any) – Value to store.
+            receiver (Player|None) – Who to send update to.
+
+        Realm:
+            Server
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Store a variable and sync it to players
+        local result = ent:setNetVar(key, value, receiver)
+
+### `getNetVar(key, default)`
+
+        Description:
+            Retrieves a stored network variable or a default value.
+
+        Parameters:
+            key (string) – Variable name.
+            default (any) – Value returned if variable is nil.
+
+        Realm:
+            Server
+            Client
+
+        Returns:
+            any – Stored value or default.
+
+    Example Usage:
+        -- Retrieve the stored variable or fallback to the default
+        local result = ent:getNetVar(key, default)
+
+### `isDoor()`
+
+        Description:
+            Client-side door check using class name.
+
+    Parameters:
+        None
+
+        Realm:
+            Client
+
+        Returns:
+            boolean – True if entity class contains "door".
+
+    Example Usage:
+        -- Determine if this entity's class name contains "door"
+        local result = ent:isDoor()
+
+### `getDoorPartner()`
+
+        Description:
+            Attempts to find the door partnered with this one.
+
+    Parameters:
+        None
+
+        Realm:
+            Client
+
+        Returns:
+            Entity|None – The partner door entity.
+
+    Example Usage:
+        -- Highlight the partner door of the one being looked at
+        local partner = ent:getDoorPartner()
+        if IsValid(partner) then
+            partner:SetColor(Color(0, 255, 0))
+        end
+
+### `getNetVar(key, default)`
+
+        Description:
+            Retrieves a network variable for this entity on the client.
+
+        Parameters:
+            key (string) – Variable name.
+            default (any) – Default if not set.
+
+        Realm:
+            Client
+
+        Returns:
+            any – Stored value or default.
+
+    Example Usage:
+        -- Access a synced variable on the client side
+        local result = ent:getNetVar(key, default)
+

--- a/docs/docs/framework/meta/inventory.md
+++ b/docs/docs/framework/meta/inventory.md
@@ -1,0 +1,436 @@
+### `getData(key, default)`
+
+    Description:
+        Returns a stored data value for this inventory.
+
+    Parameters:
+        key (string) – Data field key.
+        default (any) – Value if the key does not exist.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Stored value or default.
+
+    Example Usage:
+        -- Read how many times the container was opened
+        local opens = inv:getData("openCount", 0)
+
+### `extend(className)`
+
+    Description:
+        Creates a subclass of the inventory meta table with a new class name.
+
+    Parameters:
+        className (string) – Name of the subclass meta table.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – The newly derived inventory table.
+
+    Example Usage:
+        -- Define a subclass for weapon crates and register it
+        local WeaponInv = inv:extend("WeaponInventory")
+        function WeaponInv:configure()
+            self:addSlot("Ammo")
+            self:addSlot("Weapons")
+        end
+        WeaponInv:register("weapon_inv")
+
+### `configure()`
+
+    Description:
+        Stub for inventory configuration; meant to be overridden.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Called from a subclass to set up custom slots
+        function WeaponInv:configure()
+            self:addSlot("Ammo")
+            self:addSlot("Weapons")
+        end
+
+### `addDataProxy(key, onChange)`
+
+    Description:
+        Adds a proxy function that is called when a data field changes.
+
+    Parameters:
+        key (string) – Data field to watch.
+        onChange (function) – Callback receiving old and new values.
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Track changes to the "locked" data field
+        inv:addDataProxy("locked", function(old, new)
+            print("Locked state changed", old, new)
+            hook.Run("ChestLocked", inv, new)
+        end)
+
+### `getItemsByUniqueID(uniqueID, onlyMain)`
+
+    Description:
+        Returns all items in the inventory matching the given unique ID.
+
+    Parameters:
+        uniqueID (string) – Item unique identifier.
+        onlyMain (boolean) – Search only the main item list.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Table of matching item objects.
+
+    Example Usage:
+        -- Get all ammo boxes stored in the main list
+        local ammo = inv:getItemsByUniqueID("ammo_box", true)
+
+### `register(typeID)`
+
+    Description:
+        Registers this inventory type with the lia.inventory system.
+
+    Parameters:
+        typeID (string) – Unique identifier for this inventory type.
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Register and then immediately create the inventory type
+        WeaponInv:register("weapon_inv")
+        local chestInv = WeaponInv:new()
+
+### `new()`
+
+    Description:
+        Creates a new inventory of this type.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – New inventory instance.
+
+    Example Usage:
+        -- Create an inventory and attach it to a spawned chest entity
+        local chest = ents.Create("prop_physics")
+        chest:SetModel("models/props_junk/wood_crate001a.mdl")
+        chest:Spawn()
+        chest.inv = WeaponInv:new()
+
+### `tostring()`
+
+    Description:
+        Returns a printable representation of this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Formatted as "ClassName[id]".
+
+    Example Usage:
+        -- Print the identifier when debugging
+        print("Inventory: " .. inv:tostring())
+
+### `getType()`
+
+    Description:
+        Retrieves the inventory type table from lia.inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Inventory type definition.
+
+    Example Usage:
+        -- Read slot data from the type definition
+        local def = inv:getType()
+
+### `onDataChanged(key, oldValue, newValue)`
+
+    Description:
+        Called when an inventory data field changes. Executes any
+        registered proxy callbacks for that field.
+
+    Parameters:
+        key (string) – Data field key.
+        oldValue (any) – Previous value.
+        newValue (any) – Updated value.
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- React when the stored credit amount changes
+        inv:onDataChanged("credits", 0, 100)
+
+### `getItems()`
+
+    Description:
+        Returns all items stored in this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Item instance table indexed by itemID.
+
+    Example Usage:
+        -- Sum the weight of all items
+        for _, itm in pairs(inv:getItems()) do
+            totalWeight = totalWeight + itm.weight
+        end
+
+### `getItemsOfType(itemType)`
+
+    Description:
+        Collects all items that match the given unique ID.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Array of matching items.
+
+    Example Usage:
+        -- List all medkits currently in the inventory
+        local kits = inv:getItemsOfType("medkit")
+
+### `getFirstItemOfType(itemType)`
+
+    Description:
+        Retrieves the first item matching the given unique ID.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        Item|None – The first matching item or None.
+
+    Example Usage:
+        -- Grab the first pistol found in the inventory
+        local pistol = inv:getFirstItemOfType("pistol")
+
+### `hasItem(itemType)`
+
+    Description:
+        Determines whether the inventory contains an item type.
+
+    Parameters:
+        itemType (string) – Item unique identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if an item is found.
+
+    Example Usage:
+        -- See if any health potion exists
+        if inv:hasItem("health_potion") then ... end
+
+### `getItemCount(itemType)`
+
+    Description:
+        Counts the total quantity of a specific item type.
+
+    Parameters:
+        itemType (string|None) – Item unique ID to count. Counts all if nil.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Sum of quantities.
+
+    Example Usage:
+        -- Count the total number of bullets
+        local ammoTotal = inv:getItemCount("bullet")
+
+### `getID()`
+
+    Description:
+        Returns the unique database ID of this inventory.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Inventory identifier.
+
+    Example Usage:
+        -- Store the inventory ID on its container entity
+        entity:setNetVar("invID", inv:getID())
+
+### `eq(other)`
+
+    Description:
+        Compares two inventories by ID for equality.
+
+    Parameters:
+        other (Inventory) – Other inventory to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both inventories share the same ID.
+
+    Example Usage:
+        -- Check if two chests share the same inventory record
+        if inv:eq(other) then
+            print("Duplicate inventory")
+        end
+
+### `addItem(item, noReplicate)`
+
+        Description:
+            Inserts an item instance into this inventory and persists it.
+
+        Parameters:
+            item (Item) – Item to add.
+            noReplicate (boolean) – Skip network replication when true.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Add a looted item to the inventory
+        inv:addItem(item, false)
+
+### `removeItem(itemID, preserveItem)`
+
+        Description:
+            Removes an item by ID and optionally deletes it.
+
+        Parameters:
+            itemID (number) – Unique item identifier.
+            preserveItem (boolean) – Keep item in database when true.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Remove an item but keep it saved for later
+        inv:removeItem(itemID, true)
+
+### `syncData(key, recipients)`
+
+        Description:
+            Sends a single data field to clients.
+
+        Parameters:
+            key (string) – Field to replicate.
+            recipients (table|None) – Player recipients.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Sync the locked state to nearby players
+        inv:syncData("locked", recipients)
+
+### `sync(recipients)`
+
+        Description:
+            Sends the entire inventory and its items to players.
+
+        Parameters:
+            recipients (table|None) – Player recipients.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Send all items to the owner after they join
+        inv:sync({owner})
+
+### `delete()`
+
+        Description:
+            Removes this inventory record from the database.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Permanently delete a chest inventory on cleanup
+        inv:delete()
+
+### `destroy()`
+
+        Description:
+            Destroys all items and removes network references.
+
+    Parameters:
+        None
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Clear all items when the container entity is removed
+        inv:destroy()
+

--- a/docs/docs/framework/meta/item.md
+++ b/docs/docs/framework/meta/item.md
@@ -1,0 +1,338 @@
+### `getQuantity()`
+
+    Description:
+        Retrieves how many of this item the stack represents.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Quantity contained in this item instance.
+
+    Example Usage:
+        -- Give the player ammo equal to the stack quantity
+        player:GiveAmmo(item:getQuantity(), "pistol")
+
+### `eq(other)`
+
+    Description:
+        Compares this item instance to another by ID.
+
+    Parameters:
+        other (Item) – The other item to compare with.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if both items share the same ID.
+
+    Example Usage:
+        -- Check if the held item matches the inventory slot
+        if item:eq(slotItem) then
+            print("Same item instance")
+        end
+
+### `tostring()`
+
+    Description:
+        Returns a printable representation of this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Identifier in the form "item[uniqueID][id]".
+
+    Example Usage:
+        -- Log the item identifier during saving
+        print("Saving " .. item:tostring())
+
+### `getID()`
+
+    Description:
+        Retrieves the unique identifier of this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Item database ID.
+
+    Example Usage:
+        -- Use the ID when updating the database
+        lia.db.updateItem(item:getID(), {price = 50})
+
+### `getModel()`
+
+    Description:
+        Returns the model path associated with this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Model path.
+
+    Example Usage:
+        -- Spawn the item's model as a world prop
+        local prop = ents.Create("prop_physics")
+        prop:SetModel(item:getModel())
+        prop:Spawn()
+
+### `getSkin()`
+
+    Description:
+        Retrieves the skin index this item uses.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Skin ID applied to the model.
+
+    Example Usage:
+        -- Apply the correct skin when displaying the item
+        model:SetSkin(item:getSkin())
+
+### `getPrice()`
+
+    Description:
+        Returns the calculated purchase price for the item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The price value.
+
+    Example Usage:
+        -- Charge the player the item's price before giving it
+        if char:hasMoney(item:getPrice()) then
+            char:takeMoney(item:getPrice())
+        end
+
+### `call(method, client, entity, ...)`
+
+    Description:
+        Invokes an item method with the given player and entity context.
+
+    Parameters:
+        method (string) – Method name to run.
+        client (Player) – The player performing the action.
+        entity (Entity) – Entity representing this item.
+        ... – Additional arguments passed to the method.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Results returned by the called function.
+
+    Example Usage:
+        -- Trigger a custom "use" function when the player presses Use
+        item:call("use", client, entity)
+
+### `getOwner()`
+
+    Description:
+        Attempts to find the player currently owning this item.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player|None – The owner if available.
+
+    Example Usage:
+        -- Notify whoever currently owns the item
+        local owner = item:getOwner()
+        if IsValid(owner) then
+            owner:notify("Your item glows brightly.")
+        end
+
+### `getData(key, default)`
+
+    Description:
+        Retrieves a piece of persistent data stored on the item.
+
+    Parameters:
+        key (string) – Data key to read.
+        default (any) – Value to return when the key is absent.
+
+    Realm:
+        Shared
+
+    Returns:
+        any – Stored value or default.
+
+    Example Usage:
+        -- Retrieve a custom paint color stored on the item
+        local color = item:getData("paintColor", Color(255,255,255))
+
+### `getAllData()`
+
+    Description:
+        Returns a merged table of this item's stored data and any
+        networked values on its entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Key/value table of all data fields.
+
+    Example Usage:
+        -- Print all stored data for debugging
+        PrintTable(item:getAllData())
+
+### `hook(name, func)`
+
+    Description:
+        Registers a hook callback for this item instance.
+
+    Parameters:
+        name (string) – Hook identifier.
+        func (function) – Function to call.
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Run code when the item is used
+        item:hook("use", function(ply) ply:ChatPrint("Used!") end)
+
+### `postHook(name, func)`
+
+    Description:
+        Registers a post-hook callback for this item.
+
+    Parameters:
+        name (string) – Hook identifier.
+        func (function) – Function invoked after the main hook.
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Give a pistol after the item is picked up
+        item:postHook("pickup", function(ply) ply:Give("weapon_pistol") end)
+
+### `onRegistered()`
+
+    Description:
+        Called when the item table is first registered.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Initialize data when the item type loads
+        item:onRegistered()
+
+### `print(detail)`
+
+    Description:
+        Prints a simple representation of the item to the console.
+
+    Parameters:
+        detail (boolean) – Include position details when true.
+
+    Realm:
+        Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Output item info while debugging spawn issues
+        item:print(true)
+
+### `printData()`
+
+    Description:
+        Debug helper that prints all stored item data.
+
+    Parameters:
+        None
+
+    Realm:
+        Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Dump all stored data to the console
+        item:printData()
+
+### `addQuantity(quantity, receivers, noCheckEntity)`
+
+        Description:
+            Increases the stored quantity for this item instance.
+
+        Parameters:
+            quantity (number) – Amount to add.
+            receivers (Player|None) – Who to network the change to.
+            noCheckEntity (boolean) – Skip entity network update.
+
+        Realm:
+            Server
+        Returns:
+            None – This function does not return a value.
+
+    Example Usage:
+        -- Combine stacks from a loot drop and notify the owner
+        item:addQuantity(5, {player})
+        player:notifyLocalized("item_added", item.name, 5)
+
+### `setQuantity(quantity, receivers, noCheckEntity)`
+
+        Description:
+            Sets the current stack quantity and replicates the change.
+
+        Parameters:
+            quantity (number) – New amount to store.
+            receivers (Player|None) – Recipients to send updates to.
+            noCheckEntity (boolean) – Skip entity updates when true.
+
+        Realm:
+            Server
+        Returns:
+            None – This function does not return a value.
+
+    Example Usage:
+        -- Set quantity to 1 after splitting the stack
+        item:setQuantity(1, nil, true)
+

--- a/docs/docs/framework/meta/panel.md
+++ b/docs/docs/framework/meta/panel.md
@@ -1,0 +1,24 @@
+### `Screen-scaling helper wrappers for Panel positioning functions.`
+
+    Description:
+        These helpers apply ScreenScale and ScreenScaleH to common panel
+        positioning and sizing methods so that user interfaces remain
+        consistent across different resolutions.
+
+    Parameters:
+        None
+
+    Realm:
+        Client
+
+    Returns:
+        any – Whatever the wrapped Panel function returns.
+
+    Example Usage:
+        -- This creates a simple frame positioned using screen scaling
+        local frame = vgui.Create("DFrame")
+        frame:SetSize(200, 100)
+        frame:SetPos(25, 25)
+        frame:SetTitle("Scaled Frame")
+        frame:MakePopup()
+

--- a/docs/docs/framework/meta/player.md
+++ b/docs/docs/framework/meta/player.md
@@ -1,0 +1,625 @@
+### `getChar()`
+
+        Description:
+            Returns the currently loaded character object for this player.
+
+    Parameters:
+        None
+
+        Realm:
+            Shared
+
+        Returns:
+            Character|None – The player's active character.
+
+    Example Usage:
+        -- Retrieve the character to modify inventory
+        local char = player:getChar()
+
+### `Name()`
+
+        Description:
+            Returns either the character's roleplay name or the player's Steam name.
+
+    Parameters:
+        None
+
+        Realm:
+            Shared
+
+        Returns:
+            string – Display name.
+
+    Example Usage:
+        -- Print the roleplay name in chat
+        chat.AddText(player:Name())
+
+### `hasPrivilege(privilegeName)`
+
+    Description:
+        Wrapper for CAMI privilege checks.
+
+    Parameters:
+        privilegeName (string) – Privilege identifier.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from CAMI.PlayerHasAccess.
+
+    Example Usage:
+        -- Deny access if the player lacks a privilege
+        if not player:hasPrivilege("Manage") then
+            return false
+        end
+
+### `getCurrentVehicle()`
+
+    Description:
+        Safely returns the vehicle the player is currently using.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|None – Vehicle entity or None.
+
+    Example Usage:
+        -- Attach a camera to the vehicle the player is in
+        local veh = player:getCurrentVehicle()
+        if IsValid(veh) then
+            AttachCamera(veh)
+        end
+
+### `hasValidVehicle()`
+
+    Description:
+        Determines if the player is currently inside a valid vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if a vehicle entity is valid.
+
+    Example Usage:
+        -- Allow honking only when in a valid vehicle
+        if player:hasValidVehicle() then
+            player:GetVehicle():EmitSound("Horn")
+        end
+
+### `isNoClipping()`
+
+    Description:
+        Returns true if the player is in noclip mode and not inside a vehicle.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the player is noclipping.
+
+    Example Usage:
+        -- Disable certain actions while noclipping
+        if player:isNoClipping() then return end
+
+### `getItems()`
+
+    Description:
+        Returns the player's inventory item list if a character is loaded.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table|None – Table of items or None if absent.
+
+    Example Usage:
+        -- Iterate player's items to calculate total weight
+        for _, it in pairs(player:getItems() or {}) do
+            total = total + it.weight
+        end
+
+### `getTracedEntity(distance)`
+
+    Description:
+        Performs a simple trace from the player's shoot position.
+
+    Parameters:
+        distance (number) – Trace length in units.
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|None – The entity hit or None.
+
+    Example Usage:
+        -- Grab the entity the player is pointing at
+        local entity = player:getTracedEntity(96)
+
+### `getTrace(distance)`
+
+    Description:
+        Returns a hull trace in front of the player.
+
+    Parameters:
+        distance (number) – Hull length in units.
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Trace result.
+
+    Example Usage:
+        -- Use a hull trace for melee attacks
+        local tr = player:getTrace(48)
+
+### `getEyeEnt(distance)`
+
+    Description:
+        Returns the entity the player is looking at within a distance.
+
+    Parameters:
+        distance (number) – Maximum distance.
+
+    Realm:
+        Shared
+
+    Returns:
+        Entity|None – The entity or None if too far.
+
+    Example Usage:
+        -- Show the name of the object being looked at
+        local target = player:getEyeEnt(128)
+        if IsValid(target) then
+            player:ChatPrint(target:GetClass())
+        end
+
+### `notify(message)`
+
+    Description:
+        Sends a plain notification message to the player.
+
+    Parameters:
+        message (string) – Text to display.
+
+    Realm:
+        Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Send a welcome notification and log the join event
+        player:notify("Welcome to the server!")
+        file.Append("welcome.txt", player:SteamID() .. " joined\n")
+
+### `notifyLocalized(message, ...)`
+
+    Description:
+        Sends a localized notification to the player.
+
+    Parameters:
+        message (string) – Translation key.
+        ... – Additional parameters for localization.
+
+    Realm:
+        Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Send a localized message including the player's name and score
+        local score = player:GetFrags()
+        player:notifyLocalized("greeting_key", player:Name(), score)
+
+### `CanEditVendor(vendor)`
+
+    Description:
+        Determines whether the player can edit the given vendor.
+
+    Parameters:
+        vendor (Entity) – Vendor entity to check.
+
+    Realm:
+        Server
+
+    Returns:
+        boolean – True if allowed to edit.
+
+    Example Usage:
+        -- Determine if the player may modify the vendor
+        local result = player:CanEditVendor(vendor)
+
+### `isUser()`
+
+    Description:
+        Convenience wrapper to check if the player is in the "user" group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether usergroup is "user".
+
+    Example Usage:
+        -- Check if the player belongs to the default user group
+        local result = player:isUser()
+
+### `isStaff()`
+
+    Description:
+        Returns true if the player belongs to a staff group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from the privilege check.
+
+    Example Usage:
+        -- Verify staff permissions for administrative actions
+        local result = player:isStaff()
+
+### `isVIP()`
+
+    Description:
+        Checks whether the player is in the VIP group.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Result from privilege check.
+
+    Example Usage:
+        -- Test if the player has VIP status
+        local result = player:isVIP()
+
+### `isStaffOnDuty()`
+
+    Description:
+        Determines if the player is currently in the staff faction.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if staff faction is active.
+
+    Example Usage:
+        -- Confirm the player is currently in a staff role
+        local result = player:isStaffOnDuty()
+
+### `isFaction(faction)`
+
+    Description:
+        Checks if the player's character belongs to the given faction.
+
+    Parameters:
+        faction (number) – Faction index to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the factions match.
+
+    Example Usage:
+        -- Compare the player's faction to a requirement
+        local result = player:isFaction(faction)
+
+### `isClass(class)`
+
+    Description:
+        Returns true if the player's character is of the given class.
+
+    Parameters:
+        class (number) – Class index to compare.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the character matches the class.
+
+    Example Usage:
+        -- Determine if the player's class matches
+        local result = player:isClass(class)
+
+### `hasWhitelist(faction)`
+
+    Description:
+        Determines if the player has whitelist access for a faction.
+
+    Parameters:
+        faction (number) – Faction index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if whitelisted.
+
+    Example Usage:
+        -- Check for whitelist permission on a faction
+        local result = player:hasWhitelist(faction)
+
+### `getClass()`
+
+    Description:
+        Retrieves the class index of the player's character.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number|None – Class index or None.
+
+    Example Usage:
+        -- Retrieve the current class index
+        local result = player:getClass()
+
+### `hasClassWhitelist(class)`
+
+    Description:
+        Checks if the player's character is whitelisted for a class.
+
+    Parameters:
+        class (number) – Class index.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if class whitelist exists.
+
+    Example Usage:
+        -- Verify the player is approved for a specific class
+        local result = player:hasClassWhitelist(class)
+
+### `getClassData()`
+
+    Description:
+        Returns the class table of the player's current class.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table|None – Class definition table.
+
+    Example Usage:
+        -- Access data table for the player's class
+        local result = player:getClassData()
+
+### `getDarkRPVar(var)`
+
+    Description:
+        Compatibility helper for retrieving money with DarkRP-style calls.
+
+    Parameters:
+        var (string) – Currently only supports "money".
+
+    Realm:
+        Shared
+
+    Returns:
+        number|None – Money amount or None.
+
+    Example Usage:
+        -- Read money amount in a DarkRP-compatible way
+        local result = player:getDarkRPVar(var)
+
+### `getMoney()`
+
+    Description:
+        Convenience function to get the character's money amount.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        number – Current funds or 0.
+
+    Example Usage:
+        -- Fetch the character's stored funds
+        local result = player:getMoney()
+
+### `canAfford(amount)`
+
+    Description:
+        Checks if the player has enough money for a purchase.
+
+    Parameters:
+        amount (number) – Cost to test.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if funds are sufficient.
+
+    Example Usage:
+        -- Check if the player has enough money to buy something
+        local result = player:canAfford(amount)
+
+### `hasSkillLevel(skill, level)`
+
+    Description:
+        Verifies the player's character meets an attribute level.
+
+    Parameters:
+        skill (string) – Attribute ID.
+        level (number) – Required level.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – Whether the character satisfies the requirement.
+
+    Example Usage:
+        -- Ensure the player meets a single skill requirement
+        local result = player:hasSkillLevel(skill, level)
+
+### `meetsRequiredSkills(requiredSkillLevels)`
+
+    Description:
+        Checks a table of skill requirements against the player.
+
+    Parameters:
+        requiredSkillLevels (table) – Mapping of attribute IDs to levels.
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if all requirements are met.
+
+    Example Usage:
+        -- Validate multiple skill requirements at once
+        local result = player:meetsRequiredSkills(requiredSkillLevels)
+
+### `forceSequence(sequenceName, callback, time, noFreeze)`
+
+    Description:
+        Plays an animation sequence and optionally freezes the player.
+
+    Parameters:
+        sequenceName (string) – Sequence to play.
+        callback (function|None) – Called when finished.
+        time (number|None) – Duration override.
+        noFreeze (boolean) – Don't freeze movement when true.
+
+    Realm:
+        Shared
+
+    Returns:
+        number|boolean – Duration or false on failure.
+
+    Example Usage:
+        -- Play an animation while freezing the player
+        local result = player:forceSequence(sequenceName, callback, time, noFreeze)
+
+### `leaveSequence()`
+
+    Description:
+        Stops any forced sequence and restores player movement.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Stop the player's forced animation sequence
+        local result = player:leaveSequence()
+
+### `restoreStamina(amount)`
+
+        Description:
+            Increases the player's stamina value.
+
+        Parameters:
+            amount (number) – Amount to restore.
+
+        Realm:
+            Server
+        Returns:
+            None – This function does not return a value.
+
+    Example Usage:
+        -- Give the player extra stamina points
+        local result = player:restoreStamina(amount)
+
+### `consumeStamina(amount)`
+
+        Description:
+            Reduces the player's stamina value.
+
+        Parameters:
+            amount (number) – Amount to subtract.
+
+        Realm:
+            Server
+        Returns:
+            None – This function does not return a value.
+
+    Example Usage:
+        -- Spend stamina as the player performs an action
+        local result = player:consumeStamina(amount)
+
+### `addMoney(amount)`
+
+        Description:
+            Adds funds to the player's character, clamping to limits.
+
+        Parameters:
+            amount (number) – Money to add.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Reward the player and announce the payout
+        player:addMoney(100)
+        player:notify("You received $100 for completing the quest.")
+
+### `takeMoney(amount)`
+
+        Description:
+            Removes money from the player's character.
+
+        Parameters:
+            amount (number) – Amount to subtract.
+
+        Realm:
+            Server
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Remove money from the player's character
+        local result = player:takeMoney(amount)
+

--- a/docs/docs/framework/meta/tool.md
+++ b/docs/docs/framework/meta/tool.md
@@ -1,0 +1,377 @@
+### `Create()`
+
+    Description:
+        Creates a new tool object with default values.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – The newly created tool object.
+
+    Example Usage:
+        -- Create a table for a custom door tool mode
+        local tool = ToolGunMeta:Create()
+        tool.Mode = "lia_dooredit"
+
+### `CreateConVars()`
+
+    Description:
+        Creates client and server ConVars for this tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Ensure console variables exist for configuration
+        tool:CreateConVars()
+
+### `GetServerInfo(property)`
+
+    Description:
+        Returns the server ConVar for the given property.
+
+    Parameters:
+        property (string) – Property name.
+
+    Realm:
+        Shared
+
+    Returns:
+        ConVar – The server ConVar object.
+
+    Example Usage:
+        -- Check if the server allows using this tool
+        local allow = tool:GetServerInfo("allow_use"):GetBool()
+
+### `BuildConVarList()`
+
+    Description:
+        Returns a table of client ConVars prefixed by the tool mode.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        table – Table of convars.
+
+    Example Usage:
+        -- Get a table of client ConVars for networking
+        local cvars = tool:BuildConVarList()
+
+### `GetClientInfo(property)`
+
+    Description:
+        Retrieves a client ConVar value as a string.
+
+    Parameters:
+        property (string) – ConVar name without mode prefix.
+
+    Realm:
+        Shared
+
+    Returns:
+        string – The value stored in the ConVar.
+
+    Example Usage:
+        -- Get the client's chosen material from a ConVar
+        local mat = tool:GetClientInfo("material")
+
+### `GetClientNumber(property, default)`
+
+    Description:
+        Retrieves a numeric client ConVar value.
+
+    Parameters:
+        property (string) – ConVar name without mode prefix.
+        default (number) – Value returned if the ConVar doesn't exist.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The numeric value of the ConVar.
+
+    Example Usage:
+        -- Read the numeric power setting with a fallback
+        local power = tool:GetClientNumber("power", 10)
+
+### `Allowed()`
+
+    Description:
+        Determines whether this tool is allowed to be used.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – True if the tool is allowed.
+
+    Example Usage:
+        -- Check if the player can use the current tool
+        if tool:Allowed() then
+            tool:GetOwner():ChatPrint("Tool is permitted!")
+            hook.Run("PlayerToolPermitted", tool:GetOwner(), tool:GetMode())
+        else
+            tool:GetOwner():ChatPrint("Tool usage blocked.")
+        end
+
+### `Init()`
+
+    Description:
+        Placeholder for tool initialization.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Prepare the tool for use
+        local result = tool:Init()
+
+### `GetMode()`
+
+    Description:
+        Gets the current tool mode string.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        string – Tool mode name.
+
+    Example Usage:
+        -- Retrieve the tool's active mode string
+        local result = tool:GetMode()
+
+### `GetSWEP()`
+
+    Description:
+        Returns the SWEP associated with this tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        SWEP – The tool's weapon entity.
+
+    Example Usage:
+        -- Obtain the weapon entity representing this tool
+        local result = tool:GetSWEP()
+
+### `GetOwner()`
+
+    Description:
+        Retrieves the tool owner's player object.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Player – Owner of the tool.
+
+    Example Usage:
+        -- Reference the player who deployed the tool
+        local result = tool:GetOwner()
+
+### `GetWeapon()`
+
+    Description:
+        Retrieves the weapon entity this tool is attached to.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        Weapon – The weapon object.
+
+    Example Usage:
+        -- Access the underlying weapon object
+        local result = tool:GetWeapon()
+
+### `LeftClick()`
+
+    Description:
+        Handles the left-click action. Override for custom behavior.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – False by default.
+
+    Example Usage:
+        -- Attempt the primary tool action
+        local result = tool:LeftClick()
+
+### `RightClick()`
+
+    Description:
+        Handles the right-click action. Override for custom behavior.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+
+    Returns:
+        boolean – False by default.
+
+    Example Usage:
+        -- Attempt the secondary tool action
+        local result = tool:RightClick()
+
+### `Reload()`
+
+    Description:
+        Clears stored objects when the tool reloads.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Clear saved objects when reloading the tool
+        local result = tool:Reload()
+
+### `Deploy()`
+
+    Description:
+        Called when the tool is equipped. Releases ghost entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Equip the tool and spawn its ghost entity
+        local result = tool:Deploy()
+
+### `Holster()`
+
+    Description:
+        Called when the tool is holstered. Releases ghost entity.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Unequip the tool and remove its ghost entity
+        local result = tool:Holster()
+
+### `Think()`
+
+    Description:
+        Called every tick; releases ghost entities by default.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Run per-tick logic for the active tool
+        local result = tool:Think()
+
+### `CheckObjects()`
+
+    Description:
+        Validates stored objects and clears them if invalid.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Validate all stored objects each tick
+        local result = tool:CheckObjects()
+
+### `ClearObjects()`
+
+    Description:
+        Removes all stored objects from the tool.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Remove any objects the tool is storing
+        local result = tool:ClearObjects()
+
+### `ReleaseGhostEntity()`
+
+    Description:
+        Removes the ghost entity used for previewing placements.
+
+    Parameters:
+        None
+
+    Realm:
+        Shared
+    Returns:
+        None – This function does not return a value.
+
+    Example Usage:
+        -- Remove the placement preview entity
+        local result = tool:ReleaseGhostEntity()
+

--- a/docs/docs/framework/meta/vector.md
+++ b/docs/docs/framework/meta/vector.md
@@ -1,0 +1,96 @@
+### `Center(vec2)`
+
+    Description:
+        Returns the midpoint between this vector and the supplied vector.
+
+    Parameters:
+        vec2 (Vector) – The vector to average with this vector.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The center point of the two vectors.
+
+    Example Usage:
+        -- Average two vectors to find the midpoint
+        local midpoint = vector_origin:Center(Vector(10, 10, 10))
+        print(midpoint) -- Vector(5, 5, 5)
+
+### `Distance(vec2)`
+
+    Description:
+        Calculates the distance between this vector and another vector.
+
+    Parameters:
+        vec2 (Vector) – The other vector.
+
+    Realm:
+        Shared
+
+    Returns:
+        number – The distance between the two vectors.
+
+    Example Usage:
+        -- Measure the distance between two points
+        local dist = vector_origin:Distance(Vector(3, 4, 0))
+        print(dist) -- 5
+
+### `RotateAroundAxis(axis, degrees)`
+
+    Description:
+        Rotates the vector around an axis by the specified degrees and returns the new vector.
+
+    Parameters:
+        axis (Vector) – Axis to rotate around.
+        degrees (number) – Angle in degrees.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The rotated vector.
+
+    Example Usage:
+        -- Rotate a vector 90 degrees around the Z axis
+        local rotated = Vector(1, 0, 0):RotateAroundAxis(Vector(0, 0, 1), 90)
+        print(rotated) -- Vector(0, 1, 0)
+
+### `Right(vUp)`
+
+    Description:
+        Returns a normalized right-direction vector relative to this vector.
+
+    Parameters:
+        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The calculated right vector.
+
+    Example Usage:
+        -- Get the right direction vector
+        local rightVec = Vector(0, 1, 0):Right()
+        print(rightVec)
+
+### `Up(vUp)`
+
+    Description:
+        Returns a normalized up-direction vector relative to this vector.
+
+    Parameters:
+        vUp (Vector, optional) – Up direction to compare against. Defaults to vector_up.
+
+    Realm:
+        Shared
+
+    Returns:
+        Vector – The calculated up vector.
+
+    Example Usage:
+        -- Get the up direction vector
+        local upVec = Vector(1, 0, 0):Up()
+        print(upVec)
+

--- a/docs/lua/definitions/command_fields.lua
+++ b/docs/lua/definitions/command_fields.lua
@@ -72,11 +72,11 @@
     Description:
         Table describing how the command should appear in admin
         utilities. Common keys include:
-            Name        - display text in the menu.
-            Category    - top level grouping.
-            SubCategory - secondary grouping.
-            Icon        - 16x16 icon path.
-            ExtraFields - (optional) legacy field definitions. Missing
+            Name – display text in the menu.
+            Category – top level grouping.
+            SubCategory – secondary grouping.
+            Icon – 16x16 icon path.
+            ExtraFields – (optional) legacy field definitions. Missing
             arguments are now prompted automatically using the syntax string.
 
     Example Usage:

--- a/docs/lua/libraries/commands.lua
+++ b/docs/lua/libraries/commands.lua
@@ -40,10 +40,10 @@
       Quoted sections are treated as single arguments.
 
    Parameters:
-      text (string) - The raw input text to parse.
+      text (string) – The raw input text to parse.
 
    Returns:
-      table - A list of arguments extracted from the text.
+      table – A list of arguments extracted from the text.
 
    Realm:
       Shared
@@ -61,11 +61,11 @@
      Each field contains a name and a type derived from the syntax.
 
   Parameters:
-     syntax (string) - The syntax string, e.g. "[string Name] [number Time]".
+     syntax (string) – The syntax string, e.g. "[string Name] [number Time]".
 
   Returns:
-     table - List of fields in call order.
-     boolean - Whether the syntax strictly used the "[type Name]" format.
+     table – List of fields in call order.
+     boolean – Whether the syntax strictly used the "[type Name]" format.
 
   Realm:
      Shared
@@ -82,9 +82,9 @@
          If the command returns a string, it notifies the client (if valid).
 
       Parameters:
-         client (Player) - The player or console running the command.
-         command (string) - The name of the command to run.
-         arguments (table) - A list of arguments for the command.
+         client (Player) – The player or console running the command.
+         command (string) – The name of the command to run.
+         arguments (table) – A list of arguments for the command.
 
       Returns:
          nil
@@ -104,13 +104,13 @@
          and arguments if provided. If parsed successfully, the command is executed.
 
       Parameters:
-         client (Player) - The player or console issuing the command.
-         text (string) - The raw text that may contain the command name and arguments.
-         realCommand (string) - If provided, use this as the command name instead of parsing text.
-         arguments (table) - If provided, use these as the command arguments instead of parsing text.
+         client (Player) – The player or console issuing the command.
+         text (string) – The raw text that may contain the command name and arguments.
+         realCommand (string) – If provided, use this as the command name instead of parsing text.
+         arguments (table) – If provided, use these as the command arguments instead of parsing text.
 
       Returns:
-         boolean - True if the text was parsed as a valid command, false otherwise.
+         boolean – True if the text was parsed as a valid command, false otherwise.
 
       Realm:
          Server
@@ -127,8 +127,8 @@
          Garry's Mod net library. The server will then execute the command.
 
       Parameters:
-         command (string) - The name of the command to send.
-         ... (vararg) - Any additional arguments to pass to the command.
+         command (string) – The name of the command to send.
+         ... (vararg) – Any additional arguments to pass to the command.
 
       Returns:
          nil
@@ -149,9 +149,9 @@
      prompt only appears if the command's syntax fields were valid.
 
   Parameters:
-     cmd (string) - The command name.
-     fields (table) - Table of field names to their types.
-     prefix (table) - Arguments that were already supplied before the prompt.
+     cmd (string) – The command name.
+     fields (table) – Table of field names to their types.
+     prefix (table) – Arguments that were already supplied before the prompt.
 
   Returns:
      nil

--- a/docs/lua/libraries/data.lua
+++ b/docs/lua/libraries/data.lua
@@ -7,17 +7,17 @@
          Also caches the value in lia.data.stored.
 
       Parameters:
-         key (string) - The key under which the data is stored.
-         value (any) - The value to store.
-         global (boolean) - If true, uses a global path; otherwise, includes folder and map.
-         ignoreMap (boolean) - If true, ignores the map directory.
+         key (string) – The key under which the data is stored.
+         value (any) – The value to store.
+         global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+         ignoreMap (boolean) – If true, ignores the map directory.
 
     Returns:
-        string - The path where the data was saved.
+        string – The path where the data was saved.
 
     Realm:
         Shared
-    
+
     Example Usage:
         -- Save the admin's position as the global spawn point with a command
         concommand.Add("save_spawn", function(ply)
@@ -34,12 +34,12 @@
          Also removes the value from the cached storage.
 
       Parameters:
-         key (string) - The key corresponding to the data to be deleted.
-         global (boolean) - If true, uses a global path; otherwise, includes folder and map.
-         ignoreMap (boolean) - If true, ignores the map directory.
+         key (string) – The key corresponding to the data to be deleted.
+         global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+         ignoreMap (boolean) – If true, ignores the map directory.
 
     Returns:
-        boolean - True if the file was deleted, false otherwise.
+        boolean – True if the file was deleted, false otherwise.
 
     Realm:
         Shared
@@ -57,14 +57,14 @@
       Otherwise, reads from the file, decodes, and caches the value.
 
    Parameters:
-      key (string) - The key corresponding to the data.
-      default (any) - The default value to return if no data is found.
-      global (boolean) - If true, uses a global path; otherwise, includes folder and map.
-      ignoreMap (boolean) - If true, ignores the map directory.
-      refresh (boolean) - If true, forces reading from file instead of cache.
+      key (string) – The key corresponding to the data.
+      default (any) – The default value to return if no data is found.
+      global (boolean) – If true, uses a global path; otherwise, includes folder and map.
+      ignoreMap (boolean) – If true, ignores the map directory.
+      refresh (boolean) – If true, forces reading from file instead of cache.
 
     Returns:
-        any - The stored value, or the default if not found.
+        any – The stored value, or the default if not found.
 
     Realm:
         Shared

--- a/docs/lua/libraries/database.lua
+++ b/docs/lua/libraries/database.lua
@@ -7,8 +7,8 @@
       or re-establish one.
 
    Parameters:
-      callback (function) - The function to call when the database connection is established.
-      reconnect (boolean) - Whether to reconnect using an existing database object or not.
+      callback (function) – The function to call when the database connection is established.
+      reconnect (boolean) – Whether to reconnect using an existing database object or not.
 
     Returns:
         nil
@@ -30,7 +30,7 @@
       tables. This action is irreversible and will remove all stored data.
 
    Parameters:
-      callback (function) - The function to call when the wipe operation is completed.
+      callback (function) – The function to call when the wipe operation is completed.
 
     Returns:
         nil
@@ -75,7 +75,7 @@
       None
 
     Returns:
-        deferred - Resolves when the tables are loaded.
+        deferred – Resolves when the tables are loaded.
 
     Realm:
         Shared
@@ -95,11 +95,11 @@
       unless noEscape is set.
 
    Parameters:
-      value (any) - The value to be converted.
-      noEscape (boolean) - If true, the returned string is not escaped.
+      value (any) – The value to be converted.
+      noEscape (boolean) – If true, the returned string is not escaped.
 
     Returns:
-        string - The converted data type as a string.
+        string – The converted data type as a string.
 
     Realm:
         Shared
@@ -116,9 +116,9 @@
       The callback is invoked after the insert query is complete.
 
    Parameters:
-      value (table) - Key-value pairs representing the columns and values to insert.
-      callback (function) - The function to call when the insert operation is complete.
-      dbTable (string) - The name of the table (without the 'lia_' prefix).
+      value (table) – Key-value pairs representing the columns and values to insert.
+      callback (function) – The function to call when the insert operation is complete.
+      dbTable (string) – The name of the table (without the 'lia_' prefix).
 
     Returns:
         nil
@@ -140,10 +140,10 @@
       provided condition. The callback is invoked once the update query finishes.
 
    Parameters:
-      value (table) - Key-value pairs representing columns to update and their new values.
-      callback (function) - The function to call after the update query is complete.
-      dbTable (string) - The name of the table (without the 'lia_' prefix).
-      condition (string) - The SQL condition to determine which rows to update.
+      value (table) – Key-value pairs representing columns to update and their new values.
+      callback (function) – The function to call after the update query is complete.
+      dbTable (string) – The name of the table (without the 'lia_' prefix).
+      condition (string) – The SQL condition to determine which rows to update.
 
     Returns:
         nil
@@ -166,13 +166,13 @@
       object that resolves with the query results.
 
    Parameters:
-      fields (table|string) - The columns to select, either as a table or a comma-separated string.
-      dbTable (string) - The name of the table (without the 'lia_' prefix).
-      condition (string) - The SQL condition to filter results.
-      limit (number) - Maximum number of rows to return.
+      fields (table|string) – The columns to select, either as a table or a comma-separated string.
+      dbTable (string) – The name of the table (without the 'lia_' prefix).
+      condition (string) – The SQL condition to filter results.
+      limit (number) – Maximum number of rows to return.
 
     Returns:
-        deferred - Resolves with query results and last insert ID.
+        deferred – Resolves with query results and last insert ID.
 
     Realm:
         Shared
@@ -192,11 +192,11 @@
       Returns a deferred object that resolves when the operation completes.
 
    Parameters:
-      value (table) - Key-value pairs representing the columns and values.
-      dbTable (string) - The name of the table (without the 'lia_' prefix).
+      value (table) – Key-value pairs representing the columns and values.
+      dbTable (string) – The name of the table (without the 'lia_' prefix).
 
     Returns:
-        deferred - Resolves to a table of results and last insert ID.
+        deferred – Resolves to a table of results and last insert ID.
 
     Realm:
         Shared
@@ -213,11 +213,11 @@
       If no condition is specified, all rows are deleted. Returns a deferred object.
 
    Parameters:
-      dbTable (string) - The name of the table (without the 'lia_' prefix).
-      condition (string) - The SQL condition that determines which rows to delete.
+      dbTable (string) – The name of the table (without the 'lia_' prefix).
+      condition (string) – The SQL condition that determines which rows to delete.
 
     Returns:
-        deferred - Resolves to the results of the deletion.
+        deferred – Resolves to the results of the deletion.
 
     Realm:
         Shared

--- a/docs/lua/libraries/factions.lua
+++ b/docs/lua/libraries/factions.lua
@@ -7,7 +7,7 @@
       Each faction file should define a FACTION table with properties such as name, desc, color, etc.
 
    Parameters:
-      directory (string) - The path to the directory containing faction files.
+      directory (string) – The path to the directory containing faction files.
 
    Returns:
       nil
@@ -26,10 +26,10 @@
       Retrieves a faction by its index or unique identifier.
 
    Parameters:
-      identifier (number or string) - The faction's index or unique identifier.
+      identifier (number or string) – The faction's index or unique identifier.
 
    Returns:
-      table|nil - The faction table if found; nil otherwise.
+      table|nil – The faction table if found; nil otherwise.
 
    Realm:
       Shared
@@ -45,10 +45,10 @@
       Retrieves the index of a faction by its unique identifier.
 
    Parameters:
-      uniqueID (string) - The unique identifier of the faction.
+      uniqueID (string) – The unique identifier of the faction.
 
    Returns:
-      number|nil - The faction index if found; nil otherwise.
+      number|nil – The faction index if found; nil otherwise.
 
    Realm:
       Shared
@@ -64,10 +64,10 @@
       Retrieves a list of classes associated with the specified faction.
 
    Parameters:
-      faction (string) - The faction unique identifier.
+      faction (string) – The faction unique identifier.
 
    Returns:
-      table - A table containing class tables that belong to the faction.
+      table – A table containing class tables that belong to the faction.
 
    Realm:
       Shared
@@ -83,10 +83,10 @@
       Retrieves all player entities whose characters belong to the specified faction.
 
    Parameters:
-      faction (string) - The faction unique identifier.
+      faction (string) – The faction unique identifier.
 
    Returns:
-      table - A table of player entities in the faction.
+      table – A table of player entities in the faction.
 
    Realm:
       Shared
@@ -102,10 +102,10 @@
       Counts the number of players whose characters belong to the specified faction.
 
    Parameters:
-      faction (string) - The faction unique identifier.
+      faction (string) – The faction unique identifier.
 
    Returns:
-      number - The number of players in the faction.
+      number – The number of players in the faction.
 
    Realm:
       Shared
@@ -120,11 +120,11 @@
    Description:
       Checks if the specified faction is a member of a given category.
    Parameters:
-      faction (string) - The faction unique identifier.
-      categoryFactions (table) - A table containing faction identifiers that define the category.
+      faction (string) – The faction unique identifier.
+      categoryFactions (table) – A table containing faction identifiers that define the category.
 
    Returns:
-      boolean - True if the faction is in the category; false otherwise.
+      boolean – True if the faction is in the category; false otherwise.
 
    Realm:
       Shared
@@ -142,14 +142,14 @@
       Pre-caches the faction models.
 
    Parameters:
-      index (number) - The team index for the faction.
-      name (string) - The faction name.
-      color (Color) - The faction color.
-      default (boolean) - Whether the faction is default.
-      models (table) - A table of model paths or model data for the faction.
+      index (number) – The team index for the faction.
+      name (string) – The faction name.
+      color (Color) – The faction color.
+      default (boolean) – Whether the faction is default.
+      models (table) – A table of model paths or model data for the faction.
 
    Returns:
-      table - The newly generated faction table.
+      table – The newly generated faction table.
 
    Realm:
       Shared
@@ -186,10 +186,10 @@
       Categories are determined by keys in the faction's models table that are strings.
 
    Parameters:
-      teamName (string) - The unique identifier of the faction.
+      teamName (string) – The unique identifier of the faction.
 
    Returns:
-      table - A list of category names.
+      table – A list of category names.
 
    Realm:
       Shared
@@ -205,11 +205,11 @@
       Retrieves models from a specified category for a given faction.
 
    Parameters:
-      teamName (string) - The unique identifier of the faction.
-      category (string) - The model category to retrieve.
+      teamName (string) – The unique identifier of the faction.
+      category (string) – The model category to retrieve.
 
    Returns:
-      table - A table of models in the specified category.
+      table – A table of models in the specified category.
 
    Realm:
       Shared
@@ -226,10 +226,10 @@
       Searches through the class list for the first class that is marked as default for the faction.
 
    Parameters:
-      id (string) - The unique identifier of the faction.
+      id (string) – The unique identifier of the faction.
 
    Returns:
-      table|nil - The default class table if found; nil otherwise.
+      table|nil – The default class table if found; nil otherwise.
 
    Realm:
       Shared
@@ -246,10 +246,10 @@
          Checks the local whitelist data against the faction's uniqueID.
 
       Parameters:
-         faction (string) - The unique identifier of the faction.
+         faction (string) – The unique identifier of the faction.
 
       Returns:
-         boolean - True if the player is whitelisted; false otherwise.
+         boolean – True if the player is whitelisted; false otherwise.
 
       Realm:
          Client

--- a/docs/lua/libraries/flags.lua
+++ b/docs/lua/libraries/flags.lua
@@ -6,9 +6,9 @@
       Each flag has a description and an optional callback that is executed when the flag is applied to a player.
 
    Parameters:
-      flag (string) - The unique flag identifier.
-      desc (string) - A description of what the flag does.
-      callback (function) - An optional callback function executed when the flag is applied to a player.
+      flag (string) – The unique flag identifier.
+      desc (string) – A description of what the flag does.
+      callback (function) – An optional callback function executed when the flag is applied to a player.
 
    Returns:
       nil
@@ -28,7 +28,7 @@
          the associated callbacks for each flag that the character possesses.
 
       Parameters:
-         client (Player) - The player who spawned.
+         client (Player) – The player who spawned.
 
       Returns:
          nil

--- a/docs/lua/libraries/item.lua
+++ b/docs/lua/libraries/item.lua
@@ -5,7 +5,7 @@
       Retrieves an item definition by its identifier, checking both lia.item.base and lia.item.list.
 
    Parameters:
-      identifier (string) - The unique identifier of the item.
+      identifier (string) – The unique identifier of the item.
 
    Returns:
       The item table if found, otherwise nil.
@@ -25,7 +25,7 @@
       or in the world.
 
    Parameters:
-      itemID (number) - The numeric item ID.
+      itemID (number) – The numeric item ID.
 
    Returns:
       A table containing 'item' (the item object) and 'location' (the string location) if found,
@@ -48,7 +48,7 @@
       Retrieves the item instance table itself by its numeric ID without additional location info.
 
    Parameters:
-      itemID (number) - The numeric item ID.
+      itemID (number) – The numeric item ID.
 
    Returns:
       The item instance table if found, otherwise nil and an error message.
@@ -70,7 +70,7 @@
       Retrieves the 'data' table of an item instance by its numeric item ID.
 
    Parameters:
-      itemID (number) - The numeric item ID.
+      itemID (number) – The numeric item ID.
 
    Returns:
       The data table if found, otherwise nil and an error message.
@@ -93,9 +93,9 @@
       to register the item. Used for loading items from directory structures.
 
    Parameters:
-      path (string) - The path to the Lua file for the item.
-      baseID (string) - The base item's uniqueID to inherit from.
-      isBaseItem (boolean) - Whether this item is a base item.
+      path (string) – The path to the Lua file for the item.
+      baseID (string) – The base item's uniqueID to inherit from.
+      isBaseItem (boolean) – Whether this item is a base item.
 
    Returns:
       None
@@ -114,7 +114,7 @@
       Checks if the given object is recognized as an item (via isItem flag).
 
    Parameters:
-      object (any) - The object to check.
+      object (any) – The object to check.
 
    Returns:
       true if the object is an item, false otherwise.
@@ -136,7 +136,7 @@
       Retrieves an inventory table by its ID from lia.item.inventories.
 
    Parameters:
-      id (number) - The ID of the inventory to retrieve.
+      id (number) – The ID of the inventory to retrieve.
 
    Returns:
       The inventory table if found, otherwise nil.
@@ -159,11 +159,11 @@
       and merges data from the specified base. Optionally includes the file if provided.
 
    Parameters:
-      uniqueID (string) - The unique identifier for the item.
-      baseID (string) - The unique identifier of the base item.
-      isBaseItem (boolean) - Whether this should be registered as a base item.
-      path (string) - The optional path to the item file for inclusion.
-      luaGenerated (boolean) - True if the item is generated in code without file.
+      uniqueID (string) – The unique identifier for the item.
+      baseID (string) – The unique identifier of the base item.
+      isBaseItem (boolean) – Whether this should be registered as a base item.
+      path (string) – The optional path to the item file for inclusion.
+      luaGenerated (boolean) – True if the item is generated in code without file.
 
    Returns:
       The registered item table.
@@ -183,7 +183,7 @@
       then any folders (with base_ prefix usage), and finally any loose Lua files.
 
    Parameters:
-      directory (string) - The path to the directory containing item files.
+      directory (string) – The path to the directory containing item files.
 
    Returns:
       None
@@ -203,8 +203,8 @@
       The new item is stored in lia.item.instances using the provided item ID.
 
    Parameters:
-      uniqueID (string) - The unique identifier of the item definition.
-      id (number) - The numeric ID for this new item instance.
+      uniqueID (string) – The unique identifier of the item definition.
+      id (number) – The numeric ID for this new item instance.
 
    Returns:
       The newly created item instance.
@@ -225,9 +225,9 @@
       becomes accessible for creation or usage in the system.
 
    Parameters:
-      invType (string) - The inventory type name (identifier).
-      w (number) - The width of this inventory type.
-      h (number) - The height of this inventory type.
+      invType (string) – The inventory type name (identifier).
+      w (number) – The width of this inventory type.
+      h (number) – The height of this inventory type.
 
    Returns:
       None
@@ -247,9 +247,9 @@
       with the given character owner. Once created, it syncs the inventory to the owner if online.
 
    Parameters:
-      owner (number) - The character ID who owns this inventory.
-      invType (string) - The inventory type (must be registered first).
-      callback (function) - Optional callback function receiving the new inventory.
+      owner (number) – The character ID who owns this inventory.
+      invType (string) – The inventory type (must be registered first).
+      callback (function) – Optional callback function receiving the new inventory.
 
    Returns:
       None (asynchronous, uses a deferred internally).
@@ -271,9 +271,9 @@
       then caches it in lia.inventory.instances.
 
    Parameters:
-      w (number) - The width of the inventory.
-      h (number) - The height of the inventory.
-      id (number) - The numeric ID to assign to this inventory.
+      w (number) – The width of the inventory.
+      h (number) – The height of the inventory.
+      id (number) – The numeric ID to assign to this inventory.
 
    Returns:
       The newly created GridInv instance.
@@ -294,12 +294,12 @@
           Optionally notifies receivers about the change.
 
        Parameters:
-          itemID (number) - The numeric item ID.
-          key (string) - The data key to set.
-          value (any) - The value to set for the specified key.
-          receivers (table) - Optional table of players to receive the update.
-          noSave (boolean) - If true, won't save the data to the database immediately.
-          noCheckEntity (boolean) - If true, won't check if the item entity is valid.
+          itemID (number) – The numeric item ID.
+          key (string) – The data key to set.
+          value (any) – The value to set for the specified key.
+          receivers (table) – Optional table of players to receive the update.
+          noSave (boolean) – If true, won't save the data to the database immediately.
+          noCheckEntity (boolean) – If true, won't check if the item entity is valid.
 
        Returns:
           true if successful, false and error message if item not found.
@@ -322,12 +322,12 @@
           Once the item is created, a new item object is constructed and returned via a deferred.
 
        Parameters:
-          index (number) - The inventory ID to place the item into (or 0/NULL if none).
-          uniqueID (string) - The item definition's unique ID.
-          itemData (table) - The data table to store on the item.
-          x (number) - Optional grid X position (for grid inventories).
-          y (number) - Optional grid Y position.
-          callback (function) - Optional callback with the newly created item.
+          index (number) – The inventory ID to place the item into (or 0/NULL if none).
+          uniqueID (string) – The item definition's unique ID.
+          itemData (table) – The data table to store on the item.
+          x (number) – Optional grid X position (for grid inventories).
+          y (number) – Optional grid Y position.
+          callback (function) – Optional callback with the newly created item.
 
        Returns:
           A deferred object that resolves to the new item.
@@ -348,7 +348,7 @@
           Deletes an item from the system (database and memory) by its numeric ID.
 
        Parameters:
-          id (number) - The numeric item ID to delete.
+          id (number) – The numeric item ID to delete.
 
        Returns:
           None
@@ -368,7 +368,7 @@
           item instances in memory. This is commonly used during inventory or character loading.
 
        Parameters:
-          itemIndex (number or table) - Either a single numeric item ID or a table of numeric item IDs.
+          itemIndex (number or table) – Either a single numeric item ID or a table of numeric item IDs.
 
        Returns:
           None (asynchronous query).
@@ -390,11 +390,11 @@
           entity in the world at the specified position/angles.
 
        Parameters:
-          uniqueID (string) - The unique ID of the item definition.
-          position (Vector) - The spawn position in the world.
-          callback (function) - Optional callback when the item and entity are created.
-          angles (Angle) - Optional spawn angles.
-          data (table) - Additional data to set on the item.
+          uniqueID (string) – The unique ID of the item definition.
+          position (Vector) – The spawn position in the world.
+          callback (function) – Optional callback when the item and entity are created.
+          angles (Angle) – Optional spawn angles.
+          data (table) – Additional data to set on the item.
 
        Returns:
           A deferred object if callback is not given, otherwise none.
@@ -416,10 +416,10 @@
           then sets its width/height data, optionally providing a callback once loaded.
 
        Parameters:
-          invID (number) - The inventory ID to restore.
-          w (number) - Width to set for the inventory.
-          h (number) - Height to set for the inventory.
-          callback (function) - Optional function to call once the inventory is restored.
+          invID (number) – The inventory ID to restore.
+          w (number) – Width to set for the inventory.
+          h (number) – Height to set for the inventory.
+          callback (function) – Optional function to call once the inventory is restored.
 
        Returns:
           None (asynchronous call).

--- a/docs/lua/libraries/keybind.lua
+++ b/docs/lua/libraries/keybind.lua
@@ -8,10 +8,10 @@
       Also maps the key code back to the action identifier for reverse lookup.
 
    Parameters:
-      k (string or number) - The key identifier, either as a string (to be converted) or as a key code.
-      d (string) - The unique identifier for the keybind action.
-      cb (function) - The callback function to be executed when the key is pressed.
-      rcb (function) - The callback function to be executed when the key is released.
+      k (string or number) – The key identifier, either as a string (to be converted) or as a key code.
+      d (string) – The unique identifier for the keybind action.
+      cb (function) – The callback function to be executed when the key is pressed.
+      rcb (function) – The callback function to be executed when the key is released.
 
     Returns:
         nil
@@ -32,11 +32,11 @@
       or an optionally provided fallback value.
 
    Parameters:
-      a (string) - The unique identifier for the keybind action.
-      df (number) - An optional default key code to return if the keybind is not set.
+      a (string) – The unique identifier for the keybind action.
+      df (number) – An optional default key code to return if the keybind is not set.
 
     Returns:
-        number - The key code associated with the keybind action, or the default/fallback value if not set.
+        number – The key code associated with the keybind action, or the default/fallback value if not set.
 
    Realm:
       Client

--- a/docs/lua/libraries/languages.lua
+++ b/docs/lua/libraries/languages.lua
@@ -8,7 +8,7 @@
       it is registered in lia.lang.names.
 
    Parameters:
-      directory (string) - The path to the directory containing language files.
+      directory (string) – The path to the directory containing language files.
 
     Returns:
         nil
@@ -32,8 +32,8 @@
       will be merged with the existing ones.
 
    Parameters:
-      name (string) - The name of the language to update.
-      tbl (table) - A table containing language key-value pairs to add.
+      name (string) – The name of the language to update.
+      tbl (table) – A table containing language key-value pairs to add.
 
     Returns:
         nil

--- a/docs/lua/libraries/logger.lua
+++ b/docs/lua/libraries/logger.lua
@@ -28,9 +28,9 @@
          The registered function will be used later to generate log messages for that type.
 
       Parameters:
-         logType (string) - The unique identifier for the log type.
-         func (function) - A function that takes a client and additional parameters, returning a log string.
-         category (string) - The category for the log type, used for organizing log files.
+         logType (string) – The unique identifier for the log type.
+         func (function) – A function that takes a client and additional parameters, returning a log string.
+         category (string) – The category for the log type, used for organizing log files.
 
       Returns:
           nil
@@ -52,12 +52,12 @@
          It calls the registered log function with the provided parameters.
 
       Parameters:
-         client (Player) - The client for which the log is generated.
-         logType (string) - The identifier for the log type.
-         ... (vararg) - Additional parameters passed to the log function.
+         client (Player) – The client for which the log is generated.
+         logType (string) – The identifier for the log type.
+         ... (vararg) – Additional parameters passed to the log function.
 
       Returns:
-          string, string - The generated log string and its category if successful; otherwise, nil.
+          string, string – The generated log string and its category if successful; otherwise, nil.
 
       Realm:
          Server
@@ -77,9 +77,9 @@
          and appends the log string to a log file corresponding to its category in the logs directory.
 
       Parameters:
-         client (Player) - The client associated with the log event.
-         logType (string) - The identifier for the log type.
-         ... (vararg) - Additional parameters passed to the log type function.
+         client (Player) – The client associated with the log event.
+         logType (string) – The identifier for the log type.
+         ... (vararg) – Additional parameters passed to the log type function.
 
       Returns:
           nil

--- a/docs/lua/libraries/modularity.lua
+++ b/docs/lua/libraries/modularity.lua
@@ -7,10 +7,10 @@
       It also registers the module in the module list if applicable.
 
    Parameters:
-      uniqueID - The unique identifier of the module.
-      path - The file system path where the module is located.
-      isSingleFile - Boolean indicating if the module is a single file.
-      variable - A global variable name used to temporarily store the module.
+      uniqueID – The unique identifier of the module.
+      path – The file system path where the module is located.
+      isSingleFile – Boolean indicating if the module is a single file.
+      variable – A global variable name used to temporarily store the module.
 
    Realm:
       Server
@@ -51,8 +51,8 @@
       Non-Lua files are ignored.
 
    Parameters:
-      directory - The directory path from which to load modules.
-      group - A string representing the module group (e.g., "schema" or "module").
+      directory – The directory path from which to load modules.
+      group – A string representing the module group (e.g., "schema" or "module").
 
    Realm:
       Server
@@ -71,7 +71,7 @@
       Retrieves a module table by its identifier.
 
    Parameters:
-      identifier - The unique identifier of the module to retrieve.
+      identifier – The unique identifier of the module to retrieve.
 
    Realm:
       Server

--- a/docs/lua/libraries/webimage.lua
+++ b/docs/lua/libraries/webimage.lua
@@ -23,7 +23,7 @@
         lia.webimage.register("logo.png", "https://example.com/logo.png")
 ]]
 --[[
-    lia.webimage.get(name, flags)
+lia.webimage.get(name, flags)
 
     Description:
         Retrieves a Material for a previously registered image if it exists in
@@ -42,4 +42,21 @@
     Example Usage:
         -- This snippet demonstrates a common usage of lia.webimage.get
         local mat = lia.webimage.get("logo.png")
+]]
+
+--[[
+    HTTPS URL Handling
+
+    Description:
+        The library extends Garry's Mod's `Material()` and `DImage:SetImage()`
+        functions so they accept direct HTTP or HTTPS image URLs. The image is
+        automatically downloaded via `lia.webimage.register` and cached before
+        the material is returned or applied.
+
+    Example Usage:
+        -- Load a material directly from the web
+        local mat = Material("https://example.com/icon.png")
+
+        -- Apply a remote image to a button
+        button:SetImage("https://example.com/icon.png")
 ]]


### PR DESCRIPTION
## Summary
- convert gamemode hook docs from Lua to Markdown
- clean up class and faction hook docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f7e2ac1d483278662084578d58bcd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated extensive documentation for multiple framework libraries, including detailed API references for character, item, inventory, faction, class, command, configuration, currency, data, database, logging, networking, notification, option, time, utility, web image, and workshop management.
  * Introduced new documentation for meta objects (character, entity, inventory, item, panel, player, tool, vector) with method descriptions and usage examples.
  * Improved formatting in existing documentation by replacing hyphens with en dashes in parameter and return value descriptions for greater typographic consistency.
  * Enhanced documentation for web image handling, including support for direct HTTP/HTTPS URLs in image functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->