### PR TITLE
Improve Lua code formatting in library docs

### DIFF
--- a/docs/docs/libraries/lia.attributes.md
+++ b/docs/docs/libraries/lia.attributes.md
@@ -27,9 +27,12 @@ as the key.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.attribs.loadFromDir
-lia.attribs.loadFromDir("schema/attributes")
+    -- This snippet demonstrates a common usage of lia.attribs.loadFromDir
+    lia.attribs.loadFromDir("schema/attributes")
 ```
+
+---
+
 
 ### lia.attribs.setup(client)
 
@@ -46,6 +49,6 @@ an OnSetup callback, it is executed with the current value.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.attribs.setup
-lia.attribs.setup(client)
+    -- This snippet demonstrates a common usage of lia.attribs.setup
+    lia.attribs.setup(client)
 ```

--- a/docs/docs/libraries/lia.bars.md
+++ b/docs/docs/libraries/lia.bars.md
@@ -23,12 +23,15 @@ Retrieves a bar object from the list by its unique identifier.
 * table or nil – The bar table if found, or nil if not found.
 **Example:**
 ```lua
--- Retrieve the health bar and change its color at runtime
-local bar = lia.bar.get("health")
-if bar then
-bar.color = Color(0, 200, 0) -- make the bar green
-end
+    -- Retrieve the health bar and change its color at runtime
+    local bar = lia.bar.get("health")
+    if bar then
+        bar.color = Color(0, 200, 0) -- make the bar green
+    end
 ```
+
+---
+
 
 ### lia.bar.add(getValue, color, priority, identifier)
 
@@ -48,14 +51,17 @@ Bars are drawn in order of ascending priority.
 * number – The priority assigned to the added bar.
 **Example:**
 ```lua
--- Calculates the player's current health as a fraction of their maximum health.
--- Uses a custom color (RGB 200, 50, 40) for the bar's fill.
--- Assigns priority 1 so this bar draws before lower-priority bars.
-lia.bar.add(function()
-local client = LocalPlayer()
-return client:Health() / client:GetMaxHealth()
-end, Color(200, 50, 40), 1, "health")
+    -- Calculates the player's current health as a fraction of their maximum health.
+    -- Uses a custom color (RGB 200, 50, 40) for the bar's fill.
+    -- Assigns priority 1 so this bar draws before lower-priority bars.
+    lia.bar.add(function()
+        local client = LocalPlayer()
+        return client:Health() / client:GetMaxHealth()
+    end, Color(200, 50, 40), 1, "health")
 ```
+
+---
+
 
 ### lia.bar.remove(identifier)
 
@@ -70,9 +76,12 @@ Removes a bar from the list based on its unique identifier.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.bar.remove
-lia.bar.remove("example")
+    -- This snippet demonstrates a common usage of lia.bar.remove
+    lia.bar.remove("example")
 ```
+
+---
+
 
 ### lia.bar.drawBar(x, y, w, h, pos, max, color)
 
@@ -94,9 +103,12 @@ filling it proportionally based on pos and max.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.bar.drawBar
-lia.bar.drawBar(10, 10, 200, 20, 0.5, 1, Color(255,0,0))
+    -- This snippet demonstrates a common usage of lia.bar.drawBar
+    lia.bar.drawBar(10, 10, 200, 20, 0.5, 1, Color(255,0,0))
 ```
+
+---
+
 
 ### lia.bar.drawAction(text, duration)
 
@@ -113,9 +125,12 @@ for the specified duration on the HUD.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.bar.drawAction
-lia.bar.drawAction("Reloading", 2)
+    -- This snippet demonstrates a common usage of lia.bar.drawAction
+    lia.bar.drawAction("Reloading", 2)
 ```
+
+---
+
 
 ### lia.bar.drawAll()
 
@@ -131,6 +146,6 @@ and draws them on the HUD according to their priority and visibility rules.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of hook.Add
-hook.Add("HUDPaintBackground", "liaBarDraw", lia.bar.drawAll)
+    -- This snippet demonstrates a common usage of hook.Add
+    hook.Add("HUDPaintBackground", "liaBarDraw", lia.bar.drawAll)
 ```

--- a/docs/docs/libraries/lia.character.md
+++ b/docs/docs/libraries/lia.character.md
@@ -21,9 +21,12 @@ Creates a new character instance with default variables and metatable.
 * character (table) – New character object.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.new
-local char = lia.char.new({name = "John"}, 1, client)
+    -- This snippet demonstrates a common usage of lia.char.new
+    local char = lia.char.new({name = "John"}, 1, client)
 ```
+
+---
+
 
 ### lia.char.hookVar(varName, hookName, func)
 
@@ -40,9 +43,12 @@ Registers a hook function for when a character variable changes.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.hookVar
-lia.char.hookVar("name", "PrintName", function(old, new) print(new) end)
+    -- This snippet demonstrates a common usage of lia.char.hookVar
+    lia.char.hookVar("name", "PrintName", function(old, new) print(new) end)
 ```
+
+---
+
 
 ### lia.char.registerVar(key, data)
 
@@ -58,9 +64,12 @@ Registers a character variable with metadata and generates accessor methods.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.registerVar
-lia.char.registerVar("age", {field = "_age", default = 20})
+    -- This snippet demonstrates a common usage of lia.char.registerVar
+    lia.char.registerVar("age", {field = "_age", default = 20})
 ```
+
+---
+
 
 ### lia.char.getCharData(charID, key)
 
@@ -76,9 +85,12 @@ Retrieves character data JSON from the database as a Lua table.
 * value (any) – Data value or full table if no key provided.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.getCharData
-local age = lia.char.getCharData(1, "age")
+    -- This snippet demonstrates a common usage of lia.char.getCharData
+    local age = lia.char.getCharData(1, "age")
 ```
+
+---
+
 
 ### lia.char.getCharDataRaw(charID, key)
 
@@ -94,9 +106,12 @@ Retrieves raw character database row or specific column.
 * row (table|any) – Full row table or column value.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.getCharDataRaw
-local row = lia.char.getCharDataRaw(1)
+    -- This snippet demonstrates a common usage of lia.char.getCharDataRaw
+    local row = lia.char.getCharDataRaw(1)
 ```
+
+---
+
 
 ### lia.char.getOwnerByID(ID)
 
@@ -111,9 +126,12 @@ Finds the player entity that owns the character with the given ID.
 * Player – Player entity or nil if not found.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.getOwnerByID
-local ply = lia.char.getOwnerByID(1)
+    -- This snippet demonstrates a common usage of lia.char.getOwnerByID
+    local ply = lia.char.getOwnerByID(1)
 ```
+
+---
+
 
 ### lia.char.getBySteamID(steamID)
 
@@ -128,9 +146,12 @@ Retrieves a character object by SteamID or SteamID64.
 * Character – Character object or nil.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.getBySteamID
-local char = lia.char.getBySteamID("STEAM_0:0:11101")
+    -- This snippet demonstrates a common usage of lia.char.getBySteamID
+    local char = lia.char.getBySteamID("STEAM_0:0:11101")
 ```
+
+---
+
 
 ### lia.char.getAll()
 
@@ -145,9 +166,12 @@ Returns a table mapping all players to their loaded character objects.
 * table – Map of Player to Character.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of pairs
-for ply, char in pairs(lia.char.getAll()) do print(ply, char:getName()) end
+    -- This snippet demonstrates a common usage of pairs
+    for ply, char in pairs(lia.char.getAll()) do print(ply, char:getName()) end
 ```
+
+---
+
 
 ### lia.char.GetTeamColor(client)
 
@@ -162,9 +186,12 @@ Determines the team color for a client based on their character class or default
 * Color – Team or class color.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.GetTeamColor
-local color = lia.char.GetTeamColor(client)
+    -- This snippet demonstrates a common usage of lia.char.GetTeamColor
+    local color = lia.char.GetTeamColor(client)
 ```
+
+---
+
 
 ### lia.char.create(data, callback)
 
@@ -180,9 +207,12 @@ Inserts a new character into the database and sets up default inventory.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.create
-lia.char.create({name = "John"}, function(id) print("Created", id) end)
+    -- This snippet demonstrates a common usage of lia.char.create
+    lia.char.create({name = "John"}, function(id) print("Created", id) end)
 ```
+
+---
+
 
 ### lia.char.restore(client, callback, id)
 
@@ -199,9 +229,12 @@ Loads characters for a client from the database, optionally filtering by ID.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.restore
-lia.char.restore(client, print)
+    -- This snippet demonstrates a common usage of lia.char.restore
+    lia.char.restore(client, print)
 ```
+
+---
+
 
 ### lia.char.cleanUpForPlayer(client)
 
@@ -216,9 +249,12 @@ Cleans up loaded characters and inventories for a player on disconnect.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.cleanUpForPlayer
-lia.char.cleanUpForPlayer(client)
+    -- This snippet demonstrates a common usage of lia.char.cleanUpForPlayer
+    lia.char.cleanUpForPlayer(client)
 ```
+
+---
+
 
 ### lia.char.delete(id, client)
 
@@ -234,9 +270,12 @@ Deletes a character by ID from the database, cleans up and notifies players.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.delete
-lia.char.delete(1, client)
+    -- This snippet demonstrates a common usage of lia.char.delete
+    lia.char.delete(1, client)
 ```
+
+---
+
 
 ### lia.char.setCharData(charID, key, val)
 
@@ -253,9 +292,12 @@ Updates a character's JSON data field in the database and loaded object.
 * boolean – True on success, false on failure.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.setCharData
-lia.char.setCharData(1, "age", 25)
+    -- This snippet demonstrates a common usage of lia.char.setCharData
+    lia.char.setCharData(1, "age", 25)
 ```
+
+---
+
 
 ### lia.char.setCharName(charID, name)
 
@@ -271,9 +313,12 @@ Updates the character's name in the database and loaded object.
 * boolean – True on success, false on failure.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.setCharName
-lia.char.setCharName(1, "NewName")
+    -- This snippet demonstrates a common usage of lia.char.setCharName
+    lia.char.setCharName(1, "NewName")
 ```
+
+---
+
 
 ### lia.char.setCharModel(charID, model, bg)
 
@@ -290,6 +335,6 @@ Updates the character's model and bodygroups in the database and in-game.
 * boolean – True on success, false on failure.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.char.setCharModel
-lia.char.setCharModel(1, "models/player.mdl", {})
+    -- This snippet demonstrates a common usage of lia.char.setCharModel
+    lia.char.setCharModel(1, "models/player.mdl", {})
 ```

--- a/docs/docs/libraries/lia.chatbox.md
+++ b/docs/docs/libraries/lia.chatbox.md
@@ -18,9 +18,12 @@ Returns a formatted timestamp if chat timestamps are enabled.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.chat.timestamp
-local ts = lia.chat.timestamp(false)
+    -- This snippet demonstrates a common usage of lia.chat.timestamp
+    local ts = lia.chat.timestamp(false)
 ```
+
+---
+
 
 ### lia.chat.register(chatType, data)
 
@@ -36,14 +39,17 @@ Registers a new chat class and sets up command aliases.
 * Shared
 **Example:**
 ```lua
--- Register a simple "/me" chat command that prints actions in purple
-lia.chat.register("me", {
-onChatAdd = function(_, speaker, text)
-chat.AddText(Color(200, 100, 255), "* " .. speaker:Name() .. " " .. text)
-end,
-prefix = {"/me"}
-})
+    -- Register a simple "/me" chat command that prints actions in purple
+    lia.chat.register("me", {
+        onChatAdd = function(_, speaker, text)
+            chat.AddText(Color(200, 100, 255), "* " .. speaker:Name() .. " " .. text)
+        end,
+        prefix = {"/me"}
+    })
 ```
+
+---
+
 
 ### lia.chat.parse(client, message, noSend)
 
@@ -60,14 +66,17 @@ Parses chat text for the proper chat type and optionally sends it.
 * Shared
 **Example:**
 ```lua
--- Parse chat messages and log "/me" actions to the console
-hook.Add("PlayerSay", "LogActions", function(ply, text)
-local class, parsed = lia.chat.parse(ply, text)
-if class == "me" then
-print(ply:Name() .. " performs action: " .. parsed)
-end
-end)
+    -- Parse chat messages and log "/me" actions to the console
+    hook.Add("PlayerSay", "LogActions", function(ply, text)
+        local class, parsed = lia.chat.parse(ply, text)
+        if class == "me" then
+            print(ply:Name() .. " performs action: " .. parsed)
+        end
+    end)
 ```
+
+---
+
 
 ### lia.chat.send(speaker, chatType, text, anonymous, receivers)
 
@@ -86,6 +95,6 @@ Broadcasts a chat message to all eligible receivers.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.chat.send
-lia.chat.send(client, "ic", "Hello")
+    -- This snippet demonstrates a common usage of lia.chat.send
+    lia.chat.send(client, "ic", "Hello")
 ```

--- a/docs/docs/libraries/lia.classes.md
+++ b/docs/docs/libraries/lia.classes.md
@@ -21,9 +21,12 @@ Loads all class definitions from the given directory and stores them in lia.clas
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.loadFromDir
-lia.class.loadFromDir("schema/classes")
+    -- This snippet demonstrates a common usage of lia.class.loadFromDir
+    lia.class.loadFromDir("schema/classes")
 ```
+
+---
+
 
 ### lia.class.canBe(client, class)
 
@@ -39,9 +42,12 @@ Determines if the given client may become the specified class.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.canBe
-local allowed = lia.class.canBe(client, classID)
+    -- This snippet demonstrates a common usage of lia.class.canBe
+    local allowed = lia.class.canBe(client, classID)
 ```
+
+---
+
 
 ### lia.class.get(identifier)
 
@@ -56,9 +62,12 @@ Retrieves the class table associated with the given identifier.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.get
-local classData = lia.class.get(1)
+    -- This snippet demonstrates a common usage of lia.class.get
+    local classData = lia.class.get(1)
 ```
+
+---
+
 
 ### lia.class.getPlayers(class)
 
@@ -73,9 +82,12 @@ Returns a table of players whose characters belong to the given class.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.getPlayers
-local players = lia.class.getPlayers(classID)
+    -- This snippet demonstrates a common usage of lia.class.getPlayers
+    local players = lia.class.getPlayers(classID)
 ```
+
+---
+
 
 ### lia.class.getPlayerCount(class)
 
@@ -90,9 +102,12 @@ Counts how many players belong to the given class.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.getPlayerCount
-local count = lia.class.getPlayerCount(classID)
+    -- This snippet demonstrates a common usage of lia.class.getPlayerCount
+    local count = lia.class.getPlayerCount(classID)
 ```
+
+---
+
 
 ### lia.class.retrieveClass(class)
 
@@ -107,9 +122,12 @@ Searches the class list for a class whose ID or name matches the given text.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.retrieveClass
-local id = lia.class.retrieveClass("police")
+    -- This snippet demonstrates a common usage of lia.class.retrieveClass
+    local id = lia.class.retrieveClass("police")
 ```
+
+---
+
 
 ### lia.class.hasWhitelist(class)
 
@@ -124,8 +142,8 @@ Returns whether the specified class requires a whitelist.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.class.hasWhitelist
-if lia.class.hasWhitelist(classID) then
-print("Whitelist required")
-end
+    -- This snippet demonstrates a common usage of lia.class.hasWhitelist
+    if lia.class.hasWhitelist(classID) then
+        print("Whitelist required")
+    end
 ```

--- a/docs/docs/libraries/lia.color.md
+++ b/docs/docs/libraries/lia.color.md
@@ -24,9 +24,12 @@ Registers a named color for later lookup.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.color.register
-lia.color.register("myRed", Color(255,0,0))
+    -- This snippet demonstrates a common usage of lia.color.register
+    lia.color.register("myRed", Color(255,0,0))
 ```
+
+---
+
 
 ### lia.color.Adjust(color, rOffset, gOffset, bOffset, aOffset)
 
@@ -45,9 +48,12 @@ Creates a new color by applying offsets to each channel.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.color.Adjust
-local lighter = lia.color.Adjust(Color(50,50,50), 10,10,10)
+    -- This snippet demonstrates a common usage of lia.color.Adjust
+    local lighter = lia.color.Adjust(Color(50,50,50), 10,10,10)
 ```
+
+---
+
 
 ### lia.color.ReturnMainAdjustedColors()
 
@@ -62,6 +68,6 @@ Returns a table of commonly used UI colors derived from the base config color.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.color.ReturnMainAdjustedColors
-local uiColors = lia.color.ReturnMainAdjustedColors()
+    -- This snippet demonstrates a common usage of lia.color.ReturnMainAdjustedColors
+    local uiColors = lia.color.ReturnMainAdjustedColors()
 ```

--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -48,10 +48,13 @@ Quoted sections are treated as single arguments.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.command.extractArgs
-local args = lia.command.extractArgs('/mycommand "quoted arg" anotherArg')
--- args = {"quoted arg", "anotherArg"}
+    -- This snippet demonstrates a common usage of lia.command.extractArgs
+    local args = lia.command.extractArgs('/mycommand "quoted arg" anotherArg')
+    -- args = {"quoted arg", "anotherArg"}
 ```
+
+---
+
 
 ### lia.command.parseSyntaxFields
 
@@ -68,9 +71,12 @@ Each field contains a name and a type derived from the syntax.
 * Shared
 **Example:**
 ```lua
--- Extract field data from a syntax string
-local fields, valid = lia.command.parseSyntaxFields("[string Name] [number Time]")
+    -- Extract field data from a syntax string
+    local fields, valid = lia.command.parseSyntaxFields("[string Name] [number Time]")
 ```
+
+---
+
 
 ### lia.command.run
 
@@ -88,9 +94,12 @@ If the command returns a string, it notifies the client (if valid).
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.command.run
-lia.command.run(player, "mycommand", {"arg1", "arg2"})
+    -- This snippet demonstrates a common usage of lia.command.run
+    lia.command.run(player, "mycommand", {"arg1", "arg2"})
 ```
+
+---
+
 
 ### lia.command.parse
 
@@ -109,9 +118,12 @@ and arguments if provided. If parsed successfully, the command is executed.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.command.parse
-lia.command.parse(player, "/mycommand arg1 arg2")
+    -- This snippet demonstrates a common usage of lia.command.parse
+    lia.command.parse(player, "/mycommand arg1 arg2")
 ```
+
+---
+
 
 ### lia.command.send
 
@@ -128,9 +140,12 @@ Garry's Mod net library. The server will then execute the command.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.command.send
-lia.command.send("mycommand", "arg1", "arg2")
+    -- This snippet demonstrates a common usage of lia.command.send
+    lia.command.send("mycommand", "arg1", "arg2")
 ```
+
+---
+
 
 ### lia.command.openArgumentPrompt
 

--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -27,17 +27,20 @@ Registers a new config option with the given key, display name, default value, a
 * Shared
 **Example:**
 ```lua
--- Register a config option with a callback that prints when it changes
-lia.config.add(
-"maxPlayers",                 -- unique key
-"Maximum Players",            -- name shown in the menu
-64,                            -- default value
-function(old, new)
-print("Player limit updated from", old, "to", new)
-end,
-{category = "Server"}
-)
+    -- Register a config option with a callback that prints when it changes
+    lia.config.add(
+    "maxPlayers",                 -- unique key
+    "Maximum Players",            -- name shown in the menu
+    64,                            -- default value
+    function(old, new)
+        print("Player limit updated from", old, "to", new)
+    end,
+    {category = "Server"}
+    )
 ```
+
+---
+
 
 ### lia.config.setDefault(key, value)
 
@@ -53,9 +56,12 @@ Overrides the default value of an existing config.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.setDefault
-lia.config.setDefault("maxPlayers", 32)
+    -- This snippet demonstrates a common usage of lia.config.setDefault
+    lia.config.setDefault("maxPlayers", 32)
 ```
+
+---
+
 
 ### lia.config.forceSet(key, value, noSave)
 
@@ -72,9 +78,12 @@ Forces a config value without triggering networking or callback if 'noSave' is t
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.forceSet
-lia.config.forceSet("someSetting", true, true)
+    -- This snippet demonstrates a common usage of lia.config.forceSet
+    lia.config.forceSet("someSetting", true, true)
 ```
+
+---
+
 
 ### lia.config.set(key, value)
 
@@ -90,9 +99,12 @@ Sets a config value, runs callback, and handles networking (if on server). Also 
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.set
-lia.config.set("maxPlayers", 24)
+    -- This snippet demonstrates a common usage of lia.config.set
+    lia.config.set("maxPlayers", 24)
 ```
+
+---
+
 
 ### lia.config.get(key, default)
 
@@ -108,9 +120,12 @@ Retrieves the current value of a config, or returns a default if neither value n
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.get
-local players = lia.config.get("maxPlayers", 64)
+    -- This snippet demonstrates a common usage of lia.config.get
+    local players = lia.config.get("maxPlayers", 64)
 ```
+
+---
+
 
 ### lia.config.load()
 
@@ -129,9 +144,12 @@ Triggers "InitializedConfig" hook once done.
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.load
-lia.config.load()
+    -- This snippet demonstrates a common usage of lia.config.load
+    lia.config.load()
 ```
+
+---
+
 
 ### lia.config.getChangedValues()
 
@@ -146,9 +164,12 @@ Returns a table of all config entries where the current value differs from the d
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.getChangedValues
-local changed = lia.config.getChangedValues()
+    -- This snippet demonstrates a common usage of lia.config.getChangedValues
+    local changed = lia.config.getChangedValues()
 ```
+
+---
+
 
 ### lia.config.send(client)
 
@@ -163,9 +184,12 @@ Sends current changed config values to a specified client.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.send
-lia.config.send(client)
+    -- This snippet demonstrates a common usage of lia.config.send
+    lia.config.send(client)
 ```
+
+---
+
 
 ### lia.config.save()
 
@@ -180,6 +204,6 @@ Saves all changed config values to persistent storage.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.config.save
-lia.config.save()
+    -- This snippet demonstrates a common usage of lia.config.save
+    lia.config.save()
 ```

--- a/docs/docs/libraries/lia.currency.md
+++ b/docs/docs/libraries/lia.currency.md
@@ -25,9 +25,12 @@ form; otherwise, it returns the plural form.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.currency.get
-lia.currency.get(10)  -- e.g., "$10 dollars"
+    -- This snippet demonstrates a common usage of lia.currency.get
+    lia.currency.get(10)  -- e.g., "$10 dollars"
 ```
+
+---
+
 
 ### lia.currency.spawn
 
@@ -45,6 +48,6 @@ Validates the position and ensures the amount is a non-negative number.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.currency.spawn
-lia.currency.spawn(Vector(0, 0, 0), 100)
+    -- This snippet demonstrates a common usage of lia.currency.spawn
+    lia.currency.spawn(Vector(0, 0, 0), 100)
 ```

--- a/docs/docs/libraries/lia.darkrp.md
+++ b/docs/docs/libraries/lia.darkrp.md
@@ -25,11 +25,14 @@ and props.
 * boolean – True if the position is clear, false otherwise.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.isEmpty
-if lia.darkrp.isEmpty(Vector(0,0,0)) then
-print("Spawn point is clear")
-end
+    -- This snippet demonstrates a common usage of lia.darkrp.isEmpty
+    if lia.darkrp.isEmpty(Vector(0,0,0)) then
+        print("Spawn point is clear")
+    end
 ```
+
+---
+
 
 ### lia.darkrp.findEmptyPos(startPos, entitiesToIgnore, maxDistance, searchStep, checkArea)
 
@@ -48,9 +51,12 @@ Finds a nearby position that is unobstructed by players or props.
 * Vector – A position considered safe for spawning.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.findEmptyPos
-local pos = lia.darkrp.findEmptyPos(Vector(0,0,0), nil, 128, 16, Vector(0,0,32))
+    -- This snippet demonstrates a common usage of lia.darkrp.findEmptyPos
+    local pos = lia.darkrp.findEmptyPos(Vector(0,0,0), nil, 128, 16, Vector(0,0,32))
 ```
+
+---
+
 
 ### lia.darkrp.notify(client, _, _, message)
 
@@ -67,9 +73,12 @@ lia's notify system.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.notify
-lia.darkrp.notify(player.GetAll()[1], nil, nil, "Hello!")
+    -- This snippet demonstrates a common usage of lia.darkrp.notify
+    lia.darkrp.notify(player.GetAll()[1], nil, nil, "Hello!")
 ```
+
+---
+
 
 ### lia.darkrp.textWrap(text, fontName, maxLineWidth)
 
@@ -87,9 +96,12 @@ when drawn with the given font.
 * string – The wrapped text with newline characters inserted.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.textWrap
-local wrapped = lia.darkrp.textWrap("Some very long text", "DermaDefault", 150)
+    -- This snippet demonstrates a common usage of lia.darkrp.textWrap
+    local wrapped = lia.darkrp.textWrap("Some very long text", "DermaDefault", 150)
 ```
+
+---
+
 
 ### lia.darkrp.formatMoney(amount)
 
@@ -104,9 +116,12 @@ Converts a numeric amount to a formatted currency string.
 * string – The formatted currency value.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of print
-print(lia.darkrp.formatMoney(2500))
+    -- This snippet demonstrates a common usage of print
+    print(lia.darkrp.formatMoney(2500))
 ```
+
+---
+
 
 ### lia.darkrp.createEntity(name, data)
 
@@ -124,9 +139,12 @@ through lia's item system.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.createEntity
-lia.darkrp.createEntity("Fuel", {model = "models/props_c17/oildrum001.mdl", price = 50})
+    -- This snippet demonstrates a common usage of lia.darkrp.createEntity
+    lia.darkrp.createEntity("Fuel", {model = "models/props_c17/oildrum001.mdl", price = 50})
 ```
+
+---
+
 
 ### lia.darkrp.createCategory()
 
@@ -141,6 +159,6 @@ Placeholder for DarkRP category creation. Currently unused.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.darkrp.createCategory
-lia.darkrp.createCategory()
+    -- This snippet demonstrates a common usage of lia.darkrp.createCategory
+    lia.darkrp.createCategory()
 ```

--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -28,13 +28,16 @@ Also caches the value in lia.data.stored.
 * Shared
 **Example:**
 ```lua
--- Save the admin's position as the global spawn point with a command
-concommand.Add("save_spawn", function(ply)
-if ply:IsAdmin() then
-lia.data.set("spawn_pos", ply:GetPos(), true)
-end
-end)
+    -- Save the admin's position as the global spawn point with a command
+    concommand.Add("save_spawn", function(ply)
+        if ply:IsAdmin() then
+            lia.data.set("spawn_pos", ply:GetPos(), true)
+        end
+    end)
 ```
+
+---
+
 
 ### lia.data.delete(key, global, ignoreMap)
 
@@ -52,9 +55,12 @@ Also removes the value from the cached storage.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.data.delete
-lia.data.delete("spawn_pos")
+    -- This snippet demonstrates a common usage of lia.data.delete
+    lia.data.delete("spawn_pos")
 ```
+
+---
+
 
 ### lia.data.get(key, default, global, ignoreMap, refresh)
 
@@ -75,11 +81,11 @@ Otherwise, reads from the file, decodes, and caches the value.
 * Shared
 **Example:**
 ```lua
--- Teleport players to the saved spawn point when they spawn
-hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
-local pos = lia.data.get("spawn_pos", Vector(0, 0, 0), true)
-if pos then
-ply:SetPos(pos)
-end
-end)
+    -- Teleport players to the saved spawn point when they spawn
+    hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
+        local pos = lia.data.get("spawn_pos", Vector(0, 0, 0), true)
+        if pos then
+            ply:SetPos(pos)
+        end
+    end)
 ```

--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -26,11 +26,14 @@ or re-establish one.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.connect
-lia.db.connect(function()
-print("Database connected")
-end)
+    -- This snippet demonstrates a common usage of lia.db.connect
+    lia.db.connect(function()
+        print("Database connected")
+    end)
 ```
+
+---
+
 
 ### lia.db.wipeTables(callback)
 
@@ -46,11 +49,14 @@ tables. This action is irreversible and will remove all stored data.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.wipeTables
-lia.db.wipeTables(function()
-print("Tables wiped")
-end)
+    -- This snippet demonstrates a common usage of lia.db.wipeTables
+    lia.db.wipeTables(function()
+        print("Tables wiped")
+    end)
 ```
+
+---
+
 
 ### lia.db.loadTables()
 
@@ -66,9 +72,12 @@ storing Lilia data. This ensures the schema is properly set up.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.loadTables
-lia.db.loadTables()
+    -- This snippet demonstrates a common usage of lia.db.loadTables
+    lia.db.loadTables()
 ```
+
+---
+
 
 ### lia.db.waitForTablesToLoad()
 
@@ -84,11 +93,14 @@ This allows asynchronous code to wait for table creation before proceeding.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.waitForTablesToLoad
-lia.db.waitForTablesToLoad():next(function()
-print("Tables loaded")
-end)
+    -- This snippet demonstrates a common usage of lia.db.waitForTablesToLoad
+    lia.db.waitForTablesToLoad():next(function()
+        print("Tables loaded")
+    end)
 ```
+
+---
+
 
 ### lia.db.convertDataType(value, noEscape)
 
@@ -106,9 +118,12 @@ unless noEscape is set.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.convertDataType
-local str = lia.db.convertDataType({name = "Lilia"})
+    -- This snippet demonstrates a common usage of lia.db.convertDataType
+    local str = lia.db.convertDataType({name = "Lilia"})
 ```
+
+---
+
 
 ### lia.db.insertTable(value, callback, dbTable)
 
@@ -126,11 +141,14 @@ The callback is invoked after the insert query is complete.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.insertTable
-lia.db.insertTable({name = "Test"}, function(id)
-print("Inserted", id)
-end, "characters")
+    -- This snippet demonstrates a common usage of lia.db.insertTable
+    lia.db.insertTable({name = "Test"}, function(id)
+        print("Inserted", id)
+    end, "characters")
 ```
+
+---
+
 
 ### lia.db.updateTable(value, callback, dbTable, condition)
 
@@ -149,11 +167,14 @@ provided condition. The callback is invoked once the update query finishes.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.updateTable
-lia.db.updateTable({name = "Updated"}, function()
-print("Row updated")
-end, "characters", "id = 1")
+    -- This snippet demonstrates a common usage of lia.db.updateTable
+    lia.db.updateTable({name = "Updated"}, function()
+        print("Row updated")
+    end, "characters", "id = 1")
 ```
+
+---
+
 
 ### lia.db.select(fields, dbTable, condition, limit)
 
@@ -173,11 +194,14 @@ object that resolves with the query results.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.select
-lia.db.select("*", "characters", "id = 1"):next(function(rows)
-PrintTable(rows)
-end)
+    -- This snippet demonstrates a common usage of lia.db.select
+    lia.db.select("*", "characters", "id = 1"):next(function(rows)
+        PrintTable(rows)
+    end)
 ```
+
+---
+
 
 ### lia.db.upsert(value, dbTable)
 
@@ -195,9 +219,12 @@ Returns a deferred object that resolves when the operation completes.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.upsert
-lia.db.upsert({id = 1, name = "John"}, "characters")
+    -- This snippet demonstrates a common usage of lia.db.upsert
+    lia.db.upsert({id = 1, name = "John"}, "characters")
 ```
+
+---
+
 
 ### lia.db.delete(dbTable, condition)
 
@@ -214,11 +241,14 @@ If no condition is specified, all rows are deleted. Returns a deferred object.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.delete
-lia.db.delete("characters", "id = 1"):next(function()
-print("Row deleted")
-end)
+    -- This snippet demonstrates a common usage of lia.db.delete
+    lia.db.delete("characters", "id = 1"):next(function()
+        print("Row deleted")
+    end)
 ```
+
+---
+
 
 ### lia.db.GetCharacterTable(callback)
 
@@ -234,6 +264,6 @@ This is useful for debugging or database maintenance tasks.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.db.GetCharacterTable
-lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)
+    -- This snippet demonstrates a common usage of lia.db.GetCharacterTable
+    lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)
 ```

--- a/docs/docs/libraries/lia.factions.md
+++ b/docs/docs/libraries/lia.factions.md
@@ -25,9 +25,12 @@ Each faction file should define a FACTION table with properties such as name, de
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.loadFromDir
-lia.faction.loadFromDir("path/to/factions")
+    -- This snippet demonstrates a common usage of lia.faction.loadFromDir
+    lia.faction.loadFromDir("path/to/factions")
 ```
+
+---
+
 
 ### lia.faction.get
 
@@ -42,9 +45,12 @@ Retrieves a faction by its index or unique identifier.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.get
-local faction = lia.faction.get("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.get
+    local faction = lia.faction.get("citizen")
 ```
+
+---
+
 
 ### lia.faction.getIndex
 
@@ -59,9 +65,12 @@ Retrieves the index of a faction by its unique identifier.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getIndex
-local index = lia.faction.getIndex("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getIndex
+    local index = lia.faction.getIndex("citizen")
 ```
+
+---
+
 
 ### lia.faction.getClasses
 
@@ -76,9 +85,12 @@ Retrieves a list of classes associated with the specified faction.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getClasses
-local classes = lia.faction.getClasses("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getClasses
+    local classes = lia.faction.getClasses("citizen")
 ```
+
+---
+
 
 ### lia.faction.getPlayers
 
@@ -93,9 +105,12 @@ Retrieves all player entities whose characters belong to the specified faction.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getPlayers
-local players = lia.faction.getPlayers("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getPlayers
+    local players = lia.faction.getPlayers("citizen")
 ```
+
+---
+
 
 ### lia.faction.getPlayerCount
 
@@ -110,9 +125,12 @@ Counts the number of players whose characters belong to the specified faction.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getPlayerCount
-local count = lia.faction.getPlayerCount("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getPlayerCount
+    local count = lia.faction.getPlayerCount("citizen")
 ```
+
+---
+
 
 ### lia.faction.isFactionCategory
 
@@ -128,9 +146,12 @@ Checks if the specified faction is a member of a given category.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.isFactionCategory
-local isMember = lia.faction.isFactionCategory("citizen", {"citizen", "veteran"})
+    -- This snippet demonstrates a common usage of lia.faction.isFactionCategory
+    local isMember = lia.faction.isFactionCategory("citizen", {"citizen", "veteran"})
 ```
+
+---
+
 
 ### lia.faction.jobGenerate
 
@@ -151,9 +172,12 @@ Pre-caches the faction models.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.jobGenerate
-local faction = lia.faction.jobGenerate(2, "Police", Color(0, 0, 255), false, {"models/player/police.mdl"})
+    -- This snippet demonstrates a common usage of lia.faction.jobGenerate
+    local faction = lia.faction.jobGenerate(2, "Police", Color(0, 0, 255), false, {"models/player/police.mdl"})
 ```
+
+---
+
 
 ### lia.faction.formatModelData
 
@@ -169,9 +193,12 @@ Iterates through each faction's model data and applies formatting to ensure prop
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.formatModelData
-lia.faction.formatModelData()
+    -- This snippet demonstrates a common usage of lia.faction.formatModelData
+    lia.faction.formatModelData()
 ```
+
+---
+
 
 ### lia.faction.getCategories
 
@@ -187,9 +214,12 @@ Categories are determined by keys in the faction's models table that are strings
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getCategories
-local categories = lia.faction.getCategories("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getCategories
+    local categories = lia.faction.getCategories("citizen")
 ```
+
+---
+
 
 ### lia.faction.getModelsFromCategory
 
@@ -205,9 +235,12 @@ Retrieves models from a specified category for a given faction.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getModelsFromCategory
-local models = lia.faction.getModelsFromCategory("citizen", "special")
+    -- This snippet demonstrates a common usage of lia.faction.getModelsFromCategory
+    local models = lia.faction.getModelsFromCategory("citizen", "special")
 ```
+
+---
+
 
 ### lia.faction.getDefaultClass
 
@@ -223,9 +256,12 @@ Searches through the class list for the first class that is marked as default fo
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.getDefaultClass
-local defaultClass = lia.faction.getDefaultClass("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.getDefaultClass
+    local defaultClass = lia.faction.getDefaultClass("citizen")
 ```
+
+---
+
 
 ### lia.faction.hasWhitelist
 
@@ -241,6 +277,6 @@ Checks the local whitelist data against the faction's uniqueID.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.faction.hasWhitelist
-local whitelisted = lia.faction.hasWhitelist("citizen")
+    -- This snippet demonstrates a common usage of lia.faction.hasWhitelist
+    local whitelisted = lia.faction.hasWhitelist("citizen")
 ```

--- a/docs/docs/libraries/lia.flags.md
+++ b/docs/docs/libraries/lia.flags.md
@@ -25,9 +25,12 @@ Each flag has a description and an optional callback that is executed when the f
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.flag.add
-lia.flag.add("C", "Spawn vehicles.")
+    -- This snippet demonstrates a common usage of lia.flag.add
+    lia.flag.add("C", "Spawn vehicles.")
 ```
+
+---
+
 
 ### lia.flag.onSpawn
 
@@ -43,6 +46,6 @@ the associated callbacks for each flag that the character possesses.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.flag.onSpawn
-lia.flag.onSpawn(player)
+    -- This snippet demonstrates a common usage of lia.flag.onSpawn
+    lia.flag.onSpawn(player)
 ```

--- a/docs/docs/libraries/lia.fonts.md
+++ b/docs/docs/libraries/lia.fonts.md
@@ -24,9 +24,12 @@ Creates and stores a font using surface.CreateFont for later refresh.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.font.register
-lia.font.register("MyFont", {font = "Arial", size = 16})
+    -- This snippet demonstrates a common usage of lia.font.register
+    lia.font.register("MyFont", {font = "Arial", size = 16})
 ```
+
+---
+
 
 ### lia.font.getAvailableFonts()
 
@@ -41,10 +44,13 @@ Returns a sorted list of font names that have been registered.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.font.getAvailableFonts
-local fonts = lia.font.getAvailableFonts()
-PrintTable(fonts)
+    -- This snippet demonstrates a common usage of lia.font.getAvailableFonts
+    local fonts = lia.font.getAvailableFonts()
+    PrintTable(fonts)
 ```
+
+---
+
 
 ### lia.font.refresh()
 
@@ -59,6 +65,6 @@ Recreates all stored fonts. Called when font related config values change.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.font.refresh
-lia.font.refresh()
+    -- This snippet demonstrates a common usage of lia.font.refresh
+    lia.font.refresh()
 ```

--- a/docs/docs/libraries/lia.inventory.md
+++ b/docs/docs/libraries/lia.inventory.md
@@ -24,9 +24,12 @@ Registers a new inventory type.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.newType
-lia.inventory.newType("bag", {className = "liaBag"})
+    -- This snippet demonstrates a common usage of lia.inventory.newType
+    lia.inventory.newType("bag", {className = "liaBag"})
 ```
+
+---
+
 
 ### lia.inventory.new(typeID)
 
@@ -41,9 +44,12 @@ Instantiates a new inventory instance.
 * table
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.new
-local inv = lia.inventory.new("bag")
+    -- This snippet demonstrates a common usage of lia.inventory.new
+    local inv = lia.inventory.new("bag")
 ```
+
+---
+
 
 ### lia.inventory.loadByID(id, noCache)
 
@@ -58,9 +64,12 @@ Loads an inventory by ID (cached or via custom loader).
 * deferred
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.loadByID
-lia.inventory.loadByID(1):next(function(inv) print(inv) end)
+    -- This snippet demonstrates a common usage of lia.inventory.loadByID
+    lia.inventory.loadByID(1):next(function(inv) print(inv) end)
 ```
+
+---
+
 
 ### lia.inventory.loadFromDefaultStorage(id, noCache)
 
@@ -75,9 +84,12 @@ Default database loader.
 * deferred
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.loadFromDefaultStorage
-lia.inventory.loadFromDefaultStorage(1)
+    -- This snippet demonstrates a common usage of lia.inventory.loadFromDefaultStorage
+    lia.inventory.loadFromDefaultStorage(1)
 ```
+
+---
+
 
 ### lia.inventory.instance(typeID, initialData)
 
@@ -92,9 +104,12 @@ Creates & persists a new inventory instance.
 * deferred
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.instance
-lia.inventory.instance("bag", {charID = 1})
+    -- This snippet demonstrates a common usage of lia.inventory.instance
+    lia.inventory.instance("bag", {charID = 1})
 ```
+
+---
+
 
 ### lia.inventory.loadAllFromCharID(charID)
 
@@ -109,9 +124,12 @@ Loads all inventories for a character.
 * deferred
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.loadAllFromCharID
-lia.inventory.loadAllFromCharID(client:getChar():getID())
+    -- This snippet demonstrates a common usage of lia.inventory.loadAllFromCharID
+    lia.inventory.loadAllFromCharID(client:getChar():getID())
 ```
+
+---
+
 
 ### lia.inventory.deleteByID(id)
 
@@ -126,9 +144,12 @@ Deletes an inventory and its data.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.deleteByID
-lia.inventory.deleteByID(1)
+    -- This snippet demonstrates a common usage of lia.inventory.deleteByID
+    lia.inventory.deleteByID(1)
 ```
+
+---
+
 
 ### lia.inventory.cleanUpForCharacter(character)
 
@@ -143,9 +164,12 @@ Destroys all inventories for a character.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.cleanUpForCharacter
-lia.inventory.cleanUpForCharacter(client:getChar())
+    -- This snippet demonstrates a common usage of lia.inventory.cleanUpForCharacter
+    lia.inventory.cleanUpForCharacter(client:getChar())
 ```
+
+---
+
 
 ### lia.inventory.show(inventory, parent)
 
@@ -160,6 +184,6 @@ Displays inventory UI client‑side.
 * Panel
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.inventory.show
-local panel = lia.inventory.show(inv)
+    -- This snippet demonstrates a common usage of lia.inventory.show
+    local panel = lia.inventory.show(inv)
 ```

--- a/docs/docs/libraries/lia.item.md
+++ b/docs/docs/libraries/lia.item.md
@@ -23,9 +23,12 @@ Retrieves an item definition by its identifier, checking both lia.item.base and 
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.get
-local itemDef = lia.item.get("testItem")
+    -- This snippet demonstrates a common usage of lia.item.get
+    local itemDef = lia.item.get("testItem")
 ```
+
+---
+
 
 ### lia.item.getItemByID
 
@@ -42,12 +45,15 @@ or in the world.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.getItemByID
-local result = lia.item.getItemByID(42)
-if result then
-print("Item location: " .. result.location)
-end
+    -- This snippet demonstrates a common usage of lia.item.getItemByID
+    local result = lia.item.getItemByID(42)
+    if result then
+        print("Item location: " .. result.location)
+    end
 ```
+
+---
+
 
 ### lia.item.getInstancedItemByID
 
@@ -62,12 +68,15 @@ Retrieves the item instance table itself by its numeric ID without additional lo
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.getInstancedItemByID
-local itemInstance = lia.item.getInstancedItemByID(42)
-if itemInstance then
-print("Got item: " .. itemInstance.name)
-end
+    -- This snippet demonstrates a common usage of lia.item.getInstancedItemByID
+    local itemInstance = lia.item.getInstancedItemByID(42)
+    if itemInstance then
+        print("Got item: " .. itemInstance.name)
+    end
 ```
+
+---
+
 
 ### lia.item.getItemDataByID
 
@@ -82,12 +91,15 @@ Retrieves the 'data' table of an item instance by its numeric item ID.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.getItemDataByID
-local data = lia.item.getItemDataByID(42)
-if data then
-print("Item data found.")
-end
+    -- This snippet demonstrates a common usage of lia.item.getItemDataByID
+    local data = lia.item.getItemDataByID(42)
+    if data then
+        print("Item data found.")
+    end
 ```
+
+---
+
 
 ### lia.item.load
 
@@ -105,9 +117,12 @@ to register the item. Used for loading items from directory structures.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.load
-lia.item.load("items/base/sh_item_base.lua", nil, true)
+    -- This snippet demonstrates a common usage of lia.item.load
+    lia.item.load("items/base/sh_item_base.lua", nil, true)
 ```
+
+---
+
 
 ### lia.item.isItem
 
@@ -122,12 +137,15 @@ Checks if the given object is recognized as an item (via isItem flag).
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.isItem
-local result = lia.item.isItem(myObject)
-if result then
-print("It's an item!")
-end
+    -- This snippet demonstrates a common usage of lia.item.isItem
+    local result = lia.item.isItem(myObject)
+    if result then
+        print("It's an item!")
+    end
 ```
+
+---
+
 
 ### lia.item.getInv
 
@@ -142,12 +160,15 @@ Retrieves an inventory table by its ID from lia.item.inventories.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.getInv
-local inv = lia.item.getInv(5)
-if inv then
-print("Got inventory with ID 5")
-end
+    -- This snippet demonstrates a common usage of lia.item.getInv
+    local inv = lia.item.getInv(5)
+    if inv then
+        print("Got inventory with ID 5")
+    end
 ```
+
+---
+
 
 ### lia.item.register
 
@@ -167,9 +188,12 @@ and merges data from the specified base. Optionally includes the file if provide
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.register
-lia.item.register("special_item", "base_item", false, "path/to/item.lua")
+    -- This snippet demonstrates a common usage of lia.item.register
+    lia.item.register("special_item", "base_item", false, "path/to/item.lua")
 ```
+
+---
+
 
 ### lia.item.loadFromDir
 
@@ -185,9 +209,12 @@ then any folders (with base_ prefix usage), and finally any loose Lua files.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.loadFromDir
-lia.item.loadFromDir("lilia/gamemode/items")
+    -- This snippet demonstrates a common usage of lia.item.loadFromDir
+    lia.item.loadFromDir("lilia/gamemode/items")
 ```
+
+---
+
 
 ### lia.item.new
 
@@ -204,10 +231,13 @@ The new item is stored in lia.item.instances using the provided item ID.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.new
-local newItem = lia.item.new("testItem", 101)
-print(newItem.id) -- 101
+    -- This snippet demonstrates a common usage of lia.item.new
+    local newItem = lia.item.new("testItem", 101)
+    print(newItem.id) -- 101
 ```
+
+---
+
 
 ### lia.item.registerInv
 
@@ -225,9 +255,12 @@ becomes accessible for creation or usage in the system.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.registerInv
-lia.item.registerInv("smallInv", 4, 4)
+    -- This snippet demonstrates a common usage of lia.item.registerInv
+    lia.item.registerInv("smallInv", 4, 4)
 ```
+
+---
+
 
 ### lia.item.newInv
 
@@ -245,11 +278,14 @@ with the given character owner. Once created, it syncs the inventory to the owne
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.newInv
-lia.item.newInv(10, "smallInv", function(inventory)
-print("New inventory created:", inventory.id)
-end)
+    -- This snippet demonstrates a common usage of lia.item.newInv
+    lia.item.newInv(10, "smallInv", function(inventory)
+        print("New inventory created:", inventory.id)
+    end)
 ```
+
+---
+
 
 ### lia.item.createInv
 
@@ -267,10 +303,13 @@ then caches it in lia.inventory.instances.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.createInv
-local inv = lia.item.createInv(6, 6, 200)
-print("Created inventory with ID:", inv.id)
+    -- This snippet demonstrates a common usage of lia.item.createInv
+    local inv = lia.item.createInv(6, 6, 200)
+    print("Created inventory with ID:", inv.id)
 ```
+
+---
+
 
 ### lia.item.setItemDataByID
 
@@ -291,12 +330,15 @@ Optionally notifies receivers about the change.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.setItemDataByID
-local success, err = lia.item.setItemDataByID(50, "durability", 90)
-if not success then
-print("Error:", err)
-end
+    -- This snippet demonstrates a common usage of lia.item.setItemDataByID
+    local success, err = lia.item.setItemDataByID(50, "durability", 90)
+    if not success then
+        print("Error:", err)
+    end
 ```
+
+---
+
 
 ### lia.item.instance
 
@@ -317,11 +359,14 @@ Once the item is created, a new item object is constructed and returned via a de
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.instance
-lia.item.instance(1, "testItem", {someKey = "someValue"}):next(function(item)
-print("Item created with ID:", item.id)
-end)
+    -- This snippet demonstrates a common usage of lia.item.instance
+    lia.item.instance(1, "testItem", {someKey = "someValue"}):next(function(item)
+        print("Item created with ID:", item.id)
+    end)
 ```
+
+---
+
 
 ### lia.item.deleteByID
 
@@ -336,9 +381,12 @@ Deletes an item from the system (database and memory) by its numeric ID.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.deleteByID
-lia.item.deleteByID(42)
+    -- This snippet demonstrates a common usage of lia.item.deleteByID
+    lia.item.deleteByID(42)
 ```
+
+---
+
 
 ### lia.item.loadItemByID
 
@@ -354,11 +402,14 @@ item instances in memory. This is commonly used during inventory or character lo
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.loadItemByID
-lia.item.loadItemByID(42)
--- or
-lia.item.loadItemByID({10, 11, 12})
+    -- This snippet demonstrates a common usage of lia.item.loadItemByID
+    lia.item.loadItemByID(42)
+    -- or
+    lia.item.loadItemByID({10, 11, 12})
 ```
+
+---
+
 
 ### lia.item.spawn
 
@@ -378,11 +429,14 @@ entity in the world at the specified position/angles.
 * Server
 **Example:**
 ```lua
--- Spawn an item and use a callback to access the spawned entity
-lia.item.spawn("testItem", Vector(0, 0, 0), function(item, ent)
-print("Spawned", item.uniqueID, "at", ent:GetPos())
-end)
+    -- Spawn an item and use a callback to access the spawned entity
+    lia.item.spawn("testItem", Vector(0, 0, 0), function(item, ent)
+        print("Spawned", item.uniqueID, "at", ent:GetPos())
+    end)
 ```
+
+---
+
 
 ### lia.item.restoreInv
 
@@ -401,8 +455,8 @@ then sets its width/height data, optionally providing a callback once loaded.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.item.restoreInv
-lia.item.restoreInv(101, 5, 5, function(inv)
-print("Restored inventory with ID 101.")
-end)
+    -- This snippet demonstrates a common usage of lia.item.restoreInv
+    lia.item.restoreInv(101, 5, 5, function(inv)
+        print("Restored inventory with ID 101.")
+    end)
 ```

--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -29,9 +29,12 @@ Also maps the key code back to the action identifier for reverse lookup.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.keybind.add
-lia.keybind.add("space", "jump", function() print("Jump pressed!") end, function() print("Jump released!") end)
+    -- This snippet demonstrates a common usage of lia.keybind.add
+    lia.keybind.add("space", "jump", function() print("Jump pressed!") end, function() print("Jump released!") end)
 ```
+
+---
+
 
 ### lia.keybind.get(a, df)
 
@@ -49,9 +52,12 @@ or an optionally provided fallback value.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.keybind.get
-local jumpKey = lia.keybind.get("jump", KEY_SPACE)
+    -- This snippet demonstrates a common usage of lia.keybind.get
+    local jumpKey = lia.keybind.get("jump", KEY_SPACE)
 ```
+
+---
+
 
 ### lia.keybind.save()
 
@@ -71,9 +77,12 @@ and writes the keybind mapping (action identifiers to key codes) in JSON format.
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.keybind.save
-lia.keybind.save()
+    -- This snippet demonstrates a common usage of lia.keybind.save
+    lia.keybind.save()
 ```
+
+---
+
 
 ### lia.keybind.load()
 
@@ -95,6 +104,6 @@ Finally, it triggers the "InitializedKeybinds" hook.
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.keybind.load
-lia.keybind.load()
+    -- This snippet demonstrates a common usage of lia.keybind.load
+    lia.keybind.load()
 ```

--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -28,9 +28,12 @@ it is registered in lia.lang.names.
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.lang.loadFromDir
-lia.lang.loadFromDir("languages")
+    -- This snippet demonstrates a common usage of lia.lang.loadFromDir
+    lia.lang.loadFromDir("languages")
 ```
+
+---
+
 
 ### lia.lang.AddTable(name, tbl)
 
@@ -48,6 +51,6 @@ will be merged with the existing ones.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.lang.AddTable
-lia.lang.AddTable("english", {greeting = "Hello"})
+    -- This snippet demonstrates a common usage of lia.lang.AddTable
+    lia.lang.AddTable("english", {greeting = "Hello"})
 ```

--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -26,9 +26,12 @@ Creates the logs directory for the current active gamemode under "lilia/logs".
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.log.loadTables
-lia.log.loadTables()
+    -- This snippet demonstrates a common usage of lia.log.loadTables
+    lia.log.loadTables()
 ```
+
+---
+
 
 ### lia.log.addType(logType, func, category)
 
@@ -46,11 +49,14 @@ The registered function will be used later to generate log messages for that typ
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.log.addType
-lia.log.addType("mytype", function(client)
-return client:Name() .. " did something"
-end, "actions")
+    -- This snippet demonstrates a common usage of lia.log.addType
+    lia.log.addType("mytype", function(client)
+        return client:Name() .. " did something"
+    end, "actions")
 ```
+
+---
+
 
 ### lia.log.getString(client, logType, ...)
 
@@ -71,9 +77,12 @@ It calls the registered log function with the provided parameters.
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.log.getString
-local str, category = lia.log.getString(client, "mytype", "info")
+    -- This snippet demonstrates a common usage of lia.log.getString
+    local str, category = lia.log.getString(client, "mytype", "info")
 ```
+
+---
+
 
 ### lia.log.add(client, logType, ...)
 
@@ -91,6 +100,6 @@ and appends the log string to a log file corresponding to its category in the lo
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.log.add
-lia.log.add(client, "mytype", "info")
+    -- This snippet demonstrates a common usage of lia.log.add
+    lia.log.add(client, "mytype", "info")
 ```

--- a/docs/docs/libraries/lia.markup.md
+++ b/docs/docs/libraries/lia.markup.md
@@ -26,6 +26,6 @@ automatically wrap at that width.
 * MarkupObject – The parsed markup object with size information.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.markup.parse
-local object = lia.markup.parse("<color=255,0,0>Hello</color>", 200)
+    -- This snippet demonstrates a common usage of lia.markup.parse
+    local object = lia.markup.parse("<color=255,0,0>Hello</color>", 200)
 ```

--- a/docs/docs/libraries/lia.md
+++ b/docs/docs/libraries/lia.md
@@ -24,9 +24,12 @@ Includes a Lua file based on its realm. It determines the realm from the file na
 * The result of the include, if applicable.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.include
-lia.include("lilia/gamemode/core/libraries/util.lua", "shared")
+    -- This snippet demonstrates a common usage of lia.include
+    lia.include("lilia/gamemode/core/libraries/util.lua", "shared")
 ```
+
+---
+
 
 ### lia.includeDir(directory, fromLua, recursive, realm)
 
@@ -44,9 +47,12 @@ Includes all Lua files in a specified directory. If recursive is true, it traver
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.includeDir
-lia.includeDir("lilia/gamemode/core/libraries/shared/thirdparty", true, true)
+    -- This snippet demonstrates a common usage of lia.includeDir
+    lia.includeDir("lilia/gamemode/core/libraries/shared/thirdparty", true, true)
 ```
+
+---
+
 
 ### lia.includeGroupedDir(dir, raw, recursive, forceRealm)
 
@@ -64,9 +70,12 @@ Recursively includes all Lua files in a specified directory, preserving alphabet
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.includeGroupedDir
-lia.includeGroupedDir("core/modules", false, true, "shared")
+    -- This snippet demonstrates a common usage of lia.includeGroupedDir
+    lia.includeGroupedDir("core/modules", false, true, "shared")
 ```
+
+---
+
 
 ### lia.error(msg)
 
@@ -81,9 +90,12 @@ Prints a colored error message prefixed with "[Lilia]" to the console.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.error
-lia.error("Invalid configuration detected")
+    -- This snippet demonstrates a common usage of lia.error
+    lia.error("Invalid configuration detected")
 ```
+
+---
+
 
 ### lia.deprecated(methodName, callback)
 
@@ -99,9 +111,12 @@ Notifies that a method is deprecated and optionally runs a callback.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.deprecated
-lia.deprecated("OldFunction", function() print("Called fallback") end)
+    -- This snippet demonstrates a common usage of lia.deprecated
+    lia.deprecated("OldFunction", function() print("Called fallback") end)
 ```
+
+---
+
 
 ### lia.updater(msg)
 
@@ -116,9 +131,12 @@ Prints an updater message in cyan to the console with the Lilia prefix.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.updater
-lia.updater("Loading additional content...")
+    -- This snippet demonstrates a common usage of lia.updater
+    lia.updater("Loading additional content...")
 ```
+
+---
+
 
 ### lia.information(msg)
 
@@ -133,9 +151,12 @@ Prints an informational message with the Lilia prefix.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.information
-lia.information("Server started successfully")
+    -- This snippet demonstrates a common usage of lia.information
+    lia.information("Server started successfully")
 ```
+
+---
+
 
 ### lia.bootstrap(section, msg)
 
@@ -151,9 +172,12 @@ Logs a bootstrap message with a colored section tag for clarity.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.bootstrap
-lia.bootstrap("Database", "Connection established")
+    -- This snippet demonstrates a common usage of lia.bootstrap
+    lia.bootstrap("Database", "Connection established")
 ```
+
+---
+
 
 ### lia.includeEntities(path)
 
@@ -168,6 +192,6 @@ Includes entity files from the specified directory. It checks for standard entit
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.includeEntities
-lia.includeEntities("lilia/entities")
+    -- This snippet demonstrates a common usage of lia.includeEntities
+    lia.includeEntities("lilia/entities")
 ```

--- a/docs/docs/libraries/lia.menu.md
+++ b/docs/docs/libraries/lia.menu.md
@@ -26,9 +26,12 @@ an entity.
 * number – Identifier for the created menu entry.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.menu.add
-lia.menu.add({["Hello"] = function() print("Hi") end})
+    -- This snippet demonstrates a common usage of lia.menu.add
+    lia.menu.add({["Hello"] = function() print("Hi") end})
 ```
+
+---
+
 
 ### lia.menu.drawAll()
 
@@ -44,9 +47,12 @@ HUDPaint.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of hook.Add
-hook.Add("HUDPaint", "DrawMenus", lia.menu.drawAll)
+    -- This snippet demonstrates a common usage of hook.Add
+    hook.Add("HUDPaint", "DrawMenus", lia.menu.drawAll)
 ```
+
+---
+
 
 ### lia.menu.getActiveMenu()
 
@@ -63,9 +69,12 @@ or selected by the player.
 * callback (function|nil) – Callback for the hovered item.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.menu.getActiveMenu
-local id, callback = lia.menu.getActiveMenu()
+    -- This snippet demonstrates a common usage of lia.menu.getActiveMenu
+    local id, callback = lia.menu.getActiveMenu()
 ```
+
+---
+
 
 ### lia.menu.onButtonPressed(id, callback)
 
@@ -81,6 +90,6 @@ Removes the specified menu and runs its callback if provided.
 * boolean – True if a callback was executed.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.menu.onButtonPressed
-lia.menu.onButtonPressed(id)
+    -- This snippet demonstrates a common usage of lia.menu.onButtonPressed
+    lia.menu.onButtonPressed(id)
 ```

--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -28,9 +28,12 @@ It also registers the module in the module list if applicable.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.module.load
-lia.module.load("example", "lilia/modules/example", false)
+    -- This snippet demonstrates a common usage of lia.module.load
+    lia.module.load("example", "lilia/modules/example", false)
 ```
+
+---
+
 
 ### lia.module.initialize
 
@@ -46,9 +49,12 @@ then running the appropriate hooks after modules have been loaded.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.module.initialize
-lia.module.initialize()
+    -- This snippet demonstrates a common usage of lia.module.initialize
+    lia.module.initialize()
 ```
+
+---
+
 
 ### lia.module.loadFromDir
 
@@ -66,9 +72,12 @@ Non-Lua files are ignored.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.module.loadFromDir
-lia.module.loadFromDir("lilia/modules/core", "module")
+    -- This snippet demonstrates a common usage of lia.module.loadFromDir
+    lia.module.loadFromDir("lilia/modules/core", "module")
 ```
+
+---
+
 
 ### lia.module.get
 
@@ -83,6 +92,6 @@ Retrieves a module table by its identifier.
 * The module table if found, or nil if the module is not registered.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.module.get
-local mod = lia.module.get("schema")
+    -- This snippet demonstrates a common usage of lia.module.get
+    local mod = lia.module.get("schema")
 ```

--- a/docs/docs/libraries/lia.networking.md
+++ b/docs/docs/libraries/lia.networking.md
@@ -26,13 +26,16 @@ receiver is specified the update is only sent to those players.
 * nil
 **Example:**
 ```lua
--- Start a new round and only inform the winner
-local round = getNetVar("round", 0) + 1
-setNetVar("round", round)
-local winner = DetermineWinner()
-setNetVar("last_winner", winner, winner)
-hook.Run("RoundStarted", round)
+    -- Start a new round and only inform the winner
+    local round = getNetVar("round", 0) + 1
+    setNetVar("round", round)
+    local winner = DetermineWinner()
+    setNetVar("last_winner", winner, winner)
+    hook.Run("RoundStarted", round)
 ```
+
+---
+
 
 ### getNetVar(key, default)
 
@@ -48,12 +51,12 @@ Retrieves a global networked variable previously set by setNetVar.
 * any – Stored value or default.
 **Example:**
 ```lua
--- Inform a joining player of the current round and last winner
-hook.Add("PlayerInitialSpawn", "ShowRound", function(ply)
-ply:ChatPrint("Current round: " .. getNetVar("round", 0))
-local winner = getNetVar("last_winner")
-if IsValid(winner) then
-ply:ChatPrint("Last round won by " .. winner:Name())
-end
-end)
+    -- Inform a joining player of the current round and last winner
+    hook.Add("PlayerInitialSpawn", "ShowRound", function(ply)
+        ply:ChatPrint("Current round: " .. getNetVar("round", 0))
+        local winner = getNetVar("last_winner")
+        if IsValid(winner) then
+            ply:ChatPrint("Last round won by " .. winner:Name())
+        end
+    end)
 ```

--- a/docs/docs/libraries/lia.notice.md
+++ b/docs/docs/libraries/lia.notice.md
@@ -24,9 +24,12 @@ Sends a notification message to a specific player or all players.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.notices.notify
-lia.notices.notify("Server restarting", nil)
+    -- This snippet demonstrates a common usage of lia.notices.notify
+    lia.notices.notify("Server restarting", nil)
 ```
+
+---
+
 
 ### lia.notices.notifyLocalized(key, recipient, ...)
 
@@ -43,9 +46,12 @@ Sends a localized notification to a player or all players.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.notices.notifyLocalized
-lia.notices.notifyLocalized("welcome", client)
+    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
+    lia.notices.notifyLocalized("welcome", client)
 ```
+
+---
+
 
 ### lia.notices.notify(message)
 
@@ -60,9 +66,12 @@ Creates a visual notification panel on the client's screen.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.notices.notify
-lia.notices.notify("Item picked up")
+    -- This snippet demonstrates a common usage of lia.notices.notify
+    lia.notices.notify("Item picked up")
 ```
+
+---
+
 
 ### lia.notices.notifyLocalized(key, ...)
 
@@ -78,6 +87,6 @@ Displays a localized notification on the client's screen.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.notices.notifyLocalized
-lia.notices.notifyLocalized("item_picked_up")
+    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
+    lia.notices.notifyLocalized("item_picked_up")
 ```

--- a/docs/docs/libraries/lia.option.md
+++ b/docs/docs/libraries/lia.option.md
@@ -27,9 +27,12 @@ Adds a configuration option to the lia.option system.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.option.add
-lia.option.add("showHints", "Show Hints", "Display hints", true)
+    -- This snippet demonstrates a common usage of lia.option.add
+    lia.option.add("showHints", "Show Hints", "Display hints", true)
 ```
+
+---
+
 
 ### lia.option.set(key, value)
 
@@ -45,9 +48,12 @@ Sets the value of a specified option, saves locally, and optionally networks to 
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.option.set
-lia.option.set("showHints", false)
+    -- This snippet demonstrates a common usage of lia.option.set
+    lia.option.set("showHints", false)
 ```
+
+---
+
 
 ### lia.option.get(key, default)
 
@@ -63,9 +69,12 @@ Retrieves the value of a specified option, or returns a default if it doesn't ex
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.option.get
-local show = lia.option.get("showHints", true)
+    -- This snippet demonstrates a common usage of lia.option.get
+    local show = lia.option.get("showHints", true)
 ```
+
+---
+
 
 ### lia.option.save()
 
@@ -80,9 +89,12 @@ Saves all current option values to a file, named based on the server IP, within 
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.option.save
-lia.option.save()
+    -- This snippet demonstrates a common usage of lia.option.save
+    lia.option.save()
 ```
+
+---
+
 
 ### lia.option.load()
 
@@ -97,6 +109,6 @@ Loads saved option values from disk based on server IP and applies them to lia.o
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.option.load
-lia.option.load()
+    -- This snippet demonstrates a common usage of lia.option.load
+    lia.option.load()
 ```

--- a/docs/docs/libraries/lia.time.md
+++ b/docs/docs/libraries/lia.time.md
@@ -21,22 +21,25 @@ Returns a human-readable string indicating how long ago a given time occurred (e
 * Shared
 **Example:**
 ```lua
--- Greet players with the time since they last joined using persistence data
-hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
--- Retrieve the time this player last joined from persistent data
-local key = "lastLogin_" .. ply:SteamID64()
-local last = lia.data.get(key, nil, true)
+    -- Greet players with the time since they last joined using persistence data
+    hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
+        -- Retrieve the time this player last joined from persistent data
+        local key = "lastLogin_" .. ply:SteamID64()
+        local last = lia.data.get(key, nil, true)
 
-if last then
-ply:ChatPrint("Welcome back! You last joined " .. lia.time.TimeSince(last) .. ".")
-else
-ply:ChatPrint("Welcome for the first time!")
-end
+        if last then
+            ply:ChatPrint("Welcome back! You last joined " .. lia.time.TimeSince(last) .. ".")
+        else
+        ply:ChatPrint("Welcome for the first time!")
+    end
 
--- Store the current time for the next login
-lia.data.set(key, os.time(), true)
-end)
+    -- Store the current time for the next login
+    lia.data.set(key, os.time(), true)
+    end)
 ```
+
+---
+
 
 ### lia.time.toNumber
 
@@ -52,15 +55,18 @@ year, month, day, hour, min, sec. Defaults to current time if not provided.
 * Shared
 **Example:**
 ```lua
--- Schedule an event at a custom date and time using the parsed table
-local targetInfo = lia.time.toNumber("2025-04-01 12:30:00")
-local delay = os.time(targetInfo) - os.time()
-if delay > 0 then
-timer.Simple(delay, function()
-print("It's now April 1st, 2025, 12:30 PM!")
-end)
-end
+    -- Schedule an event at a custom date and time using the parsed table
+    local targetInfo = lia.time.toNumber("2025-04-01 12:30:00")
+    local delay = os.time(targetInfo) - os.time()
+    if delay > 0 then
+        timer.Simple(delay, function()
+            print("It's now April 1st, 2025, 12:30 PM!")
+        end)
+    end
 ```
+
+---
+
 
 ### lia.time.GetDate
 
@@ -78,14 +84,17 @@ Returns the full current date and time formatted based on the
 * Shared
 **Example:**
 ```lua
--- Announce the current server date and time to all players every hour
-timer.Create("ServerTimeAnnounce", 3600, 0, function()
-local dateString = lia.time.GetDate()
-for _, ply in player.Iterator() do
-ply:ChatPrint("Server time: " .. dateString)
-end
-end)
+    -- Announce the current server date and time to all players every hour
+    timer.Create("ServerTimeAnnounce", 3600, 0, function()
+        local dateString = lia.time.GetDate()
+        for _, ply in player.Iterator() do
+            ply:ChatPrint("Server time: " .. dateString)
+        end
+    end)
 ```
+
+---
+
 
 ### lia.time.GetHour
 
@@ -104,11 +113,11 @@ Returns the current hour formatted based on the
 * Shared
 **Example:**
 ```lua
--- Toggle an NPC's shop based on the in-game hour
-local hour = lia.time.GetHour()
-if hour >= 9 and hour < 17 then
-npc:SetNWBool("ShopOpen", true)
-else
-npc:SetNWBool("ShopOpen", false)
-end
+    -- Toggle an NPC's shop based on the in-game hour
+    local hour = lia.time.GetHour()
+    if hour >= 9 and hour < 17 then
+        npc:SetNWBool("ShopOpen", true)
+    else
+    npc:SetNWBool("ShopOpen", false)
+    end
 ```

--- a/docs/docs/libraries/lia.util.md
+++ b/docs/docs/libraries/lia.util.md
@@ -24,12 +24,15 @@ Finds and returns a table of players within a given spherical radius from an ori
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.FindPlayersInSphere
-local players = lia.util.FindPlayersInSphere(Vector(0, 0, 0), 200)
-for _, ply in ipairs(players) do
-print(ply:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.FindPlayersInSphere
+    local players = lia.util.FindPlayersInSphere(Vector(0, 0, 0), 200)
+    for _, ply in ipairs(players) do
+        print(ply:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayer
 
@@ -48,12 +51,15 @@ Attempts to find a player by identifier. The identifier can be STEAMID, SteamID6
     
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayer
-local foundPly = lia.util.findPlayer(someAdmin, "Bob")
-if foundPly then
-print("Found player: " .. foundPly:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayer
+    local foundPly = lia.util.findPlayer(someAdmin, "Bob")
+    if foundPly then
+        print("Found player: " .. foundPly:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayerItems
 
@@ -68,12 +74,15 @@ Finds all item entities in the world created by the specified player.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayerItems
-local items = lia.util.findPlayerItems(LocalPlayer())
-for _, item in ipairs(items) do
-print("Found item entity: " .. item:GetClass())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayerItems
+    local items = lia.util.findPlayerItems(LocalPlayer())
+    for _, item in ipairs(items) do
+        print("Found item entity: " .. item:GetClass())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayerItemsByClass
 
@@ -89,12 +98,15 @@ Finds all item entities in the world created by the specified player with a spec
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayerItemsByClass
-local items = lia.util.findPlayerItemsByClass(LocalPlayer(), "food_banana")
-for _, item in ipairs(items) do
-print("Found item entity: " .. item:GetClass())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayerItemsByClass
+    local items = lia.util.findPlayerItemsByClass(LocalPlayer(), "food_banana")
+    for _, item in ipairs(items) do
+        print("Found item entity: " .. item:GetClass())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayerEntities
 
@@ -110,12 +122,15 @@ Finds all entities in the world created by or associated with the specified play
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayerEntities
-local entities = lia.util.findPlayerEntities(LocalPlayer(), "prop_physics")
-for _, ent in ipairs(entities) do
-print("Found player entity: " .. ent:GetClass())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayerEntities
+    local entities = lia.util.findPlayerEntities(LocalPlayer(), "prop_physics")
+    for _, ent in ipairs(entities) do
+        print("Found player entity: " .. ent:GetClass())
+    end
 ```
+
+---
+
 
 ### lia.util.stringMatches
 
@@ -131,11 +146,14 @@ Checks if string a matches string b (case-insensitive, partial matches).
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.stringMatches
-if lia.util.stringMatches("Hello", "he") then
-print("Strings match!")
-end
+    -- This snippet demonstrates a common usage of lia.util.stringMatches
+    if lia.util.stringMatches("Hello", "he") then
+        print("Strings match!")
+    end
 ```
+
+---
+
 
 ### lia.util.getAdmins
 
@@ -148,12 +166,15 @@ Returns all players considered staff or admins, as determined by client:isStaff(
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.getAdmins
-local admins = lia.util.getAdmins()
-for _, admin in ipairs(admins) do
-print("Staff: " .. admin:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.getAdmins
+    local admins = lia.util.getAdmins()
+    for _, admin in ipairs(admins) do
+        print("Staff: " .. admin:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayerBySteamID64
 
@@ -168,12 +189,15 @@ Finds a player currently on the server by their SteamID64.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID64
-local ply = lia.util.findPlayerBySteamID64("76561198000000000")
-if ply then
-print("Found player: " .. ply:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID64
+    local ply = lia.util.findPlayerBySteamID64("76561198000000000")
+    if ply then
+        print("Found player: " .. ply:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.findPlayerBySteamID
 
@@ -188,12 +212,15 @@ Finds a player currently on the server by their SteamID.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID
-local ply = lia.util.findPlayerBySteamID("STEAM_0:1:23456789")
-if ply then
-print("Found player: " .. ply:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID
+    local ply = lia.util.findPlayerBySteamID("STEAM_0:1:23456789")
+    if ply then
+        print("Found player: " .. ply:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.canFit
 
@@ -211,12 +238,15 @@ Checks if a hull (defined by mins and maxs) can fit at the given position withou
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.canFit
-local canStand = lia.util.canFit(somePos, Vector(-16, -16, 0), Vector(16, 16, 72))
-if canStand then
-print("The player can stand here.")
-end
+    -- This snippet demonstrates a common usage of lia.util.canFit
+    local canStand = lia.util.canFit(somePos, Vector(-16, -16, 0), Vector(16, 16, 72))
+    if canStand then
+        print("The player can stand here.")
+    end
 ```
+
+---
+
 
 ### lia.util.playerInRadius
 
@@ -232,12 +262,15 @@ Finds and returns a table of players within a given radius from a position.
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.playerInRadius
-local playersNearby = lia.util.playerInRadius(Vector(0, 0, 0), 250)
-for _, ply in ipairs(playersNearby) do
-print("Nearby player: " .. ply:Name())
-end
+    -- This snippet demonstrates a common usage of lia.util.playerInRadius
+    local playersNearby = lia.util.playerInRadius(Vector(0, 0, 0), 250)
+    for _, ply in ipairs(playersNearby) do
+        print("Nearby player: " .. ply:Name())
+    end
 ```
+
+---
+
 
 ### lia.util.formatStringNamed
 
@@ -253,10 +286,13 @@ Formats a string with named or indexed placeholders. If a table is passed, uses 
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.formatStringNamed
-local result = lia.util.formatStringNamed("Hello, {name}!", {name = "Bob"})
-print(result) -- "Hello, Bob!"
+    -- This snippet demonstrates a common usage of lia.util.formatStringNamed
+    local result = lia.util.formatStringNamed("Hello, {name}!", {name = "Bob"})
+    print(result) -- "Hello, Bob!"
 ```
+
+---
+
 
 ### lia.util.getMaterial
 
@@ -272,11 +308,14 @@ Retrieves a cached Material for the specified path and parameters, to avoid repe
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.getMaterial
-local mat = lia.util.getMaterial("path/to/material", "noclamp smooth")
-surface.SetMaterial(mat)
-surface.DrawTexturedRect(0, 0, 100, 100)
+    -- This snippet demonstrates a common usage of lia.util.getMaterial
+    local mat = lia.util.getMaterial("path/to/material", "noclamp smooth")
+    surface.SetMaterial(mat)
+    surface.DrawTexturedRect(0, 0, 100, 100)
 ```
+
+---
+
 
 ### lia.util.findFaction
 
@@ -292,12 +331,15 @@ Finds a faction by name or uniqueID. If an exact identifier is found in lia.fact
 * Shared
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findFaction
-local faction = lia.util.findFaction(client, "citizen")
-if faction then
-print("Found faction: " .. faction.name)
-end
+    -- This snippet demonstrates a common usage of lia.util.findFaction
+    local faction = lia.util.findFaction(client, "citizen")
+    if faction then
+        print("Found faction: " .. faction.name)
+    end
 ```
+
+---
+
 
 ### lia.util.CreateTableUI
 
@@ -317,9 +359,12 @@ Sends a net message to the client to create a table UI with given data.
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.CreateTableUI
-lia.util.CreateTableUI(somePlayer, "My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, someData, someOptions, charID)
+    -- This snippet demonstrates a common usage of lia.util.CreateTableUI
+    lia.util.CreateTableUI(somePlayer, "My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, someData, someOptions, charID)
 ```
+
+---
+
 
 ### lia.util.findEmptySpace
 
@@ -339,12 +384,15 @@ Finds potential empty space positions around an entity using a grid-based approa
 * Server
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.findEmptySpace
-local positions = lia.util.findEmptySpace(someEntity, someFilter, 32, 3, 36, 5)
-for _, pos in ipairs(positions) do
-print("Empty space at: " .. tostring(pos))
-end
+    -- This snippet demonstrates a common usage of lia.util.findEmptySpace
+    local positions = lia.util.findEmptySpace(someEntity, someFilter, 32, 3, 36, 5)
+    for _, pos in ipairs(positions) do
+        print("Empty space at: " .. tostring(pos))
+    end
 ```
+
+---
+
 
 ### lia.util.ShadowText
 
@@ -367,9 +415,12 @@ Draws text with a shadow offset.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.ShadowText
-lia.util.ShadowText("Hello!", "DermaDefault", 100, 100, color_white, color_black, 2, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+    -- This snippet demonstrates a common usage of lia.util.ShadowText
+    lia.util.ShadowText("Hello!", "DermaDefault", 100, 100, color_white, color_black, 2, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
 ```
+
+---
+
 
 ### lia.util.DrawTextOutlined
 
@@ -391,9 +442,12 @@ Draws text with an outlined border.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.DrawTextOutlined
-lia.util.DrawTextOutlined("Outlined Text", "DermaLarge", 100, 200, color_white, TEXT_ALIGN_CENTER, 2, color_black)
+    -- This snippet demonstrates a common usage of lia.util.DrawTextOutlined
+    lia.util.DrawTextOutlined("Outlined Text", "DermaLarge", 100, 200, color_white, TEXT_ALIGN_CENTER, 2, color_black)
 ```
+
+---
+
 
 ### lia.util.DrawTip
 
@@ -415,9 +469,12 @@ Draws a tooltip-like shape with text in the center.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.DrawTip
-lia.util.DrawTip(100, 100, 200, 60, "This is a tip!", "DermaDefault", color_white, color_black)
+    -- This snippet demonstrates a common usage of lia.util.DrawTip
+    lia.util.DrawTip(100, 100, 200, 60, "This is a tip!", "DermaDefault", color_white, color_black)
 ```
+
+---
+
 
 ### lia.util.drawText
 
@@ -439,9 +496,12 @@ Draws text with a subtle shadow effect.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.drawText
-lia.util.drawText("Hello World", 200, 300, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, "liaGenericFont", 100)
+    -- This snippet demonstrates a common usage of lia.util.drawText
+    lia.util.drawText("Hello World", 200, 300, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, "liaGenericFont", 100)
 ```
+
+---
+
 
 ### lia.util.drawTexture
 
@@ -461,9 +521,12 @@ Draws a textured rectangle with the specified material.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.drawTexture
-lia.util.drawTexture("path/to/material", color_white, 50, 50, 64, 64)
+    -- This snippet demonstrates a common usage of lia.util.drawTexture
+    lia.util.drawTexture("path/to/material", color_white, 50, 50, 64, 64)
 ```
+
+---
+
 
 ### lia.util.skinFunc
 
@@ -480,9 +543,12 @@ Calls a skin function by name, passing the panel and any extra arguments.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.skinFunc
-lia.util.skinFunc("PaintButton", someButton, 10, 20)
+    -- This snippet demonstrates a common usage of lia.util.skinFunc
+    lia.util.skinFunc("PaintButton", someButton, 10, 20)
 ```
+
+---
+
 
 ### lia.util.wrapText
 
@@ -499,13 +565,16 @@ Wraps text to a maximum width, returning a table of lines and the maximum line w
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.wrapText
-local lines, maxW = lia.util.wrapText("Some long string that needs wrapping...", 200, "liaChatFont")
-for _, line in ipairs(lines) do
-print(line)
-end
-print("Max width: " .. maxW)
+    -- This snippet demonstrates a common usage of lia.util.wrapText
+    local lines, maxW = lia.util.wrapText("Some long string that needs wrapping...", 200, "liaChatFont")
+    for _, line in ipairs(lines) do
+        print(line)
+    end
+    print("Max width: " .. maxW)
 ```
+
+---
+
 
 ### lia.util.drawBlur
 
@@ -522,9 +591,12 @@ Draws a blur effect over the specified panel.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.drawBlur
-lia.util.drawBlur(somePanel, 5, 1)
+    -- This snippet demonstrates a common usage of lia.util.drawBlur
+    lia.util.drawBlur(somePanel, 5, 1)
 ```
+
+---
+
 
 ### lia.util.drawBlurAt
 
@@ -544,9 +616,12 @@ Draws a blur effect at a specified rectangle on the screen.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.drawBlurAt
-lia.util.drawBlurAt(100, 100, 200, 150, 5, 1)
+    -- This snippet demonstrates a common usage of lia.util.drawBlurAt
+    lia.util.drawBlurAt(100, 100, 200, 150, 5, 1)
 ```
+
+---
+
 
 ### lia.util.CreateTableUI
 
@@ -565,6 +640,6 @@ Creates and displays a table UI with given columns and data on the client side.
 * Client
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.util.CreateTableUI
-lia.util.CreateTableUI("My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, myData, myOptions, 1)
+    -- This snippet demonstrates a common usage of lia.util.CreateTableUI
+    lia.util.CreateTableUI("My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, myData, myOptions, 1)
 ```

--- a/docs/docs/libraries/lia.webimage.md
+++ b/docs/docs/libraries/lia.webimage.md
@@ -28,9 +28,12 @@ resulting Material.
 * nil
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.webimage.register
-lia.webimage.register("logo.png", "https://example.com/logo.png")
+    -- This snippet demonstrates a common usage of lia.webimage.register
+    lia.webimage.register("logo.png", "https://example.com/logo.png")
 ```
+
+---
+
 
 ### lia.webimage.get(name, flags)
 
@@ -47,9 +50,12 @@ the cache.
 * Material|nil – The image material or nil if missing.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.webimage.get
-local mat = lia.webimage.get("logo.png")
+    -- This snippet demonstrates a common usage of lia.webimage.get
+    local mat = lia.webimage.get("logo.png")
 ```
+
+---
+
 
 HTTPS URL Handling
     
@@ -60,9 +66,9 @@ automatically downloaded via `lia.webimage.register` and cached before
 the material is returned or applied.
 **Example:**
 ```lua
--- Load a material directly from the web
-local mat = Material("https://example.com/icon.png")
+    -- Load a material directly from the web
+    local mat = Material("https://example.com/icon.png")
 
--- Apply a remote image to a button
-button:SetImage("https://example.com/icon.png")
+    -- Apply a remote image to a button
+    button:SetImage("https://example.com/icon.png")
 ```

--- a/docs/docs/libraries/lia.workshop.md
+++ b/docs/docs/libraries/lia.workshop.md
@@ -21,9 +21,12 @@ Collects workshop IDs from installed addons and registered modules.
 * ids (table) – Table of workshop IDs to download.
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.workshop.gather
-local ids = lia.workshop.gather()
+    -- This snippet demonstrates a common usage of lia.workshop.gather
+    local ids = lia.workshop.gather()
 ```
+
+---
+
 
 ### lia.workshop.send(ply)
 
@@ -38,6 +41,6 @@ Sends the collected workshop IDs to a connecting player.
 * None
 **Example:**
 ```lua
--- This snippet demonstrates a common usage of lia.workshop.send
-lia.workshop.send(ply)
+    -- This snippet demonstrates a common usage of lia.workshop.send
+    lia.workshop.send(ply)
 ```

--- a/fix_docs.py
+++ b/fix_docs.py
@@ -1,0 +1,43 @@
+import os,glob,re
+
+def format_block(text):
+    lines=text.split('\n')
+    indent=0
+    out=[]
+    for ln in lines:
+        stripped=ln.strip()
+        if stripped=='' and not ln.strip():
+            out.append('')
+            continue
+        # decrease indent before line if closing
+        if re.match(r'^(end|else|elseif|until)\b', stripped) or stripped.startswith('}'):
+            indent=max(indent-1,0)
+        out.append('    '*(indent+1)+stripped)
+        # increase indent after line if opener
+        if re.search(r'(\bdo$|\bthen$|\bfunction\b.*$)', stripped) or stripped.endswith('{') or stripped=='repeat':
+            indent+=1
+    return '\n'.join(out)
+
+for path in glob.glob('docs/docs/libraries/*.md'):
+    with open(path,'r') as f:
+        lines=f.readlines()
+    new=[]
+    in_block=False
+    code=[]
+    for line in lines:
+        if line.startswith('```lua') and not in_block:
+            in_block=True
+            new.append('```lua\n')
+            code=[]
+            continue
+        if line.startswith('```') and in_block:
+            in_block=False
+            new.append(format_block('\n'.join(code))+'\n')
+            new.append('```\n')
+            continue
+        if in_block:
+            code.append(line.rstrip('\n'))
+        else:
+            new.append(line)
+    with open(path,'w') as f:
+        f.writelines(new)


### PR DESCRIPTION
## Summary
- add a helper script `fix_docs.py` to autoformat Lua snippets
- reformat Lua code blocks across library docs with proper indentation

## Testing
- `python3 fix_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_6860f13df67c83279177d7c17e51e830