### PR TITLE
Fix docs intros for hooks

### DIFF
--- a/docs/docs/hooks/attribute_hooks.md
+++ b/docs/docs/hooks/attribute_hooks.md
@@ -6,7 +6,7 @@ This document lists hooks related to attribute setup and changes.
 
 ## Overview
 
-Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
+Attributes can define their own hooks to react when a player's attribute is created or its value changes. Implement these functions on the `ATTRIBUTE` table to run custom logic. All hooks are optional; if a hook is omitted the default behavior is used.
 
 ---
 

--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -1,12 +1,18 @@
 # Gamemode Hooks
 
-This document describes all `FACTION` function hooks defined within the codebase. Use these to customize default naming, descriptions, and lifecycle events when characters are created, spawned, or transferred within a faction.
+This document lists global hooks triggered by the gamemode. You can define them on the `GM` table, inside a `MODULE`, on the `SCHEMA`, or call them anywhere with `hook.Add`.
+
+- **MODULE** functions load only from `/modules`.
+- **SCHEMA** functions live in `/schema`.
+- **hook.Add** may be used from any file.
+
+If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, the one loaded last overrides the others.
 
 ---
 
 ## Overview
 
-Each faction can implement these shared- and server-side hooks to control how characters are initialized, described, and handled as they move through creation, spawning, and transfers. All hooks are optional; if you omit a hook, default behavior applies.
+Gamemode hooks fire at various stages during play and let you modify global behavior. Implement them in any of the locations described above. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.
 
 ---
 


### PR DESCRIPTION
## Summary
- update gamemode hooks intro with MODULE/SCHEMA details and override behavior

## Testing
- `luacheck` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6860d6bafce48327b4436f04d8839e0e