### PR TITLE
Expand meta docs headings

### DIFF
--- a/docs/docs/meta/character.md
+++ b/docs/docs/meta/character.md
@@ -1,12 +1,12 @@
 # Character Meta
 
-This document describes the methods available on character objects.
+Character objects returned by `player:getChar()` persist inventory, stats, and money. This reference outlines helper functions for managing those records.
 
 ---
 
 ## Overview
 
-These meta functions extend standard character objects with convenience helpers used throughout Lilia.
+The character meta library provides shortcuts for fetching stored values, verifying permissions, and linking a character back to its player. These routines centralize logic used by banking, crafting, and other gameplay systems.
 
 ---
 

--- a/docs/docs/meta/entity.md
+++ b/docs/docs/meta/entity.md
@@ -1,12 +1,12 @@
 # Entity Meta
 
-This document describes the methods available on entity objects.
+Entities in Garry's Mod may represent props, items, and interactive objects. This reference describes utility functions added to entity metatables for easier classification and management.
 
 ---
 
 ## Overview
 
-These meta functions extend standard entity objects with convenience helpers used throughout Lilia.
+The entity meta library exposes detection routines, network-safe data helpers, and wrappers for retrieving item information or safe positions. Using these functions ensures consistent behavior when handling game objects across Lilia.
 
 ---
 

--- a/docs/docs/meta/inventory.md
+++ b/docs/docs/meta/inventory.md
@@ -1,12 +1,12 @@
 # Inventory Meta
 
-This document describes the methods available on inventory objects.
+Inventories hold items for characters or in-world containers. This document lists methods for managing and syncing these item stores.
 
 ---
 
 ## Overview
 
-These meta functions extend standard inventory objects with convenience helpers used throughout Lilia.
+Inventory meta functions handle transactions, capacity checks, retrieval by slot or ID, and persistent data storage. They also manage network updates so clients remain in sync with server-side inventory changes.
 
 ---
 

--- a/docs/docs/meta/item.md
+++ b/docs/docs/meta/item.md
@@ -1,12 +1,12 @@
 # Item Meta
 
-This document describes the methods available on item objects.
+Item objects represent things found in inventories or spawned in the world. This guide describes methods for reading and manipulating item data.
 
 ---
 
 ## Overview
 
-These meta functions extend standard item objects with convenience helpers used throughout Lilia.
+Item meta functions cover stack counts, categories, weight calculations, and network variables. They enable consistent item interaction across trading, crafting, and interface components.
 
 ---
 

--- a/docs/docs/meta/panel.md
+++ b/docs/docs/meta/panel.md
@@ -1,12 +1,12 @@
 # Panel Meta
 
-This document describes the methods available on panel objects.
+Lilia's interface relies on VGUI panels with extra functionality. This document describes convenience methods available to those panels.
 
 ---
 
 ## Overview
 
-These meta functions extend standard panel objects with convenience helpers used throughout Lilia.
+Panel meta functions support scaled positioning, listen for inventory changes, and offer other utilities that make building responsive menus and HUD elements easier.
 
 ---
 

--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -1,12 +1,12 @@
 # Player Meta
 
-This document describes the methods available on player objects.
+Lilia extends Garry's Mod players with characters, inventories, and permission checks. This reference details the meta functions enabling that integration.
 
 ---
 
 ## Overview
 
-These meta functions extend standard player objects with convenience helpers used throughout Lilia.
+Player meta functions provide quick access to the active character, networking helpers for messaging or data transfer, and utility checks such as admin status. They unify player-related logic across the framework.
 
 ---
 

--- a/docs/docs/meta/tool.md
+++ b/docs/docs/meta/tool.md
@@ -1,12 +1,12 @@
 # Tool Meta
 
-This document describes the methods available on the ToolGun object.
+The ToolGun interacts with the world through specialized meta functions. This guide lists utilities for object manipulation and ghost entity management.
 
 ---
 
 ## Overview
 
-These meta functions extend the ToolGun object with convenience helpers used throughout Lilia.
+Tool meta functions track hovered entities, create ghost previews, and wrap common building operations. They ensure consistent behavior across custom tools in Lilia.
 
 ---
 

--- a/docs/docs/meta/vector.md
+++ b/docs/docs/meta/vector.md
@@ -1,12 +1,12 @@
 # Vector Meta
 
-This document describes the methods available on vector objects.
+Vector utilities expand Garry's Mod's math library. This document describes additional operations for 3D vectors.
 
 ---
 
 ## Overview
 
-These meta functions extend standard vector objects with convenience helpers used throughout Lilia.
+Vector meta functions provide calculations such as midpoints, distances, and axis rotations to support movement, physics, and placement tasks.
 
 ---
 


### PR DESCRIPTION
## Summary
- expand intro lines for meta docs
- elaborate on overview section explaining their purpose

## Testing
- `luarocks --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d6c82ca48327a3869cd5ac4bbf6f