### PR TITLE
Fix tab autocomplete in chatbox

### DIFF
--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -182,17 +182,18 @@ Garry's Mod net library. The server will then execute the command.
 
 ### lia.command.openArgumentPrompt
 
-    
 **Description:**
 
-Opens a window asking the player to fill in any arguments that were
-omitted or left as placeholders when running a chat command. The
-prompt only appears if the command's syntax fields were valid.
+Opens a window asking the player to fill in arguments for the given command. If only
+the command name is supplied, all arguments defined in the command's syntax are
+requested. Passing existing arguments causes the prompt to request only the missing
+ones.
 **Parameters:**
 
 * cmd (string) – The command name.
-* fields (table) – Table of field names to their types.
-* prefix (table) – Arguments that were already supplied before the prompt.
+* args (table|string) – Optional. Either the arguments already provided or a table of
+missing fields from the server.
+* prefix (table) – Optional prefix when using the legacy field table format.
 **Returns:**
 
 * nil

--- a/gamemode/core/derma/panels/chatbox.lua
+++ b/gamemode/core/derma/panels/chatbox.lua
@@ -174,8 +174,7 @@ function PANEL:setActive(state)
                     if IsValid(selectedCommand) then
                         local commandName = selectedCommand:GetText():match("^/([^ ]+)")
                         local commandData = self.commands[commandName]
-                        local syntaxPreview = commandData and commandData.syntax or ""
-                        self.text:SetText("/" .. commandName .. " " .. syntaxPreview)
+                        self.text:SetText("/" .. commandName)
                         self.text:SetCaretPos(#self.text:GetText())
                         self.text:RequestFocus()
                     end

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -239,6 +239,26 @@ if SERVER then
 else
     function lia.command.openArgumentPrompt(cmdKey, fields, prefix)
         local ply = LocalPlayer()
+        local command = lia.command.list[cmdKey]
+        if not command then return end
+        local firstKey = istable(fields) and next(fields)
+        if not fields or isstring(fields) or (firstKey and isnumber(firstKey)) then
+            local args = fields
+            if isstring(args) then args = lia.command.extractArgs(args) end
+            local parsed, valid = lia.command.parseSyntaxFields(command.syntax)
+            if not valid then return end
+            fields = {}
+            prefix = {}
+            local tokens = args and combineBracketArgs(args) or {}
+            for i, field in ipairs(parsed) do
+                local arg = tokens[i]
+                if arg then
+                    prefix[#prefix + 1] = arg
+                else
+                    fields[field.name] = field.type
+                end
+            end
+        end
         local numFields = table.Count(fields)
         local frameW, frameH = 600, 200 + numFields * 75
         local frame = vgui.Create("DFrame")


### PR DESCRIPTION
## Summary
- adjust tab autocomplete to only insert the command name
- allow `lia.command.openArgumentPrompt` to accept a command id and figure out missing arguments
- document the new prompt behaviour

## Testing
- `luacheck gamemode/core/libraries/commands.lua`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861b5f3ffbc832783ceb2f531dae336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chatbox command suggestion: Tab completion now inserts only the command name without the syntax preview.

* **Documentation**
  * Clarified and updated the documentation for the command argument prompt, including parameter descriptions and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->