### PR TITLE
Unify definition docs

### DIFF
--- a/docs/docs/definitions/attribute.md
+++ b/docs/docs/definitions/attribute.md
@@ -18,9 +18,9 @@ Each attribute is registered on the global `ATTRIBUTE` table. You can customize:
 
 | Field          | Type      | Default | Description                                                                                    |
 | -------------- | --------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `name`         | `string`  | —       | Human-readable title of the attribute.                                                         |
-| `desc`         | `string`  | —       | Brief description or lore text.                                                                |
-| `startingMax`  | `number`  | `0`     | Maximum base value at character creation, before any startup bonus points are applied.         |
+| `name`         | `string`  | `"Unknown"` | Human-readable title of the attribute. |
+| `desc`         | `string`  | `"No Description"`  | Brief description or lore text. |
+| `startingMax`  | `number`  | `30`    | Maximum base value at character creation, before any startup bonus points are applied. |
 | `noStartBonus` | `boolean` | `false` | If `true`, players cannot allocate any of the creation startup bonus points to this attribute. |
 | `maxValue`     | `number`  | `30`    | Absolute upper limit an attribute can ever reach.                                              |
 

--- a/docs/docs/definitions/class.md
+++ b/docs/docs/definitions/class.md
@@ -12,32 +12,32 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 
 ## Field Summary
 
-| Field                 | Type           | Description                                                    |
-|-----------------------|----------------|----------------------------------------------------------------|
-| `name`                | `string`       | Displayed name of the class.                                   |
-| `desc`                | `string`       | Description or lore of the class.                              |
-| `isDefault`           | `boolean`      | Whether the class is available by default.                     |
-| `isWhitelisted`       | `boolean`      | Whether the class requires whitelist to join.                  |
-| `faction`             | `number`       | Linked faction index (e.g., `FACTION_CITIZEN`).                |
-| `color`               | `Color`        | UI color associated with the class.                            |
-| `weapons`             | `string[]`     | Weapons granted to members of this class.                      |
-| `pay`                 | `number`       | Payment amount per interval.                                   |
-| `payLimit`            | `number`       | Maximum accumulated pay.                                       |
-| `payTimer`            | `number`       | Interval (seconds) between paychecks.                          |
-| `limit`               | `number`       | Maximum number of players in this class.                       |
-| `health`              | `number`       | Default starting health.                                       |
-| `armor`               | `number`       | Default starting armor.                                        |
-| `scale`               | `number`       | Player model scale multiplier.                                |
-| `runSpeed`            | `number`       | Default running speed.                                         |
-| `runSpeedMultiplier`  | `boolean`      | Multiply base speed instead of replacing it.                   |
-| `walkSpeed`           | `number`       | Default walking speed.                                         |
-| `walkSpeedMultiplier` | `boolean`      | Multiply base walk speed instead of replacing it.              |
-| `jumpPower`           | `number`       | Default jump power.                                            |
-| `jumpPowerMultiplier` | `boolean`      | Multiply base jump power instead of replacing it.              |
-| `bloodcolor`          | `number`       | Blood color enumeration constant.                              |
-| `bodyGroups`          | `table`        | Bodygroup index mapping applied on spawn.                      |
-| `model`               | `string`       | Model path (or table of paths) used by this class.             |
-| `index`               | `number`       | Unique team index assigned at registration.                    |
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | `"Unknown"` | Displayed name of the class. |
+| `desc` | `string` | `"No Description"` | Description or lore of the class. |
+| `isDefault` | `boolean` | `false` | Whether the class is available by default. |
+| `isWhitelisted` | `boolean` | `false` | Whether the class requires whitelist to join. |
+| `faction` | `number` | `0` | Linked faction index (e.g., `FACTION_CITIZEN`). |
+| `color` | `Color` | `Color(255,255,255)` | UI color associated with the class. |
+| `weapons` | `table` | `{}` | Weapons granted to members of this class. |
+| `pay` | `number` | `0` | Payment amount per interval. |
+| `payLimit` | `number` | `0` | Maximum accumulated pay. |
+| `payTimer` | `number` | `300` | Interval (seconds) between paychecks. |
+| `limit` | `number` | `0` | Maximum number of players in this class. |
+| `health` | `number` | `0` | Default starting health. |
+| `armor` | `number` | `0` | Default starting armor. |
+| `scale` | `number` | `1` | Player model scale multiplier. |
+| `runSpeed` | `number` | `0` | Default running speed. |
+| `runSpeedMultiplier` | `boolean` | `false` | Multiply base speed instead of replacing it. |
+| `walkSpeed` | `number` | `0` | Default walking speed. |
+| `walkSpeedMultiplier` | `boolean` | `false` | Multiply base walk speed instead of replacing it. |
+| `jumpPower` | `number` | `0` | Default jump power. |
+| `jumpPowerMultiplier` | `boolean` | `false` | Multiply base jump power instead of replacing it. |
+| `bloodcolor` | `number` | `0` | Blood color enumeration constant. |
+| `bodyGroups` | `table` | `{}` | Bodygroup index mapping applied on spawn. |
+| `model` | `string` | `""` | Model path (or table of paths) used by this class. |
+| `index` | `number` | `auto` | Unique team index assigned at registration. |
 
 ---
 
@@ -110,7 +110,7 @@ CLASS.faction = FACTION_CITIZEN
 #### `color`
 
 **Type:** `Color`
-**Description:** UI color representing the class.
+**Description:** UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
 **Example:**
 
 ```lua
@@ -123,7 +123,7 @@ CLASS.color = Color(255, 0, 0)
 
 #### `weapons`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Weapons granted to members of this class on spawn.
 **Example:**
 
@@ -291,10 +291,11 @@ CLASS.bodyGroups = { [1] = 2, [3] = 1 }
 
 #### `model`
 
-**Type:** `string` or `string[]`
+**Type:** `string` or `table`
 **Description:** Model path (or list of paths) assigned to this class.
 **Example:**
 
 ```lua
 CLASS.model = "models/player/alyx.mdl"
 ```
+---

--- a/docs/docs/definitions/command.md
+++ b/docs/docs/definitions/command.md
@@ -13,16 +13,16 @@ When you register a command with `lia.command.add`, you provide a table of field
 
 ## Field Summary
 
-| Field               | Type                       | Description                                                      |
-|---------------------|----------------------------|------------------------------------------------------------------|
-| `alias`             | `string` or `string[]`     | Alternative names for the command.                               |
-| `adminOnly`         | `boolean`                  | Restrict to admins (registers a CAMI privilege).                 |
-| `superAdminOnly`    | `boolean`                  | Restrict to superadmins (registers a CAMI privilege).            |
-| `privilege`         | `string`                   | Custom CAMI privilege name (defaults to command name).           |
-| `syntax`            | `string`                   | Human-readable argument format shown in help.                    |
-| `desc`              | `string`                   | Short description shown in command lists and menus.              |
-| `AdminStick`        | `table`                    | Defines how the command appears in admin utilities.              |
-| `onRun(client, args)` | `function(client, table)` | Function executed when the command is invoked.                   |
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `alias` | `string` or `table` | `nil` | Alternative names for the command. |
+| `adminOnly` | `boolean` | `false` | Restrict to admins (registers a CAMI privilege). |
+| `superAdminOnly` | `boolean` | `false` | Restrict to superadmins (registers a CAMI privilege). |
+| `privilege` | `string` | `nil` | Custom CAMI privilege name (defaults to command name). |
+| `syntax` | `string` | `""` | Human-readable argument format shown in help. |
+| `desc` | `string` | `""` | Short description shown in command lists and menus. |
+| `AdminStick` | `table` | `nil` | Defines how the command appears in admin utilities. |
+| `onRun(client, args)` | `function(client, table)` | `nil` | Function executed when the command is invoked. |
 
 ---
 
@@ -31,7 +31,7 @@ When you register a command with `lia.command.add`, you provide a table of field
 ### Aliases & Permissions
 
 #### `alias`
-**Type:** `string` or `string[]`  
+**Type:** `string` or `table`  
 **Description:** One or more alternative command names that trigger the same behavior.  
 **Example:**
 ```lua
@@ -99,7 +99,7 @@ syntax = "[string Target Name] [number Amount]"
 **Example:**
 
 ```lua
-desc = L("doorbuyDesc")
+desc = "Purchase a door if it is available and you can afford it."
 ```
 
 ---
@@ -146,3 +146,4 @@ onRun = function(client, arguments)
     end
 end
 ```
+---

--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -13,37 +13,37 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 
 ## Field Summary
 
-| Field                       | Type         | Description                                            |
-|-----------------------------|--------------|--------------------------------------------------------|
-| `name`                      | `string`     | Display name shown to players.                         |
-| `desc`                      | `string`     | Lore or descriptive text.                              |
-| `isDefault`                 | `boolean`    | Whether the faction is available without whitelist.    |
-| `color`                     | `Color`      | UI color representing the faction.                     |
-| `models`                    | `string[]`   | Available player model paths.                          |
-| `uniqueID`                  | `string`     | Internal string identifier.                            |
-| `weapons`                   | `string[]`   | Automatically granted weapons.                         |
-| `items`                     | `string[]`   | Automatically granted items.                           |
-| `index`                     | `number`     | Numeric ID assigned at registration time.              |
-| `pay`                       | `number`     | Payment amount per interval.                           |
-| `payLimit`                  | `number`     | Maximum accumulated pay.                               |
-| `payTimer`                  | `number`     | Interval (in seconds) between paychecks.               |
-| `limit`                     | `number`     | Maximum number of players in the faction.              |
-| `oneCharOnly`               | `boolean`    | Restrict players to one character only.                |
-| `health`                    | `number`     | Starting health.                                       |
-| `armor`                     | `number`     | Starting armor.                                        |
-| `scale`                     | `number`     | Player model scale multiplier.                        |
-| `runSpeed`                  | `number`     | Base running speed.                                    |
-| `runSpeedMultiplier`        | `boolean`    | Multiply base speed instead of replacing it.           |
-| `walkSpeed`                 | `number`     | Base walking speed.                                    |
-| `walkSpeedMultiplier`       | `boolean`    | Multiply base walk speed instead of replacing it.      |
-| `jumpPower`                 | `number`     | Base jump power.                                       |
-| `jumpPowerMultiplier`       | `boolean`    | Multiply base jump power instead of replacing it.      |
-| `MemberToMemberAutoRecognition` | `boolean` | Auto-recognition among faction members.                |
-| `bloodcolor`                | `number`     | Blood color enum.                                      |
-| `bodyGroups`                | `table`      | Bodygroup name→index mapping applied on spawn.         |
-| `NPCRelations`              | `table`      | NPC class→disposition mapping on spawn/creation.       |
-| `RecognizesGlobally`        | `boolean`    | Global player recognition.                             |
-| `ScoreboardHidden`          | `boolean`    | Hide members from the scoreboard.                      |
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | `"Unknown"` | Display name shown to players. |
+| `desc` | `string` | `"No Description"` | Lore or descriptive text. |
+| `isDefault` | `boolean` | `true` | Whether the faction is available without whitelist. |
+| `color` | `Color` | `Color(255,255,255)` | UI color representing the faction. |
+| `models` | `table` | `DefaultModels` | Available player model paths. |
+| `uniqueID` | `string` | `filename` | Internal string identifier. |
+| `weapons` | `table` | `{}` | Automatically granted weapons. |
+| `items` | `table` | `{}` | Automatically granted items. |
+| `index` | `number` | `auto` | Numeric ID assigned at registration time. |
+| `pay` | `number` | `0` | Payment amount per interval. |
+| `payLimit` | `number` | `0` | Maximum accumulated pay. |
+| `payTimer` | `number` | `300` | Interval (in seconds) between paychecks. |
+| `limit` | `number` | `0` | Maximum number of players in the faction. |
+| `oneCharOnly` | `boolean` | `false` | Restrict players to one character only. |
+| `health` | `number` | `0` | Starting health. |
+| `armor` | `number` | `0` | Starting armor. |
+| `scale` | `number` | `1` | Player model scale multiplier. |
+| `runSpeed` | `number` | `0` | Base running speed. |
+| `runSpeedMultiplier` | `boolean` | `false` | Multiply base speed instead of replacing it. |
+| `walkSpeed` | `number` | `0` | Base walking speed. |
+| `walkSpeedMultiplier` | `boolean` | `false` | Multiply base walk speed instead of replacing it. |
+| `jumpPower` | `number` | `0` | Base jump power. |
+| `jumpPowerMultiplier` | `boolean` | `false` | Multiply base jump power instead of replacing it. |
+| `MemberToMemberAutoRecognition` | `boolean` | `false` | Auto-recognition among faction members. |
+| `bloodcolor` | `number` | `0` | Blood color enum. |
+| `bodyGroups` | `table` | `{}` | Bodygroup name→index mapping applied on spawn. |
+| `NPCRelations` | `table` | `{}` | NPC class→disposition mapping on spawn/creation. |
+| `RecognizesGlobally` | `boolean` | `false` | Global player recognition. |
+| `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 
 ---
 
@@ -106,7 +106,7 @@ FACTION_STAFF = FACTION.index
 #### `color`
 
 **Type:** `Color`
-**Description:** Color used in UI elements to represent the faction.
+**Description:** Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
 **Example:**
 
 ```lua
@@ -115,7 +115,7 @@ FACTION.color = Color(255, 56, 252)
 
 #### `models`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Table of player model paths available to faction members.
 **Example:**
 
@@ -145,7 +145,7 @@ FACTION.bodyGroups = {
 
 #### `weapons`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Weapons automatically granted on spawn.
 **Example:**
 
@@ -155,7 +155,7 @@ FACTION.weapons = {"weapon_physgun", "gmod_tool"}
 
 #### `items`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Item uniqueIDs automatically granted on character creation.
 **Example:**
 
@@ -363,3 +363,4 @@ FACTION.bloodcolor = BLOOD_COLOR_RED
 ```lua
 FACTION.ScoreboardHidden = false
 ```
+---

--- a/docs/docs/definitions/items.md
+++ b/docs/docs/definitions/items.md
@@ -13,57 +13,57 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 
 ## Field Summary
 
-| Field                   | Type               | Description                                            |
-|-------------------------|--------------------|--------------------------------------------------------|
-| `BagSound`              | `table`            | Sound played when moving items to/from the bag.       |
-| `DropOnDeath`           | `boolean`          | Deletes the item upon player death.                    |
-| `FactionWhitelist`      | `number[]`         | Allowed faction indices for vendor interaction.        |
-| `RequiredSkillLevels`   | `table`            | Skill requirements needed to use the item.             |
-| `SteamIDWhitelist`      | `string[]`         | Allowed Steam IDs for vendor interaction.              |
-| `UsergroupWhitelist`    | `string[]`         | Allowed user groups for vendor interaction.            |
-| `VIPWhitelist`          | `boolean`          | Restricts usage to VIP players.                        |
-| `ammo`                  | `string`           | Ammo type provided.                                    |
-| `ammoAmount`            | `number`           | Amount of ammo contained.                              |
-| `armor`                 | `number`           | Armor value granted when equipped.                     |
-| `attribBoosts`          | `table`            | Attribute boosts applied when equipped.                |
-| `base`                  | `string`           | Base item this item derives from.                      |
-| `canSplit`              | `boolean`          | Whether the item stack can be divided.                 |
-| `category`              | `string`           | Inventory grouping category.                           |
-| `class`                 | `string`           | Weapon entity class.                                   |
-| `contents`              | `string`           | HTML contents of a readable book.                      |
-| `desc`                  | `string`           | Short description shown to players.                    |
-| `entityid`              | `string`           | Entity class spawned by the item.                      |
-| `equipSound`            | `string`           | Sound played when equipping.                           |
-| `flag`                  | `string`           | Flag required to purchase the item.                    |
-| `functions`             | `table`            | Table of interaction functions.                        |
-| `grenadeClass`          | `string`           | Class name used when spawning a grenade.               |
-| `health`                | `number`           | Amount of health restored when used.                   |
-| `height`                | `number`           | Height in inventory grid.                              |
-| `id`                    | `any`              | Database identifier.                                   |
-| `invHeight`             | `number`           | Internal bag inventory height.                         |
-| `invWidth`              | `number`           | Internal bag inventory width.                          |
-| `isBag`                 | `boolean`          | Marks the item as a bag providing extra inventory.     |
-| `isBase`                | `boolean`          | Indicates the table is a base item.                    |
-| `isOutfit`              | `boolean`          | Marks the item as an outfit.                           |
-| `isStackable`           | `boolean`          | Allows stacking multiple quantities.                   |
-| `isWeapon`              | `boolean`          | Marks the item as a weapon.                            |
-| `maxQuantity`           | `number`           | Maximum stack size.                                    |
-| `model`                 | `string`           | 3D model path for the item.                            |
-| `name`                  | `string`           | Displayed name of the item.                            |
-| `newSkin`               | `number`           | Skin index applied to the player model.                |
-| `outfitCategory`        | `string`           | Slot or category for the outfit.                       |
-| `pacData`               | `table`            | PAC3 customization information.                        |
-| `postHooks`             | `table`            | Table of post-hook callbacks.                          |
-| `price`                 | `number`           | Item cost for trading or selling.                      |
-| `quantity`              | `number`           | Current amount in the item stack.                      |
-| `rarity`                | `string`           | Rarity level affecting vendor color.                   |
-| `replacements`          | `string`           | Model replacements when equipped.                      |
-| `unequipSound`          | `string`           | Sound played when unequipping.                         |
-| `uniqueID`              | `string`           | Overrides the automatically generated unique identifier.|
-| `url`                   | `string`           | Web address opened when using the item.                |
-| `visualData`            | `table`            | Table storing outfit visual information.               |
-| `weaponCategory`        | `string`           | Slot category for the weapon.                          |
-| `width`                 | `number`           | Width in inventory grid.                               |
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `BagSound` | `table` | `nil` | Sound played when moving items to/from the bag. |
+| `DropOnDeath` | `boolean` | `false` | Deletes the item upon player death. |
+| `FactionWhitelist` | `table` | `nil` | Allowed faction indices for vendor interaction. |
+| `RequiredSkillLevels` | `table` | `nil` | Skill requirements needed to use the item. |
+| `SteamIDWhitelist` | `table` | `nil` | Allowed Steam IDs for vendor interaction. |
+| `UsergroupWhitelist` | `table` | `nil` | Allowed user groups for vendor interaction. |
+| `VIPWhitelist` | `boolean` | `false` | Restricts usage to VIP players. |
+| `ammo` | `string` | `""` | Ammo type provided. |
+| `ammoAmount` | `number` | `0` | Amount of ammo contained. |
+| `armor` | `number` | `0` | Armor value granted when equipped. |
+| `attribBoosts` | `table` | `{}` | Attribute boosts applied when equipped. |
+| `base` | `string` | `""` | Base item this item derives from. |
+| `canSplit` | `boolean` | `true` | Whether the item stack can be divided. |
+| `category` | `string` | `"Miscellaneous"` | Inventory grouping category. |
+| `class` | `string` | `""` | Weapon entity class. |
+| `contents` | `string` | `""` | HTML contents of a readable book. |
+| `desc` | `string` | `"No Description"` | Short description shown to players. |
+| `entityid` | `string` | `""` | Entity class spawned by the item. |
+| `equipSound` | `string` | `""` | Sound played when equipping. |
+| `flag` | `string` | `""` | Flag required to purchase the item. |
+| `functions` | `table` | `DefaultFunctions` | Table of interaction functions. |
+| `grenadeClass` | `string` | `""` | Class name used when spawning a grenade. |
+| `health` | `number` | `0` | Amount of health restored when used. |
+| `height` | `number` | `1` | Height in inventory grid. |
+| `id` | `any` | `0` | Database identifier. |
+| `invHeight` | `number` | `0` | Internal bag inventory height. |
+| `invWidth` | `number` | `0` | Internal bag inventory width. |
+| `isBag` | `boolean` | `false` | Marks the item as a bag providing extra inventory. |
+| `isBase` | `boolean` | `false` | Indicates the table is a base item. |
+| `isOutfit` | `boolean` | `false` | Marks the item as an outfit. |
+| `isStackable` | `boolean` | `false` | Allows stacking multiple quantities. |
+| `isWeapon` | `boolean` | `false` | Marks the item as a weapon. |
+| `maxQuantity` | `number` | `1` | Maximum stack size. |
+| `model` | `string` | `""` | 3D model path for the item. |
+| `name` | `string` | `"INVALID NAME"` | Displayed name of the item. |
+| `newSkin` | `number` | `0` | Skin index applied to the player model. |
+| `outfitCategory` | `string` | `""` | Slot or category for the outfit. |
+| `pacData` | `table` | `{}` | PAC3 customization information. |
+| `postHooks` | `table` | `{}` | Table of post-hook callbacks. |
+| `price` | `number` | `0` | Item cost for trading or selling. |
+| `quantity` | `number` | `1` | Current amount in the item stack. |
+| `rarity` | `string` | `""` | Rarity level affecting vendor color. |
+| `replacements` | `string` | `""` | Model replacements when equipped. |
+| `unequipSound` | `string` | `""` | Sound played when unequipping. |
+| `uniqueID` | `string` | `"undefined"` | Overrides the automatically generated unique identifier. |
+| `url` | `string` | `""` | Web address opened when using the item. |
+| `visualData` | `table` | `{}` | Table storing outfit visual information. |
+| `weaponCategory` | `string` | `""` | Slot category for the weapon. |
+| `width` | `number` | `1` | Width in inventory grid. |
 
 ---
 
@@ -115,7 +115,7 @@ ITEM.DropOnDeath = true
 
 #### `FactionWhitelist`
 
-**Type:** `number[]`
+**Type:** `table`
 **Description:** Allowed faction indices for vendor interaction.
 **Example:**
 
@@ -135,7 +135,7 @@ ITEM.RequiredSkillLevels = {Strength = 5}
 
 #### `SteamIDWhitelist`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Allowed Steam IDs for vendor interaction.
 **Example:**
 
@@ -145,7 +145,7 @@ ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
 
 #### `UsergroupWhitelist`
 
-**Type:** `string[]`
+**Type:** `table`
 **Description:** Allowed user groups for vendor interaction.
 **Example:**
 
@@ -592,3 +592,4 @@ ITEM.functions = {}
 ```lua
 ITEM.postHooks = {}
 ```
+---

--- a/docs/docs/definitions/module.md
+++ b/docs/docs/definitions/module.md
@@ -13,25 +13,25 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 
 ## Field Summary
 
-| Field                | Type                    | Description                                                      |
-|----------------------|-------------------------|------------------------------------------------------------------|
-| `name`               | `string`                | Identifies the module in logs and UI.                            |
-| `author`             | `string`                | Name or SteamID64 of the module’s author.                        |
-| `discord`            | `string`                | Discord tag or support channel.                                  |
-| `version`            | `string`                | Version string for compatibility checks.                         |
-| `desc`               | `string`                | Short description of module functionality.                       |
-| `identifier`         | `string`                | Unique global key referencing the module.                        |
-| `CAMIPrivileges`     | `table`                 | CAMI privileges defined or required by the module.               |
-| `WorkshopContent`    | `table`                 | Steam Workshop add-on IDs required.                              |
-| `enabled`            | `boolean` or `function` | Controls whether the module loads.                               |
-| `Dependencies`       | `table`                 | Files or folders required for the module to run.                 |
-| `folder`             | `string`                | Filesystem path where the module resides.                        |
-| `path`               | `string`                | Absolute path to the module’s root directory.                    |
-| `uniqueID`           | `string`                | Internal identifier for the module list.                         |
-| `loading`            | `boolean`               | True while the module is in the process of loading.              |
-| `ModuleLoaded`       | `function`              | Callback run after module finishes loading.                      |
-| `Public`             | `boolean`               | Participates in public version checks.                           |
-| `Private`            | `boolean`               | Uses private version checking.                                   |
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | `"Unknown"` | Identifies the module in logs and UI. |
+| `author` | `string` | `"Anonymous"` | Name or SteamID64 of the module’s author. |
+| `discord` | `string` | `""` | Discord tag or support channel. |
+| `version` | `string` | `""` | Version string for compatibility checks. |
+| `desc` | `string` | `"No Description"` | Short description of module functionality. |
+| `identifier` | `string` | `""` | Unique global key referencing the module. |
+| `CAMIPrivileges` | `table` | `nil` | CAMI privileges defined or required by the module. |
+| `WorkshopContent` | `table` | `nil` | Steam Workshop add-on IDs required. |
+| `enabled` | `boolean` or `function` | `true` | Controls whether the module loads. |
+| `Dependencies` | `table` | `nil` | Files or folders required for the module to run. |
+| `folder` | `string` | `""` | Filesystem path where the module resides. |
+| `path` | `string` | `""` | Absolute path to the module’s root directory. |
+| `uniqueID` | `string` | `""` | Internal identifier for the module list. |
+| `loading` | `boolean` | `false` | True while the module is in the process of loading. |
+| `ModuleLoaded` | `function` | `nil` | Callback run after module finishes loading. |
+| `Public` | `boolean` | `false` | Participates in public version checks. |
+| `Private` | `boolean` | `false` | Uses private version checking. |
 
 ---
 
@@ -228,3 +228,4 @@ print(MODULE.path)
 ```lua
 print(MODULE.uniqueID)
 ```
+---

--- a/docs/docs/definitions/panels.md
+++ b/docs/docs/definitions/panels.md
@@ -530,3 +530,4 @@ factionButton.DoClick = function()
     vgui.Create("VendorFactionEditor"):MoveLeftOf(factionButton, 4)
 end
 ```
+---


### PR DESCRIPTION
## Summary
- fix defaults in attribute field summary
- standardize all definition tables to include `Default` column
- ensure each definition doc ends with a closing delimiter
- fix L-string examples
- remove default column from panel reference
- replace `string[]` with `table` and populate default values for each field
- set faction and class color defaults to `Color(255,255,255)`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6860ca96f61c83278794b4d4cce706a3