### PR TITLE
Fix library doc headers

### DIFF
--- a/docs/docs/libraries/lia.attributes.md
+++ b/docs/docs/libraries/lia.attributes.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Attributes Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents the functions for working with character attributes.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper methods for modifying them. It also exposes hooks for registering new attributes and controlling how they progress.
 
 ---
 

--- a/docs/docs/libraries/lia.bars.md
+++ b/docs/docs/libraries/lia.bars.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Bars Library
 
-This document lists hooks related to attribute setup and changes.
+This page describes the API for status bars displayed on the HUD.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The bars library manages health, stamina, and other progress bars displayed on the player's HUD. It lets you register custom bar callbacks, draws them every frame, and provides helpers for temporary action bars.
 
 ---
 

--- a/docs/docs/libraries/lia.character.md
+++ b/docs/docs/libraries/lia.character.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Character Library
 
-This document lists hooks related to attribute setup and changes.
+This page covers utilities for manipulating character data.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The character library handles creation and persistence of player characters. It manages character variables, interacts with the database, and offers helpers for retrieving characters by ID or SteamID.
 
 ---
 

--- a/docs/docs/libraries/lia.chatbox.md
+++ b/docs/docs/libraries/lia.chatbox.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Chatbox Library
 
-This document lists hooks related to attribute setup and changes.
+This page outlines chatbox related functions and helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The chatbox library defines chat commands and renders messages. It lets you register new chat types with custom formatting and handles radius-based or global message visibility.
 
 ---
 

--- a/docs/docs/libraries/lia.classes.md
+++ b/docs/docs/libraries/lia.classes.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Classes Library
 
-This document lists hooks related to attribute setup and changes.
+This page details the class system functions.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The classes library loads Lua definitions that describe player classes. It stores available classes, registers default attributes, and provides lookup functions by name or index.
 
 ---
 

--- a/docs/docs/libraries/lia.color.md
+++ b/docs/docs/libraries/lia.color.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Color Library
 
-This document lists hooks related to attribute setup and changes.
+This page lists helper functions for working with colors.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The color library centralizes color utilities used throughout the UI. You can register reusable colors, adjust their channels to create variants, and fetch the main palette from the configuration.
 
 ---
 

--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Commands Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents command registration and execution.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The commands library registers console and chat commands. It parses arguments, checks permissions, and routes the command handlers for execution.
 
 ---
 

--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Config Library
 
-This document lists hooks related to attribute setup and changes.
+This page explains how to add and access configuration settings.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The config library stores server configuration values with descriptions and default settings. It also provides callbacks when values change so modules can react to new options.
 
 ---
 

--- a/docs/docs/libraries/lia.currency.md
+++ b/docs/docs/libraries/lia.currency.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Currency Library
 
-This document lists hooks related to attribute setup and changes.
+This page covers money and currency related helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The currency library formats money amounts and converts between numeric and display representations. It stores the currency symbol and helps with cost calculations.
 
 ---
 

--- a/docs/docs/libraries/lia.darkrp.md
+++ b/docs/docs/libraries/lia.darkrp.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# DarkRP Compatibility
 
-This document lists hooks related to attribute setup and changes.
+This page describes helpers for integrating with DarkRP.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The darkrp library bridges functionality with the DarkRP gamemode. It offers helper checks and wrappers to maintain compatibility when running Lilia alongside DarkRP.
 
 ---
 

--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Data Library
 
-This document lists hooks related to attribute setup and changes.
+This page describes persistent data storage helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The data library persists key/value pairs either on disk or through the database backend. It supplies convenience methods for saving, retrieving, and deleting stored data.
 
 ---
 

--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Database Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents functions for connecting to the database.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The database library sets up the SQL connection used by the framework. It defines helpers for creating tables, performing queries, and waiting for asynchronous operations to finish.
 
 ---
 

--- a/docs/docs/libraries/lia.factions.md
+++ b/docs/docs/libraries/lia.factions.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Factions Library
 
-This document lists hooks related to attribute setup and changes.
+This page covers the faction system helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The factions library loads faction definitions and stores them for later lookup. It provides functions to find factions by index or name and to iterate all faction data.
 
 ---
 

--- a/docs/docs/libraries/lia.flags.md
+++ b/docs/docs/libraries/lia.flags.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Flags Library
 
-This document lists hooks related to attribute setup and changes.
+This page explains permission flag management.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The flags library assigns text-based permission flags to players. It offers tools for checking whether a player possesses a flag and for saving or loading flag data.
 
 ---
 

--- a/docs/docs/libraries/lia.fonts.md
+++ b/docs/docs/libraries/lia.fonts.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Fonts Library
 
-This document lists hooks related to attribute setup and changes.
+This page lists utilities for creating fonts.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The fonts library wraps surface.CreateFont for commonly used fonts. It reduces duplication by registering fonts once and allowing them to be recalled by name.
 
 ---
 

--- a/docs/docs/libraries/lia.inventory.md
+++ b/docs/docs/libraries/lia.inventory.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Inventory Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents inventory handling functions.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The inventory library manages item containers and grid inventories. It supports registering new inventory types and handles item transfers between them.
 
 ---
 

--- a/docs/docs/libraries/lia.item.md
+++ b/docs/docs/libraries/lia.item.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Item Library
 
-This document lists hooks related to attribute setup and changes.
+This page covers item definition helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The item library contains utilities for retrieving item definitions and creating new items. It also provides shared item methods used throughout the framework.
 
 ---
 

--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Keybind Library
 
-This document lists hooks related to attribute setup and changes.
+This page describes functions to register custom keybinds.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The keybind library stores user-defined keyboard bindings. It reads and writes keybind files and dispatches callbacks when the associated keys are pressed.
 
 ---
 

--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Languages Library
 
-This document lists hooks related to attribute setup and changes.
+This page explains how translations and phrases are loaded.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The languages library loads localization files from directories. It resolves phrase keys to translated text and allows runtime language switching.
 
 ---
 

--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Logger Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents logging utilities.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The logger library writes structured log entries to files and the console. It tracks important gameplay events for later auditing or debugging.
 
 ---
 

--- a/docs/docs/libraries/lia.markup.md
+++ b/docs/docs/libraries/lia.markup.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Markup Library
 
-This document lists hooks related to attribute setup and changes.
+This page covers markup parsing helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The markup library parses a subset of HTML-like tags for drawing rich text in chat panels. It handles basic color, size, and font formatting.
 
 ---
 

--- a/docs/docs/libraries/lia.md
+++ b/docs/docs/libraries/lia.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Lia Core Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents general utilities used throughout Lilia.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The lia core library exposes shared helper functions used across multiple modules. It primarily handles file inclusion logic and other small utilities.
 
 ---
 

--- a/docs/docs/libraries/lia.menu.md
+++ b/docs/docs/libraries/lia.menu.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Menu Library
 
-This document lists hooks related to attribute setup and changes.
+This page describes small menu creation helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The menu library offers convenience functions for building simple context menus. It supports nested options and automatically positions them on screen.
 
 ---
 

--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Modularity Library
 
-This document lists hooks related to attribute setup and changes.
+This page explains the module loading system.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The modularity library loads modules contained in the 'modules' folder. It resolves dependencies and initializes serverside and clientside components.
 
 ---
 

--- a/docs/docs/libraries/lia.networking.md
+++ b/docs/docs/libraries/lia.networking.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Networking Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents network variable and message helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The networking library synchronizes data between the server and clients. It provides wrappers around net messages and networked variables.
 
 ---
 

--- a/docs/docs/libraries/lia.notice.md
+++ b/docs/docs/libraries/lia.notice.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Notice Library
 
-This document lists hooks related to attribute setup and changes.
+This page describes how popup notices are displayed.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The notice library displays temporary popup notifications at the top of the player's screen. Notices can be queued or targeted to specific players.
 
 ---
 

--- a/docs/docs/libraries/lia.option.md
+++ b/docs/docs/libraries/lia.option.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Option Library
 
-This document lists hooks related to attribute setup and changes.
+This page details the client/server option system.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The option library stores user and server options with default values. It offers getters and setters that automatically network changes between client and server.
 
 ---
 

--- a/docs/docs/libraries/lia.time.md
+++ b/docs/docs/libraries/lia.time.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Time Library
 
-This document lists hooks related to attribute setup and changes.
+This page lists time and date utilities.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The time library handles date formatting and relative time conversions. It offers helper functions to compute durations such as 'time since' or 'time until'.
 
 ---
 

--- a/docs/docs/libraries/lia.util.md
+++ b/docs/docs/libraries/lia.util.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Utility Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents miscellaneous helper functions.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The util library contains small miscellaneous helper functions used across modules. These include player searches, entity queries, and geometric calculations.
 
 ---
 

--- a/docs/docs/libraries/lia.webimage.md
+++ b/docs/docs/libraries/lia.webimage.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# WebImage Library
 
-This document lists hooks related to attribute setup and changes.
+This page explains how web images are downloaded and cached.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The webimage library downloads remote images and caches them as materials. It avoids repeated downloads and allows you to reference web images by name.
 
 ---
 

--- a/docs/docs/libraries/lia.workshop.md
+++ b/docs/docs/libraries/lia.workshop.md
@@ -1,12 +1,12 @@
-# Attribute Hooks
+# Workshop Library
 
-This document lists hooks related to attribute setup and changes.
+This page documents Workshop addon helpers.
 
 ---
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+The workshop library tracks required Workshop addon IDs and mounts them on clients. It helps ensure that players have the assets needed for the gamemode.
 
 ---
 


### PR DESCRIPTION
## Summary
- expand overview sections in library docs

## Testing
- `mkdocs build -f docs/mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_e_6860d6b4d210832789a1a305d7077429