### PR TITLE
Add modules listing

### DIFF
--- a/docs/docs/modules.md
+++ b/docs/docs/modules.md
@@ -1,0 +1,844 @@
+# Optional Modules
+
+## Advert
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/advert.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/advert.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/advert.html](https://liliaframework.github.io/Modules/advert.html)
+
+**Description:** Adds a Advert Command
+
+**Features:**
+- Adds a `/advert` chat command for server-wide announcements
+
+- Includes a configurable delay to prevent spam
+
+---
+
+## Alcoholism
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/alcoholism.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/alcoholism.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/alcoholism.html](https://liliaframework.github.io/Modules/alcoholism.html)
+
+**Description:** Adds Alcohol and Effects to it.
+
+**Features:**
+- Consumable alcohol items raise blood alcohol content
+
+- High BAC causes motion blur and stumbling movement
+
+- BAC gradually lowers over time
+
+---
+
+## Auto Restarter
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/autorestarter.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/autorestarter.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/autorestarter.html](https://liliaframework.github.io/Modules/autorestarter.html)
+
+**Description:** Automatically restarts the server every interval.
+
+**Features:**
+- Schedules automatic restarts at a configurable interval
+
+- Displays countdown warnings to connected players
+
+---
+
+## Bodygrouper
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/bodygrouper.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/bodygrouper.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/bodygrouper.html](https://liliaframework.github.io/Modules/bodygrouper.html)
+
+**Description:** Adds a bodygroup menu and bodygroup closet, akin to BodygroupR on GModStore
+
+**Features:**
+- Admin command to open a bodygroup menu for any player
+
+- Closet entity that lets players change model bodygroups
+
+---
+
+## Broadcasts
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/broadcasts.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/broadcasts.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/broadcasts.html](https://liliaframework.github.io/Modules/broadcasts.html)
+
+**Description:** Adds a Faction & Class Broadcast Command
+
+**Features:**
+- Provides `/factionbroadcast` and `/classbroadcast` commands
+
+- Sends messages to selected factions or classes
+
+---
+
+## Captions
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/captions.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/captions.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/captions.html](https://liliaframework.github.io/Modules/captions.html)
+
+**Description:** Adds a easy way of adding in-game captions.
+
+**Features:**
+- Command based system for showing in-game captions
+
+- Captions fade in and out and are networked to all clients
+
+---
+
+## Cards
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cards.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cards.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/cards.html](https://liliaframework.github.io/Modules/cards.html)
+
+**Description:** Adds the ability to draw a random card from a card deck
+
+**Features:**
+- Draws a random playing card with `/card`
+
+- Includes card deck items
+
+---
+
+## Chat Messages
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/chatmessages.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/chatmessages.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/chatmessages.html](https://liliaframework.github.io/Modules/chatmessages.html)
+
+**Description:** Adds Simple Adverts.
+
+**Features:**
+- Periodically posts custom chat messages to everyone
+
+- Interval and message list are configurable
+
+---
+
+## Cinematic Text
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cinematictext.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cinematictext.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/cinematictext.html](https://liliaframework.github.io/Modules/cinematictext.html)
+
+**Description:** Cinematic looking splash text for that extra flair
+
+**Features:**
+- Creates cinematic splash text with optional black bars
+
+- Supports custom colors, large titles and countdowns
+
+---
+
+## Climb
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/climb.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/climb.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/climb.html](https://liliaframework.github.io/Modules/climb.html)
+
+**Description:** Adds the ability to climb up ledges.
+
+**Features:**
+- Players can climb ledges when jumping toward them
+
+- Uses trace detection to start the climb animation
+
+---
+
+## Code Utils
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/codeutils.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/codeutils.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/codeutils.html](https://liliaframework.github.io/Modules/codeutils.html)
+
+**Description:** Adds a few extensions to the lia.util library.
+
+**Features:**
+- Extra helper functions added to `lia.util`
+
+- Includes network convenience wrappers
+
+---
+
+## Community Commands
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/communitycommands.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/communitycommands.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/communitycommands.html](https://liliaframework.github.io/Modules/communitycommands.html)
+
+**Description:** Adds links to the various content
+
+**Features:**
+- Chat commands that link players to community resources
+
+- Simple to customize
+
+---
+
+## Corpse ID
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/corpseid.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/corpseid.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/corpseid.html](https://liliaframework.github.io/Modules/corpseid.html)
+
+**Description:** Adds a corpse identification mechanic.
+
+**Features:**
+- Allows identifying corpses to see their information
+
+- Stores identification state on the corpse
+
+---
+
+## Cursor
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cursor.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cursor.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/cursor.html](https://liliaframework.github.io/Modules/cursor.html)
+
+**Description:** Adds a Cursor.
+
+**Features:**
+- Provides a custom on-screen cursor system
+
+- Can be toggled via configuration
+
+---
+
+## Simple Cutscenes
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cutscenes.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cutscenes.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/cutscenes.html](https://liliaframework.github.io/Modules/cutscenes.html)
+
+**Description:** A system for simple cutscenes
+
+**Features:**
+- Framework for simple camera cutscenes
+
+- Includes chat command to play predefined scenes
+
+---
+
+## Damage Numbers
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/damagenumbers.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/damagenumbers.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/damagenumbers.html](https://liliaframework.github.io/Modules/damagenumbers.html)
+
+**Description:** Display damage numbers when you hit someone, or when you get hit.
+
+**Features:**
+- Shows floating damage numbers when dealing or taking damage
+
+- Display style and duration are configurable
+
+---
+
+## Development HUD
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmenthud.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmenthud.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/developmenthud.html](https://liliaframework.github.io/Modules/developmenthud.html)
+
+**Description:** Adds a Development HUD
+
+**Features:**
+- Adds an on-screen HUD with FPS and debug info
+
+- Useful while developing new content
+
+---
+
+## Development Server
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmentserver.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmentserver.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/developmentserver.html](https://liliaframework.github.io/Modules/developmentserver.html)
+
+**Description:** Adds the option for a Development Server, which can run specific functions.
+
+**Features:**
+- Hooks for running code only on a dev server
+
+- Enables special debug commands
+
+---
+
+## Discord Relay
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/discordrelay.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/discordrelay.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/discordrelay.html](https://liliaframework.github.io/Modules/discordrelay.html)
+
+**Description:** Relays Logs to Discord.
+
+**Features:**
+- Relays server logs and chat events to Discord via webhooks
+
+- Channel configuration is handled in settings
+
+---
+
+## Donator
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/donator.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/donator.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/donator.html](https://liliaframework.github.io/Modules/donator.html)
+
+**Description:** Adds Several Donation Related Libraries.
+
+**Features:**
+- Utilities for checking donor status and granting perks
+
+- Integrates with donation systems
+
+---
+
+## Door Kick
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/doorkick.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/doorkick.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/doorkick.html](https://liliaframework.github.io/Modules/doorkick.html)
+
+**Description:** Allows you to kick doors open.
+
+**Features:**
+- Lets players kick doors open with an animation
+
+- Only works on unlocked or breachable doors
+
+---
+
+## Hospitals
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/enhanceddeath.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/enhanceddeath.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/enhanceddeath.html](https://liliaframework.github.io/Modules/enhanceddeath.html)
+
+**Description:** Adds Hospitals that Spawn you after dying
+
+**Features:**
+- After dying players respawn at configured hospitals
+
+- Supports placement of multiple hospital spawn points
+
+---
+
+## Extended Descriptions
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/extendeddescriptions.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/extendeddescriptions.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/extendeddescriptions.html](https://liliaframework.github.io/Modules/extendeddescriptions.html)
+
+**Description:** This Module focuses on adding Extended Descriptions.
+
+**Features:**
+- Allows longer character or item descriptions
+
+- Displays them in info panels
+
+---
+
+## First Person Effects
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/firstpersoneffects.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/firstpersoneffects.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/firstpersoneffects.html](https://liliaframework.github.io/Modules/firstpersoneffects.html)
+
+**Description:** Realistic first person effects.
+
+**Features:**
+- Adds screen shake and other first-person effects
+
+- Enhances immersion when running or landing
+
+---
+
+## Flashlight
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/flashlight.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/flashlight.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/flashlight.html](https://liliaframework.github.io/Modules/flashlight.html)
+
+**Description:** Makes Flashlight a bit more serious
+
+**Features:**
+- More realistic flashlight with tweakable brightness
+
+- Optional battery drain system
+
+---
+
+## Free Look
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/freelook.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/freelook.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/freelook.html](https://liliaframework.github.io/Modules/freelook.html)
+
+**Description:** Adds Free Look similar to EFT
+
+**Features:**
+- Enables free look similar to modern shooters
+
+- Bind a key to look around without moving your aim
+
+---
+
+## Gamemaster Teleport Points
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/gamemasterpoints.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/gamemasterpoints.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/gamemasterpoints.html](https://liliaframework.github.io/Modules/gamemasterpoints.html)
+
+**Description:** Allow GMs to teleport to predefined points on the map
+
+**Features:**
+- Teleport system for gamemasters
+
+- Commands to save, remove and travel to points
+
+---
+
+## Extra HUD Elements
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/hud_extras.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/hud_extras.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/hud_extras.html](https://liliaframework.github.io/Modules/hud_extras.html)
+
+**Description:** Implements Extra HUD Elements.
+
+**Features:**
+- Adds extra HUD elements such as ammo or status bars
+
+- Elements can be toggled in configuration
+
+---
+
+## Instant Killing
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/instakill.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/instakill.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/instakill.html](https://liliaframework.github.io/Modules/instakill.html)
+
+**Description:** Enables instant kills on headshots
+
+**Features:**
+- Optional headshot insta-kill mechanic
+
+- Damage scaling controlled via config
+
+---
+
+## Join Leave Messages
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/joinleavemessages.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/joinleavemessages.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/joinleavemessages.html](https://liliaframework.github.io/Modules/joinleavemessages.html)
+
+**Description:** Adds Join and Leave Messages
+
+**Features:**
+- Announces player join and leave events in chat
+
+- Uses color-coded messages
+
+---
+
+## Load Messages
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loadmessages.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loadmessages.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/loadmessages.html](https://liliaframework.github.io/Modules/loadmessages.html)
+
+**Description:** Sends faction-based messages to players when they first load their character.
+
+**Features:**
+- Shows a welcome message when players load in
+
+- Can vary message by faction
+
+---
+
+## Loyalism
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loyalism.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loyalism.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/loyalism.html](https://liliaframework.github.io/Modules/loyalism.html)
+
+**Description:** System for loyalist tiers.
+
+**Features:**
+- System of loyalist tiers that players can gain
+
+- Tiers grant access to special items or areas
+
+---
+
+## Map Cleaner
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/mapcleaner.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/mapcleaner.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/mapcleaner.html](https://liliaframework.github.io/Modules/mapcleaner.html)
+
+**Description:** Adds a Map Cleaner with configurable timings
+
+**Features:**
+- Periodically cleans dropped items and debris
+
+- Warns players before removing entities
+
+---
+
+## Model Pay
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modelpay.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modelpay.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/modelpay.html](https://liliaframework.github.io/Modules/modelpay.html)
+
+**Description:** Adds a system to pay per model
+
+**Features:**
+- Charges players currency based on their chosen model
+
+- Supports custom prices for each model
+
+---
+
+## Model Tweaker
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modeltweaker.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modeltweaker.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/modeltweaker.html](https://liliaframework.github.io/Modules/modeltweaker.html)
+
+**Description:** Adds a Model Tweaker Entity.
+
+**Features:**
+- Entity that lets admins tweak model bodygroups and skins
+
+- Saves adjustments for later
+
+---
+
+## NPC Drops
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcdrop.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcdrop.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/npcdrop.html](https://liliaframework.github.io/Modules/npcdrop.html)
+
+**Description:** Adds NPCs that drop items
+
+**Features:**
+- NPCs can drop items when killed based on weighted tables
+
+- Supports custom loot lists per NPC type
+
+---
+
+## NPC Spawner
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcspawner.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcspawner.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/npcspawner.html](https://liliaframework.github.io/Modules/npcspawner.html)
+
+**Description:** Adds automatic npc spawning
+
+**Features:**
+- Automatically spawns NPCs at defined points
+
+- Spawner intervals and limits are configurable
+
+---
+
+## Perma Remove
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/permaremove.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/permaremove.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/permaremove.html](https://liliaframework.github.io/Modules/permaremove.html)
+
+**Description:** Allows staff to permanently remove map entities
+
+**Features:**
+- Allows staff to permanently remove map entities
+
+- Removals persist across server restarts
+
+---
+
+## Radio
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/radio.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/radio.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/radio.html](https://liliaframework.github.io/Modules/radio.html)
+
+**Description:** Radio
+
+**Features:**
+- Adds handheld radios with multiple channels
+
+- Includes UI for channel selection and push-to-talk
+
+---
+
+## Raised Weapons
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/raisedweapons.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/raisedweapons.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/raisedweapons.html](https://liliaframework.github.io/Modules/raisedweapons.html)
+
+**Description:** Adds a safety system that holsters sweps.
+
+**Features:**
+- Implements a holster/safety system for weapons
+
+- Players must raise weapons to fire
+
+---
+
+## Realistic Damage
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticdamage.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticdamage.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/realisticdamage.html](https://liliaframework.github.io/Modules/realisticdamage.html)
+
+**Description:** Adds Damage Scalers for Realism
+
+**Features:**
+- Damage scaling for more realistic combat
+
+- Tweaks hit group multipliers and armor effects
+
+---
+
+## Realistic View
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticview.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticview.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/realisticview.html](https://liliaframework.github.io/Modules/realisticview.html)
+
+**Description:** Adds an realistic 1st Person View that allows to see the entire body.
+
+**Features:**
+- Shows the player body in first person
+
+- Adjusts camera position for a realistic view
+
+---
+
+## Rumour
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/rumour.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/rumour.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/rumour.html](https://liliaframework.github.io/Modules/rumour.html)
+
+**Description:** Adds a Rumour Command
+
+**Features:**
+- Adds a `/rumour` chat command for sharing gossip
+
+- Rumours are broadcast to nearby players
+
+---
+
+## Shoot Locks
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/shootlock.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/shootlock.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/shootlock.html](https://liliaframework.github.io/Modules/shootlock.html)
+
+**Description:** Shoot locks to open doors.
+
+**Features:**
+- Allows shooting certain locks to open doors
+
+- Checks lock health and plays effects
+
+---
+
+## Lockpicking
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/simple_lockpicking.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/simple_lockpicking.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/simple_lockpicking.html](https://liliaframework.github.io/Modules/simple_lockpicking.html)
+
+**Description:** Adds simple Lockpicking to bruteforce doors!
+
+**Features:**
+- Brute force style lockpicking minigame
+
+- Includes custom lockpick items
+
+---
+
+## Slots
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slots.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slots.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/slots.html](https://liliaframework.github.io/Modules/slots.html)
+
+**Description:** Adds a Slots Machine.
+
+**Features:**
+- Slot machine entity players can gamble on
+
+- Uses animated reels and configurable payouts
+
+---
+
+## Heavy Weapons
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slowweapons.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slowweapons.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/slowweapons.html](https://liliaframework.github.io/Modules/slowweapons.html)
+
+**Description:** A module that allows you to make certain weapons that slow you down
+
+**Features:**
+- Heavy weapons slow down player movement
+
+- Define which weapons count as heavy
+
+---
+
+## Stun Gun
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/stungun.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/stungun.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/stungun.html](https://liliaframework.github.io/Modules/stungun.html)
+
+**Description:** An Stun Gun Reworked from CustomHQ
+
+**Features:**
+- Non-lethal stun gun weapon
+
+- Temporarily incapacitates targets
+
+---
+
+## Tying
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/tying.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/tying.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/tying.html](https://liliaframework.github.io/Modules/tying.html)
+
+**Description:** Adds Tying Items That Serve As Handcuffs. Enchance Roleplay Overall.
+
+**Features:**
+- Adds handcuff-style tying items
+
+- Tied players have restricted actions
+
+---
+
+## View Bob
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/viewbob.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/viewbob.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/viewbob.html](https://liliaframework.github.io/Modules/viewbob.html)
+
+**Description:** Adds an custom View Bob.
+
+**Features:**
+- Adds camera bobbing while moving
+
+- Amount of bob can be configured
+
+---
+
+## VManip
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/vmanip.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/vmanip.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/vmanip.html](https://liliaframework.github.io/Modules/vmanip.html)
+
+**Description:** Adds VManip Compatibility to Lilia.
+
+**Features:**
+- Integrates VManip animations with the framework
+
+- Provides networked VManip events
+
+---
+
+## Warrant
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/warrants.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/warrants.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/warrants.html](https://liliaframework.github.io/Modules/warrants.html)
+
+**Description:** Adds Warrants
+
+**Features:**
+- System for creating and tracking search warrants
+
+- Includes commands to issue and revoke warrants
+
+---
+
+## War Table
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wartable.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wartable.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/wartable.html](https://liliaframework.github.io/Modules/wartable.html)
+
+**Description:** Adds a interactive War Table
+
+**Features:**
+- Interactive war table entity for planning
+
+- Supports moving pieces and drawing zones
+
+---
+
+## Weight Inv
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/weightinv.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/weightinv.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/weightinv.html](https://liliaframework.github.io/Modules/weightinv.html)
+
+**Description:** Adds a weight inventory type.
+
+**Features:**
+- Inventory system that tracks total weight
+
+- Items have weight values that limit carrying capacity
+
+---
+
+## Whitelist
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/whitelist.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/whitelist.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/whitelist.html](https://liliaframework.github.io/Modules/whitelist.html)
+
+**Description:** Adds a Server Whitelist
+
+**Features:**
+- Simple server whitelist management
+
+- Players not on the list cannot join
+
+---
+
+## Word Filter
+
+**Download Here:** [https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wordfilter.zip](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wordfilter.zip)
+
+**Module Website:** [https://liliaframework.github.io/Modules/wordfilter.html](https://liliaframework.github.io/Modules/wordfilter.html)
+
+**Description:** Filters unwanted words out of the chat
+
+**Features:**
+- Filters unwanted words from chat
+
+- Customizable blocked word list
+
+---
+


### PR DESCRIPTION
## Summary
- document modules available in the separate Modules repository
- restructure entries to remove links from names and add explicit download links

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ea7389e48327bea5bf88d06bc58e