### PR TITLE
Fix attribute docs formatting

### DIFF
--- a/docs/docs/definitions/class.md
+++ b/docs/docs/definitions/class.md
@@ -46,8 +46,12 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 ### Basic Info
 
 #### `name`
-**Type:** `string`  
-**Description:** The displayed name of the class.  
+**Type:**
+
+`string`  
+**Description:**
+
+The displayed name of the class.  
 **Example Usage:**
 ```lua
 CLASS.name = "Engineer"
@@ -55,8 +59,12 @@ CLASS.name = "Engineer"
 
 #### `desc`
 
-**Type:** `string`
-**Description:** The description or lore of the class.
+**Type:**
+
+`string`
+**Description:**
+
+The description or lore of the class.
 **Example Usage:**
 
 ```lua
@@ -65,8 +73,12 @@ CLASS.desc = "Technicians who maintain equipment."
 
 #### `index`
 
-**Type:** `number`
-**Description:** Unique numeric identifier (team index) for the class.
+**Type:**
+
+`number`
+**Description:**
+
+Unique numeric identifier (team index) for the class.
 **Example Usage:**
 
 ```lua
@@ -79,8 +91,12 @@ CLASS.index = CLASS_ENGINEER
 
 #### `isDefault`
 
-**Type:** `boolean`
-**Description:** Determines if the class is available to all players by default.
+**Type:**
+
+`boolean`
+**Description:**
+
+Determines if the class is available to all players by default.
 **Example Usage:**
 
 ```lua
@@ -89,8 +105,12 @@ CLASS.isDefault = true
 
 #### `isWhitelisted`
 
-**Type:** `boolean`
-**Description:** Indicates if the class requires a whitelist entry to be accessible.
+**Type:**
+
+`boolean`
+**Description:**
+
+Indicates if the class requires a whitelist entry to be accessible.
 **Example Usage:**
 
 ```lua
@@ -99,8 +119,12 @@ CLASS.isWhitelisted = false
 
 #### `faction`
 
-**Type:** `number`
-**Description:** Links this class to a specific faction index.
+**Type:**
+
+`number`
+**Description:**
+
+Links this class to a specific faction index.
 **Example Usage:**
 
 ```lua
@@ -109,8 +133,12 @@ CLASS.faction = FACTION_CITIZEN
 
 #### `color`
 
-**Type:** `Color`
-**Description:** UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
+**Type:**
+
+`Color`
+**Description:**
+
+UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
 **Example Usage:**
 
 ```lua
@@ -123,8 +151,12 @@ CLASS.color = Color(255, 0, 0)
 
 #### `weapons`
 
-**Type:** `table`
-**Description:** Weapons granted to members of this class on spawn.
+**Type:**
+
+`table`
+**Description:**
+
+Weapons granted to members of this class on spawn.
 **Example Usage:**
 
 ```lua
@@ -133,8 +165,12 @@ CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
 
 #### `pay`
 
-**Type:** `number`
-**Description:** Payment amount issued per pay interval.
+**Type:**
+
+`number`
+**Description:**
+
+Payment amount issued per pay interval.
 **Example Usage:**
 
 ```lua
@@ -143,8 +179,12 @@ CLASS.pay = 50
 
 #### `payLimit`
 
-**Type:** `number`
-**Description:** Maximum accumulated pay a player can hold.
+**Type:**
+
+`number`
+**Description:**
+
+Maximum accumulated pay a player can hold.
 **Example Usage:**
 
 ```lua
@@ -153,8 +193,12 @@ CLASS.payLimit = 1000
 
 #### `payTimer`
 
-**Type:** `number`
-**Description:** Interval in seconds between salary payouts.
+**Type:**
+
+`number`
+**Description:**
+
+Interval in seconds between salary payouts.
 **Example Usage:**
 
 ```lua
@@ -163,8 +207,12 @@ CLASS.payTimer = 3600
 
 #### `limit`
 
-**Type:** `number`
-**Description:** Maximum number of players allowed in this class simultaneously.
+**Type:**
+
+`number`
+**Description:**
+
+Maximum number of players allowed in this class simultaneously.
 **Example Usage:**
 
 ```lua
@@ -177,8 +225,12 @@ CLASS.limit = 10
 
 #### `health`
 
-**Type:** `number`
-**Description:** Default starting health for class members.
+**Type:**
+
+`number`
+**Description:**
+
+Default starting health for class members.
 **Example Usage:**
 
 ```lua
@@ -187,8 +239,12 @@ CLASS.health = 150
 
 #### `armor`
 
-**Type:** `number`
-**Description:** Default starting armor.
+**Type:**
+
+`number`
+**Description:**
+
+Default starting armor.
 **Example Usage:**
 
 ```lua
@@ -197,8 +253,12 @@ CLASS.armor = 50
 
 #### `scale`
 
-**Type:** `number`
-**Description:** Multiplier for player model size.
+**Type:**
+
+`number`
+**Description:**
+
+Multiplier for player model size.
 **Example Usage:**
 
 ```lua
@@ -207,8 +267,12 @@ CLASS.scale = 1.2
 
 #### `runSpeed`
 
-**Type:** `number`
-**Description:** Default running speed.
+**Type:**
+
+`number`
+**Description:**
+
+Default running speed.
 **Example Usage:**
 
 ```lua
@@ -217,8 +281,12 @@ CLASS.runSpeed = 250
 
 #### `runSpeedMultiplier`
 
-**Type:** `boolean`
-**Description:** Multiply base run speed instead of replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+Multiply base run speed instead of replacing it.
 **Example Usage:**
 
 ```lua
@@ -227,8 +295,12 @@ CLASS.runSpeedMultiplier = true
 
 #### `walkSpeed`
 
-**Type:** `number`
-**Description:** Default walking speed.
+**Type:**
+
+`number`
+**Description:**
+
+Default walking speed.
 **Example Usage:**
 
 ```lua
@@ -237,8 +309,12 @@ CLASS.walkSpeed = 200
 
 #### `walkSpeedMultiplier`
 
-**Type:** `boolean`
-**Description:** Multiply base walk speed instead of replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+Multiply base walk speed instead of replacing it.
 **Example Usage:**
 
 ```lua
@@ -247,8 +323,12 @@ CLASS.walkSpeedMultiplier = false
 
 #### `jumpPower`
 
-**Type:** `number`
-**Description:** Default jump power.
+**Type:**
+
+`number`
+**Description:**
+
+Default jump power.
 **Example Usage:**
 
 ```lua
@@ -257,8 +337,12 @@ CLASS.jumpPower = 200
 
 #### `jumpPowerMultiplier`
 
-**Type:** `boolean`
-**Description:** Multiply base jump power instead of replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+Multiply base jump power instead of replacing it.
 **Example Usage:**
 
 ```lua
@@ -267,8 +351,12 @@ CLASS.jumpPowerMultiplier = true
 
 #### `bloodcolor`
 
-**Type:** `number`
-**Description:** Blood color enumeration constant for this class.
+**Type:**
+
+`number`
+**Description:**
+
+Blood color enumeration constant for this class.
 **Example Usage:**
 
 ```lua
@@ -281,8 +369,12 @@ CLASS.bloodcolor = BLOOD_COLOR_RED
 
 #### `bodyGroups`
 
-**Type:** `table`
-**Description:** Mapping of bodygroup indices to values applied on spawn.
+**Type:**
+
+`table`
+**Description:**
+
+Mapping of bodygroup indices to values applied on spawn.
 **Example Usage:**
 
 ```lua
@@ -294,8 +386,12 @@ CLASS.bodyGroups = {
 
 #### `model`
 
-**Type:** `string` or `table`
-**Description:** Model path (or list of paths) assigned to this class.
+**Type:**
+
+`string` or `table`
+**Description:**
+
+Model path (or list of paths) assigned to this class.
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/command.md
+++ b/docs/docs/definitions/command.md
@@ -31,8 +31,12 @@ When you register a command with `lia.command.add`, you provide a table of field
 ### Aliases & Permissions
 
 #### `alias`
-**Type:** `string` or `table`  
-**Description:** One or more alternative command names that trigger the same behavior.  
+**Type:**
+
+`string` or `table`  
+**Description:**
+
+One or more alternative command names that trigger the same behavior.  
 **Example Usage:**
 ```lua
 alias = {"chargiveflag", "giveflag"}
@@ -42,8 +46,12 @@ alias = {"chargiveflag", "giveflag"}
 
 #### `adminOnly`
 
-**Type:** `boolean`
-**Description:** If `true`, only players with the registered CAMI admin privilege (automatically created) may run the command.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, only players with the registered CAMI admin privilege (automatically created) may run the command.
 **Example Usage:**
 
 ```lua
@@ -54,8 +62,12 @@ adminOnly = true
 
 #### `superAdminOnly`
 
-**Type:** `boolean`
-**Description:** If `true`, restricts usage to super administrators (automatically registers a CAMI privilege).
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, restricts usage to super administrators (automatically registers a CAMI privilege).
 **Example Usage:**
 
 ```lua
@@ -66,8 +78,12 @@ superAdminOnly = true
 
 #### `privilege`
 
-**Type:** `string`
-**Description:** Custom CAMI privilege name checked when running the command. Defaults to the command’s primary name if omitted.
+**Type:**
+
+`string`
+**Description:**
+
+Custom CAMI privilege name checked when running the command. Defaults to the command’s primary name if omitted.
 **Example Usage:**
 
 ```lua
@@ -80,8 +96,12 @@ privilege = "Manage Doors"
 
 #### `syntax`
 
-**Type:** `string`
-**Description:** Human-readable syntax string shown in help menus. Does not affect argument parsing.
+**Type:**
+
+`string`
+**Description:**
+
+Human-readable syntax string shown in help menus. Does not affect argument parsing.
 You can use spaces in argument names for better readability.
 The in-game prompt only appears when every argument follows the `[type Name]` format.
 **Example Usage:**
@@ -94,8 +114,12 @@ syntax = "[string Target Name] [number Amount]"
 
 #### `desc`
 
-**Type:** `string`
-**Description:** Short description of what the command does, displayed in command lists and menus.
+**Type:**
+
+`string`
+**Description:**
+
+Short description of what the command does, displayed in command lists and menus.
 **Example Usage:**
 
 ```lua
@@ -108,8 +132,12 @@ desc = "Purchase a door if it is available and you can afford it."
 
 #### `AdminStick`
 
-**Type:** `table`
-**Description:** Defines how the command appears in admin utility menus. Common keys:
+**Type:**
+
+`table`
+**Description:**
+
+Defines how the command appears in admin utility menus. Common keys:
 
 * `Name` (string): Display text.
 * `Category` (string): Top-level grouping.
@@ -133,8 +161,12 @@ AdminStick = {
 
 #### `onRun(client, args)`
 
-**Type:** `function(client, table)`
-**Description:** Function called when the command is executed. `args` is a table of parsed arguments. Return a string to send a message back to the caller, or return nothing for silent execution.
+**Type:**
+
+`function(client, table)`
+**Description:**
+
+Function called when the command is executed. `args` is a table of parsed arguments. Return a string to send a message back to the caller, or return nothing for silent execution.
 
 **Example Usage:**
 

--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -52,8 +52,12 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 ### Basic Info
 
 #### `name`
-**Type:** `string`  
-**Description:** Display name shown for members of this faction.  
+**Type:**
+
+`string`  
+**Description:**
+
+Display name shown for members of this faction.  
 **Example Usage:**
 ```lua
 FACTION.name = "Minecrafters"
@@ -61,8 +65,12 @@ FACTION.name = "Minecrafters"
 
 #### `desc`
 
-**Type:** `string`
-**Description:** Lore or descriptive text about the faction.
+**Type:**
+
+`string`
+**Description:**
+
+Lore or descriptive text about the faction.
 **Example Usage:**
 
 ```lua
@@ -71,8 +79,12 @@ FACTION.desc = "Surviving and crafting in the blocky world."
 
 #### `isDefault`
 
-**Type:** `boolean`
-**Description:** Set to `true` if players may select this faction without a whitelist.
+**Type:**
+
+`boolean`
+**Description:**
+
+Set to `true` if players may select this faction without a whitelist.
 **Example Usage:**
 
 ```lua
@@ -81,8 +93,12 @@ FACTION.isDefault = false
 
 #### `uniqueID`
 
-**Type:** `string`
-**Description:** Internal string identifier for referencing the faction.
+**Type:**
+
+`string`
+**Description:**
+
+Internal string identifier for referencing the faction.
 **Example Usage:**
 
 ```lua
@@ -91,8 +107,12 @@ FACTION.uniqueID = "staff"
 
 #### `index`
 
-**Type:** `number`
-**Description:** Numeric identifier assigned during faction registration.
+**Type:**
+
+`number`
+**Description:**
+
+Numeric identifier assigned during faction registration.
 **Example Usage:**
 
 ```lua
@@ -105,8 +125,12 @@ FACTION_STAFF = FACTION.index
 
 #### `color`
 
-**Type:** `Color`
-**Description:** Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
+**Type:**
+
+`Color`
+**Description:**
+
+Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
 **Example Usage:**
 
 ```lua
@@ -115,8 +139,12 @@ FACTION.color = Color(255, 56, 252)
 
 #### `models`
 
-**Type:** `table`
-**Description:** Table of player model paths available to faction members.
+**Type:**
+
+`table`
+**Description:**
+
+Table of player model paths available to faction members.
 **Example Usage:**
 
 ```lua
@@ -128,8 +156,12 @@ FACTION.models = {
 
 #### `bodyGroups`
 
-**Type:** `table`
-**Description:** Mapping of bodygroup names to index values applied on spawn.
+**Type:**
+
+`table`
+**Description:**
+
+Mapping of bodygroup names to index values applied on spawn.
 **Example Usage:**
 
 ```lua
@@ -145,8 +177,12 @@ FACTION.bodyGroups = {
 
 #### `weapons`
 
-**Type:** `table`
-**Description:** Weapons automatically granted on spawn.
+**Type:**
+
+`table`
+**Description:**
+
+Weapons automatically granted on spawn.
 **Example Usage:**
 
 ```lua
@@ -155,8 +191,12 @@ FACTION.weapons = {"weapon_physgun", "gmod_tool"}
 
 #### `items`
 
-**Type:** `table`
-**Description:** Item uniqueIDs automatically granted on character creation.
+**Type:**
+
+`table`
+**Description:**
+
+Item uniqueIDs automatically granted on character creation.
 **Example Usage:**
 
 ```lua
@@ -165,8 +205,12 @@ FACTION.items = {"radio", "handcuffs"}
 
 #### `pay`
 
-**Type:** `number`
-**Description:** Payment amount for members each interval.
+**Type:**
+
+`number`
+**Description:**
+
+Payment amount for members each interval.
 **Example Usage:**
 
 ```lua
@@ -175,8 +219,12 @@ FACTION.pay = 50
 
 #### `payLimit`
 
-**Type:** `number`
-**Description:** Maximum pay a member can accumulate.
+**Type:**
+
+`number`
+**Description:**
+
+Maximum pay a member can accumulate.
 **Example Usage:**
 
 ```lua
@@ -185,8 +233,12 @@ FACTION.payLimit = 1000
 
 #### `payTimer`
 
-**Type:** `number`
-**Description:** Interval in seconds between salary payouts.
+**Type:**
+
+`number`
+**Description:**
+
+Interval in seconds between salary payouts.
 **Example Usage:**
 
 ```lua
@@ -195,8 +247,12 @@ FACTION.payTimer = 3600
 
 #### `limit`
 
-**Type:** `number`
-**Description:** Maximum number of players allowed in this faction.
+**Type:**
+
+`number`
+**Description:**
+
+Maximum number of players allowed in this faction.
 **Example Usage:**
 
 ```lua
@@ -205,8 +261,12 @@ FACTION.limit = 20
 
 #### `oneCharOnly`
 
-**Type:** `boolean`
-**Description:** If `true`, players may only create one character in this faction.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, players may only create one character in this faction.
 **Example Usage:**
 
 ```lua
@@ -219,8 +279,12 @@ FACTION.oneCharOnly = true
 
 #### `health`
 
-**Type:** `number`
-**Description:** Starting health for faction members.
+**Type:**
+
+`number`
+**Description:**
+
+Starting health for faction members.
 **Example Usage:**
 
 ```lua
@@ -229,8 +293,12 @@ FACTION.health = 150
 
 #### `armor`
 
-**Type:** `number`
-**Description:** Starting armor for faction members.
+**Type:**
+
+`number`
+**Description:**
+
+Starting armor for faction members.
 **Example Usage:**
 
 ```lua
@@ -239,8 +307,12 @@ FACTION.armor = 25
 
 #### `scale`
 
-**Type:** `number`
-**Description:** Player model scale multiplier.
+**Type:**
+
+`number`
+**Description:**
+
+Player model scale multiplier.
 **Example Usage:**
 
 ```lua
@@ -249,8 +321,12 @@ FACTION.scale = 1.1
 
 #### `runSpeed`
 
-**Type:** `number`
-**Description:** Base running speed.
+**Type:**
+
+`number`
+**Description:**
+
+Base running speed.
 **Example Usage:**
 
 ```lua
@@ -259,8 +335,12 @@ FACTION.runSpeed = 250
 
 #### `runSpeedMultiplier`
 
-**Type:** `boolean`
-**Description:** If `true`, multiplies the base speed rather than replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, multiplies the base speed rather than replacing it.
 **Example Usage:**
 
 ```lua
@@ -269,8 +349,12 @@ FACTION.runSpeedMultiplier = false
 
 #### `walkSpeed`
 
-**Type:** `number`
-**Description:** Base walking speed.
+**Type:**
+
+`number`
+**Description:**
+
+Base walking speed.
 **Example Usage:**
 
 ```lua
@@ -279,8 +363,12 @@ FACTION.walkSpeed = 200
 
 #### `walkSpeedMultiplier`
 
-**Type:** `boolean`
-**Description:** If `true`, multiplies the base walk speed rather than replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, multiplies the base walk speed rather than replacing it.
 **Example Usage:**
 
 ```lua
@@ -289,8 +377,12 @@ FACTION.walkSpeedMultiplier = true
 
 #### `jumpPower`
 
-**Type:** `number`
-**Description:** Base jump power.
+**Type:**
+
+`number`
+**Description:**
+
+Base jump power.
 **Example Usage:**
 
 ```lua
@@ -299,8 +391,12 @@ FACTION.jumpPower = 200
 
 #### `jumpPowerMultiplier`
 
-**Type:** `boolean`
-**Description:** If `true`, multiplies the base jump power rather than replacing it.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, multiplies the base jump power rather than replacing it.
 **Example Usage:**
 
 ```lua
@@ -313,8 +409,12 @@ FACTION.jumpPowerMultiplier = true
 
 #### `MemberToMemberAutoRecognition`
 
-**Type:** `boolean`
-**Description:** Whether faction members automatically recognize each other on sight.
+**Type:**
+
+`boolean`
+**Description:**
+
+Whether faction members automatically recognize each other on sight.
 **Example Usage:**
 
 ```lua
@@ -323,8 +423,12 @@ FACTION.MemberToMemberAutoRecognition = true
 
 #### `RecognizesGlobally`
 
-**Type:** `boolean`
-**Description:** If `true`, members recognize all players globally, regardless of faction.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, members recognize all players globally, regardless of faction.
 **Example Usage:**
 
 ```lua
@@ -333,8 +437,12 @@ FACTION.RecognizesGlobally = false
 
 #### `NPCRelations`
 
-**Type:** `table`
-**Description:** Mapping of NPC class names to disposition constants (`D_HT`, `D_LI`, etc.). NPCs are updated on spawn/creation.
+**Type:**
+
+`table`
+**Description:**
+
+Mapping of NPC class names to disposition constants (`D_HT`, `D_LI`, etc.). NPCs are updated on spawn/creation.
 **Example Usage:**
 
 ```lua
@@ -346,8 +454,12 @@ FACTION.NPCRelations = {
 
 #### `bloodcolor`
 
-**Type:** `number`
-**Description:** Blood color enumeration constant for faction members.
+**Type:**
+
+`number`
+**Description:**
+
+Blood color enumeration constant for faction members.
 **Example Usage:**
 
 ```lua
@@ -356,8 +468,12 @@ FACTION.bloodcolor = BLOOD_COLOR_RED
 
 #### `ScoreboardHidden`
 
-**Type:** `boolean`
-**Description:** If `true`, members of this faction are hidden from the scoreboard.
+**Type:**
+
+`boolean`
+**Description:**
+
+If `true`, members of this faction are hidden from the scoreboard.
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/items.md
+++ b/docs/docs/definitions/items.md
@@ -71,8 +71,12 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 ### Audio & Interaction
 
 #### `BagSound`
-**Type:** `table`
-**Description:** Sound played when moving items to/from the bag; specified as `{path, volume}`.
+**Type:**
+
+`table`
+**Description:**
+
+Sound played when moving items to/from the bag; specified as `{path, volume}`.
 **Example Usage:**
 ```lua
 ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
@@ -80,8 +84,12 @@ ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
 
 #### `equipSound`
 
-**Type:** `string`
-**Description:** Sound played when equipping the item.
+**Type:**
+
+`string`
+**Description:**
+
+Sound played when equipping the item.
 **Example Usage:**
 
 ```lua
@@ -90,8 +98,12 @@ ITEM.equipSound = "items/ammo_pickup.wav"
 
 #### `unequipSound`
 
-**Type:** `string`
-**Description:** Sound played when unequipping the item.
+**Type:**
+
+`string`
+**Description:**
+
+Sound played when unequipping the item.
 **Example Usage:**
 
 ```lua
@@ -104,8 +116,12 @@ ITEM.unequipSound = "items/ammo_pickup.wav"
 
 #### `DropOnDeath`
 
-**Type:** `boolean`
-**Description:** Deletes the item upon player death.
+**Type:**
+
+`boolean`
+**Description:**
+
+Deletes the item upon player death.
 **Example Usage:**
 
 ```lua
@@ -114,8 +130,12 @@ ITEM.DropOnDeath = true
 
 #### `FactionWhitelist`
 
-**Type:** `table`
-**Description:** Allowed faction indices for vendor interaction.
+**Type:**
+
+`table`
+**Description:**
+
+Allowed faction indices for vendor interaction.
 **Example Usage:**
 
 ```lua
@@ -124,8 +144,12 @@ ITEM.FactionWhitelist = {FACTION_CITIZEN}
 
 #### `RequiredSkillLevels`
 
-**Type:** `table`
-**Description:** Skill requirements needed to use the item.
+**Type:**
+
+`table`
+**Description:**
+
+Skill requirements needed to use the item.
 **Example Usage:**
 
 ```lua
@@ -134,8 +158,12 @@ ITEM.RequiredSkillLevels = {Strength = 5}
 
 #### `SteamIDWhitelist`
 
-**Type:** `table`
-**Description:** Allowed Steam IDs for vendor interaction.
+**Type:**
+
+`table`
+**Description:**
+
+Allowed Steam IDs for vendor interaction.
 **Example Usage:**
 
 ```lua
@@ -144,8 +172,12 @@ ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
 
 #### `UsergroupWhitelist`
 
-**Type:** `table`
-**Description:** Allowed user groups for vendor interaction.
+**Type:**
+
+`table`
+**Description:**
+
+Allowed user groups for vendor interaction.
 **Example Usage:**
 
 ```lua
@@ -154,8 +186,12 @@ ITEM.UsergroupWhitelist = {"admin"}
 
 #### `VIPWhitelist`
 
-**Type:** `boolean`
-**Description:** Restricts usage to VIP players.
+**Type:**
+
+`boolean`
+**Description:**
+
+Restricts usage to VIP players.
 **Example Usage:**
 
 ```lua
@@ -168,8 +204,12 @@ ITEM.VIPWhitelist = true
 
 #### `isBag`
 
-**Type:** `boolean`
-**Description:** Marks the item as a bag providing extra inventory.
+**Type:**
+
+`boolean`
+**Description:**
+
+Marks the item as a bag providing extra inventory.
 **Example Usage:**
 
 ```lua
@@ -178,8 +218,12 @@ ITEM.isBag = true
 
 #### `invWidth`
 
-**Type:** `number`
-**Description:** Internal bag inventory width.
+**Type:**
+
+`number`
+**Description:**
+
+Internal bag inventory width.
 **Example Usage:**
 
 ```lua
@@ -188,8 +232,12 @@ ITEM.invWidth = 2
 
 #### `invHeight`
 
-**Type:** `number`
-**Description:** Internal bag inventory height.
+**Type:**
+
+`number`
+**Description:**
+
+Internal bag inventory height.
 **Example Usage:**
 
 ```lua
@@ -198,8 +246,12 @@ ITEM.invHeight = 2
 
 #### `width`
 
-**Type:** `number`
-**Description:** Width in the external inventory grid.
+**Type:**
+
+`number`
+**Description:**
+
+Width in the external inventory grid.
 **Example Usage:**
 
 ```lua
@@ -208,8 +260,12 @@ ITEM.width = 2
 
 #### `height`
 
-**Type:** `number`
-**Description:** Height in the external inventory grid.
+**Type:**
+
+`number`
+**Description:**
+
+Height in the external inventory grid.
 **Example Usage:**
 
 ```lua
@@ -218,8 +274,12 @@ ITEM.height = 1
 
 #### `canSplit`
 
-**Type:** `boolean`
-**Description:** Whether the item stack can be divided.
+**Type:**
+
+`boolean`
+**Description:**
+
+Whether the item stack can be divided.
 **Example Usage:**
 
 ```lua
@@ -228,8 +288,12 @@ ITEM.canSplit = true
 
 #### `isStackable`
 
-**Type:** `boolean`
-**Description:** Allows stacking multiple quantities.
+**Type:**
+
+`boolean`
+**Description:**
+
+Allows stacking multiple quantities.
 **Example Usage:**
 
 ```lua
@@ -238,8 +302,12 @@ ITEM.isStackable = false
 
 #### `maxQuantity`
 
-**Type:** `number`
-**Description:** Maximum stack size.
+**Type:**
+
+`number`
+**Description:**
+
+Maximum stack size.
 **Example Usage:**
 
 ```lua
@@ -248,8 +316,12 @@ ITEM.maxQuantity = 10
 
 #### `quantity`
 
-**Type:** `number`
-**Description:** Current amount in the item stack.
+**Type:**
+
+`number`
+**Description:**
+
+Current amount in the item stack.
 **Example Usage:**
 
 ```lua
@@ -262,8 +334,12 @@ print(item:getQuantity())
 
 #### `base`
 
-**Type:** `string`
-**Description:** Base item this item derives from.
+**Type:**
+
+`string`
+**Description:**
+
+Base item this item derives from.
 **Example Usage:**
 
 ```lua
@@ -272,8 +348,12 @@ ITEM.base = "weapon"
 
 #### `isBase`
 
-**Type:** `boolean`
-**Description:** Indicates the table is a base item.
+**Type:**
+
+`boolean`
+**Description:**
+
+Indicates the table is a base item.
 **Example Usage:**
 
 ```lua
@@ -282,8 +362,12 @@ ITEM.isBase = true
 
 #### `category`
 
-**Type:** `string`
-**Description:** Inventory grouping category.
+**Type:**
+
+`string`
+**Description:**
+
+Inventory grouping category.
 **Example Usage:**
 
 ```lua
@@ -292,8 +376,12 @@ ITEM.category = "Storage"
 
 #### `name`
 
-**Type:** `string`
-**Description:** Displayed name of the item.
+**Type:**
+
+`string`
+**Description:**
+
+Displayed name of the item.
 **Example Usage:**
 
 ```lua
@@ -302,8 +390,12 @@ ITEM.name = "Example Item"
 
 #### `desc`
 
-**Type:** `string`
-**Description:** Short description shown to players.
+**Type:**
+
+`string`
+**Description:**
+
+Short description shown to players.
 **Example Usage:**
 ```lua
 ITEM.desc = "An example item"
@@ -311,8 +403,12 @@ ITEM.desc = "An example item"
 
 #### `uniqueID`
 
-**Type:** `string`
-**Description:** Overrides the automatically generated unique identifier.
+**Type:**
+
+`string`
+**Description:**
+
+Overrides the automatically generated unique identifier.
 **Example Usage:**
 
 ```lua
@@ -321,8 +417,12 @@ ITEM.uniqueID = "custom_unique_id"
 
 #### `id`
 
-**Type:** `any`
-**Description:** Database identifier.
+**Type:**
+
+`any`
+**Description:**
+
+Database identifier.
 **Example Usage:**
 
 ```lua
@@ -335,8 +435,12 @@ print(item.id)
 
 #### `armor`
 
-**Type:** `number`
-**Description:** Armor value granted when equipped.
+**Type:**
+
+`number`
+**Description:**
+
+Armor value granted when equipped.
 **Example Usage:**
 
 ```lua
@@ -345,8 +449,12 @@ ITEM.armor = 50
 
 #### `health`
 
-**Type:** `number`
-**Description:** Amount of health restored when used.
+**Type:**
+
+`number`
+**Description:**
+
+Amount of health restored when used.
 **Example Usage:**
 
 ```lua
@@ -355,8 +463,12 @@ ITEM.health = 50
 
 #### `attribBoosts`
 
-**Type:** `table`
-**Description:** Attribute boosts applied on equip.
+**Type:**
+
+`table`
+**Description:**
+
+Attribute boosts applied on equip.
 **Example Usage:**
 
 ```lua
@@ -365,8 +477,12 @@ ITEM.attribBoosts = {strength = 5}
 
 #### `isOutfit`
 
-**Type:** `boolean`
-**Description:** Marks the item as an outfit.
+**Type:**
+
+`boolean`
+**Description:**
+
+Marks the item as an outfit.
 **Example Usage:**
 ```lua
 ITEM.isOutfit = true
@@ -374,8 +490,12 @@ ITEM.isOutfit = true
 
 #### `newSkin`
 
-**Type:** `number`
-**Description:** Skin index applied to the player model.
+**Type:**
+
+`number`
+**Description:**
+
+Skin index applied to the player model.
 **Example Usage:**
 
 ```lua
@@ -384,8 +504,12 @@ ITEM.newSkin = 1
 
 #### `outfitCategory`
 
-**Type:** `string`
-**Description:** Slot or category for the outfit.
+**Type:**
+
+`string`
+**Description:**
+
+Slot or category for the outfit.
 **Example Usage:**
 
 ```lua
@@ -394,8 +518,12 @@ ITEM.outfitCategory = "body"
 
 #### `pacData`
 
-**Type:** `table`
-**Description:** PAC3 customization information.
+**Type:**
+
+`table`
+**Description:**
+
+PAC3 customization information.
 **Example Usage:**
 
 ```lua
@@ -428,8 +556,12 @@ ITEM.pacData = {
 
 #### `replacements`
 
-**Type:** `string`
-**Description:** Model replacements when equipped.
+**Type:**
+
+`string`
+**Description:**
+
+Model replacements when equipped.
 **Example Usage:**
 
 ```lua
@@ -449,8 +581,12 @@ ITEM.replacements = {
 
 #### `class`
 
-**Type:** `string`
-**Description:** Weapon entity class.
+**Type:**
+
+`string`
+**Description:**
+
+Weapon entity class.
 **Example Usage:**
 
 ```lua
@@ -459,8 +595,12 @@ ITEM.class = "weapon_pistol"
 
 #### `isWeapon`
 
-**Type:** `boolean`
-**Description:** Marks the item as a weapon.
+**Type:**
+
+`boolean`
+**Description:**
+
+Marks the item as a weapon.
 **Example Usage:**
 
 ```lua
@@ -469,8 +609,12 @@ ITEM.isWeapon = true
 
 #### `grenadeClass`
 
-**Type:** `string`
-**Description:** Class name used when spawning a grenade.
+**Type:**
+
+`string`
+**Description:**
+
+Class name used when spawning a grenade.
 **Example Usage:**
 
 ```lua
@@ -479,8 +623,12 @@ ITEM.grenadeClass = "weapon_frag"
 
 #### `ammo`
 
-**Type:** `string`
-**Description:** Ammo type provided.
+**Type:**
+
+`string`
+**Description:**
+
+Ammo type provided.
 **Example Usage:**
 
 ```lua
@@ -489,8 +637,12 @@ ITEM.ammo = "pistol"
 
 #### `ammoAmount`
 
-**Type:** `number`
-**Description:** Amount of ammo contained.
+**Type:**
+
+`number`
+**Description:**
+
+Amount of ammo contained.
 **Example Usage:**
 
 ```lua
@@ -499,8 +651,12 @@ ITEM.ammoAmount = 30
 
 #### `weaponCategory`
 
-**Type:** `string`
-**Description:** Slot category for the weapon.
+**Type:**
+
+`string`
+**Description:**
+
+Slot category for the weapon.
 **Example Usage:**
 
 ```lua
@@ -513,8 +669,12 @@ ITEM.weaponCategory = "sidearm"
 
 #### `model`
 
-**Type:** `string`
-**Description:** 3D model path for the item.
+**Type:**
+
+`string`
+**Description:**
+
+3D model path for the item.
 **Example Usage:**
 
 ```lua
@@ -527,8 +687,12 @@ ITEM.model = "models/props_c17/oildrum001.mdl"
 
 #### `entityid`
 
-**Type:** `string`
-**Description:** Entity class spawned by the item.
+**Type:**
+
+`string`
+**Description:**
+
+Entity class spawned by the item.
 **Example Usage:**
 
 ```lua
@@ -537,8 +701,12 @@ ITEM.entityid = "item_suit"
 
 #### `contents`
 
-**Type:** `string`
-**Description:** HTML contents of a readable book.
+**Type:**
+
+`string`
+**Description:**
+
+HTML contents of a readable book.
 **Example Usage:**
 
 ```lua
@@ -551,8 +719,12 @@ ITEM.contents = "<h1>Book</h1>"
 
 #### `price`
 
-**Type:** `number`
-**Description:** Item cost for trading or selling.
+**Type:**
+
+`number`
+**Description:**
+
+Item cost for trading or selling.
 **Example Usage:**
 
 ```lua
@@ -561,8 +733,12 @@ ITEM.price = 100
 
 #### `flag`
 
-**Type:** `string`
-**Description:** Flag required to purchase the item.
+**Type:**
+
+`string`
+**Description:**
+
+Flag required to purchase the item.
 **Example Usage:**
 
 ```lua
@@ -571,8 +747,12 @@ ITEM.flag = "Y"
 
 #### `rarity`
 
-**Type:** `string`
-**Description:** Rarity level affecting vendor color.
+**Type:**
+
+`string`
+**Description:**
+
+Rarity level affecting vendor color.
 **Example Usage:**
 
 ```lua
@@ -581,8 +761,12 @@ ITEM.rarity = "Legendary"
 
 #### `url`
 
-**Type:** `string`
-**Description:** Web address opened when using the item.
+**Type:**
+
+`string`
+**Description:**
+
+Web address opened when using the item.
 **Example Usage:**
 
 ```lua
@@ -595,8 +779,12 @@ ITEM.url = "https://example.com"
 
 #### `functions`
 
-**Type:** `table`
-**Description:** Table of interaction functions.
+**Type:**
+
+`table`
+**Description:**
+
+Table of interaction functions.
 **Example Usage:**
 
 ```lua
@@ -605,8 +793,12 @@ ITEM.functions = {}
 
 #### `postHooks`
 
-**Type:** `table`
-**Description:** Table of post-hook callbacks.
+**Type:**
+
+`table`
+**Description:**
+
+Table of post-hook callbacks.
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/module.md
+++ b/docs/docs/definitions/module.md
@@ -20,7 +20,6 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 | `discord` | `string` | `""` | Discord tag or support channel. |
 | `version` | `string` | `""` | Version string for compatibility checks. |
 | `desc` | `string` | `"No Description"` | Short description of module functionality. |
-| `identifier` | `string` | `""` | Unique global key referencing the module. |
 | `CAMIPrivileges` | `table` | `nil` | CAMI privileges defined or required by the module. |
 | `WorkshopContent` | `table` | `nil` | Steam Workshop add-on IDs required. |
 | `enabled` | `boolean` or `function` | `true` | Controls whether the module loads. |
@@ -40,8 +39,12 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 ### Identification & Metadata
 
 #### `name`
-**Type:** `string`  
-**Description:** Identifies the module in logs and UI elements.  
+**Type:**
+
+`string`  
+**Description:**
+
+Identifies the module in logs and UI elements.  
 **Example Usage:**
 ```lua
 MODULE.name = "My Module"
@@ -49,8 +52,12 @@ MODULE.name = "My Module"
 
 #### `author`
 
-**Type:** `string`
-**Description:** Name or SteamID64 of the module’s author.
+**Type:**
+
+`string`
+**Description:**
+
+Name or SteamID64 of the module’s author.
 **Example Usage:**
 
 ```lua
@@ -59,8 +66,12 @@ MODULE.author = "Samael"
 
 #### `discord`
 
-**Type:** `string`
-**Description:** Discord tag or support channel for the module.
+**Type:**
+
+`string`
+**Description:**
+
+Discord tag or support channel for the module.
 **Example Usage:**
 
 ```lua
@@ -69,32 +80,29 @@ MODULE.discord = "@liliaplayer"
 
 #### `desc`
 
-**Type:** `string`
-**Description:** Short description of what the module provides.
+**Type:**
+
+`string`
+**Description:**
+
+Short description of what the module provides.
 **Example Usage:**
 
 ```lua
 MODULE.desc = "Adds a Chatbox"
 ```
-
-#### `identifier`
-
-**Type:** `string`
-**Description:** Unique key used to reference this module globally.
-**Example Usage:**
-
-```lua
-MODULE.identifier = "example_mod"
-```
-
 ---
 
 ### Version & Compatibility
 
 #### `version`
 
-**Type:** `string`
-**Description:** Version string used for compatibility checks.
+**Type:**
+
+`string`
+**Description:**
+
+Version string used for compatibility checks.
 **Example Usage:**
 
 ```lua
@@ -103,8 +111,12 @@ MODULE.version = "1.0"
 
 #### `Public`
 
-**Type:** `boolean`
-**Description:** When true, the module participates in public version checks.
+**Type:**
+
+`boolean`
+**Description:**
+
+When true, the module participates in public version checks.
 **Example Usage:**
 
 ```lua
@@ -113,8 +125,12 @@ MODULE.Public = true
 
 #### `Private`
 
-**Type:** `boolean`
-**Description:** When true, the module uses private version checking.
+**Type:**
+
+`boolean`
+**Description:**
+
+When true, the module uses private version checking.
 **Example Usage:**
 
 ```lua
@@ -127,8 +143,12 @@ MODULE.Private = true
 
 #### `CAMIPrivileges`
 
-**Type:** `table`
-**Description:** CAMI privileges required or provided by the module.
+**Type:**
+
+`table`
+**Description:**
+
+CAMI privileges required or provided by the module.
 **Example Usage:**
 
 ```lua
@@ -139,8 +159,12 @@ MODULE.CAMIPrivileges = {
 
 #### `WorkshopContent`
 
-**Type:** `table`
-**Description:** Steam Workshop add-on IDs required by this module.
+**Type:**
+
+`table`
+**Description:**
+
+Steam Workshop add-on IDs required by this module.
 **Example Usage:**
 
 ```lua
@@ -149,8 +173,12 @@ MODULE.WorkshopContent = { "2959728255" }
 
 #### `Dependencies`
 
-**Type:** `table`
-**Description:** Files or folders that this module requires to run.
+**Type:**
+
+`table`
+**Description:**
+
+Files or folders that this module requires to run.
 **Example Usage:**
 
 ```lua
@@ -165,8 +193,12 @@ MODULE.Dependencies = {
 
 #### `enabled`
 
-**Type:** `boolean` or `function`
-**Description:** Controls whether the module loads. Can be a static boolean or a function returning a boolean.
+**Type:**
+
+`boolean` or `function`
+**Description:**
+
+Controls whether the module loads. Can be a static boolean or a function returning a boolean.
 **Example Usage:**
 
 ```lua
@@ -175,8 +207,12 @@ MODULE.enabled = true
 
 #### `loading`
 
-**Type:** `boolean`
-**Description:** True while the module is in the process of loading.
+**Type:**
+
+`boolean`
+**Description:**
+
+True while the module is in the process of loading.
 **Example Usage:**
 
 ```lua
@@ -185,8 +221,12 @@ if MODULE.loading then return end
 
 #### `ModuleLoaded`
 
-**Type:** `function`
-**Description:** Optional callback run after the module finishes loading.
+**Type:**
+
+`function`
+**Description:**
+
+Optional callback run after the module finishes loading.
 **Example Usage:**
 
 ```lua
@@ -201,8 +241,12 @@ end
 
 #### `folder`
 
-**Type:** `string`
-**Description:** Filesystem path where the module is located.
+**Type:**
+
+`string`
+**Description:**
+
+Filesystem path where the module is located.
 **Example Usage:**
 
 ```lua
@@ -211,8 +255,12 @@ print(MODULE.folder)
 
 #### `path`
 
-**Type:** `string`
-**Description:** Absolute path to the module’s root directory.
+**Type:**
+
+`string`
+**Description:**
+
+Absolute path to the module’s root directory.
 **Example Usage:**
 
 ```lua
@@ -221,8 +269,12 @@ print(MODULE.path)
 
 #### `uniqueID`
 
-**Type:** `string`
-**Description:** Identifier used internally for the module list.
+**Type:**
+
+`string`
+**Description:**
+
+Identifier used internally for the module list.
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/panels.md
+++ b/docs/docs/definitions/panels.md
@@ -60,473 +60,362 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 ## Panel Details
 
 ### `liaMarkupPanel`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Panel that renders text using Garry's Mod markup language and wraps `markup.Parse` so formatted chat messages can be displayed easily.
+`DPanel`
 
-**Example Usage:**
-```lua
--- Create a formatted chat line
-local chatLine = vgui.Create("liaMarkupPanel", chatScroll)
-chatLine:setMarkup("<color=255,255,0>Hello!</color>")
-chatLine:Dock(TOP)
-```
+**Description:**
+
+Panel that renders text using Garry's Mod markup language and wraps `markup.Parse` so formatted chat messages can be displayed easily.
 
 ### `liaCharInfo`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Displays the current character's stats and fields in the F1 menu. The panel updates periodically and can show plugin-defined information.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local infoPanel = vgui.Create("liaCharInfo") -- part of the F1 menu
-infoPanel:Dock(FILL)
-infoPanel:setup() -- populate displayed fields
-```
+**Description:**
+
+Displays the current character's stats and fields in the F1 menu. The panel updates periodically and can show plugin-defined information.
 
 ### `liaMenu`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Main F1 menu housing tabs like Character, Help and Settings. It controls switching between tabs and can be opened on demand.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local menu = vgui.Create("liaMenu")
-menu:MakePopup()
-menu:openTab("Character")
-```
+**Description:**
+
+Main F1 menu housing tabs like Character, Help and Settings. It controls switching between tabs and can be opened on demand.
 
 ### `liaClasses`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Lists available classes in the F1 menu and shows requirements for each. Players may click a button to join a class when eligible.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local btn = parent:Add("liaMediumButton")
-btn:SetText("Medic")
-btn.DoClick = function()
-    RunConsoleCommand("lia_class", "medic")
-end
-```
+**Description:**
+
+Lists available classes in the F1 menu and shows requirements for each. Players may click a button to join a class when eligible.
 
 ### `liaModelPanel`
-**Base Panel:** `DModelPanel`
+**Base Panel:**
 
-**Description:** Displays a model with custom lighting and mouse controls for rotation and zoom. Useful for previewing items or player characters.
+`DModelPanel`
 
-**Example Usage:**
-```lua
-local mdl = vgui.Create("liaModelPanel", frame)
-mdl:SetModel("models/props_c17/oildrum001.mdl")
-mdl:SetCamPos(Vector(35, 0, 55))
-```
+**Description:**
+
+Displays a model with custom lighting and mouse controls for rotation and zoom. Useful for previewing items or player characters.
 
 ### `FacingModelPanel`
-**Base Panel:** `DModelPanel`
+**Base Panel:**
 
-**Description:** Variant of `liaModelPanel` that locks the camera to the model's head bone, ideal for mugshots or scoreboard avatars.
+`DModelPanel`
 
-**Example Usage:**
-```lua
-local avatar = vgui.Create("FacingModelPanel", frame)
-avatar:SetModel("models/Humans/Group01/Female_01.mdl")
-```
+**Description:**
+
+Variant of `liaModelPanel` that locks the camera to the model's head bone, ideal for mugshots or scoreboard avatars.
 
 ### `DProgressBar`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Simple progress bar panel. Update its fraction each frame to visually represent timed actions.
+`DPanel`
 
-**Example Usage:**
-```lua
-local progress = vgui.Create("DProgressBar", panel)
-progress:SetFraction(0)
-timer.Simple(2, function() progress:SetFraction(1) end)
-```
+**Description:**
+
+Simple progress bar panel. Update its fraction each frame to visually represent timed actions.
 
 ### `liaNotice`
-**Base Panel:** `DLabel`
+**Base Panel:**
 
-**Description:** Small label for quick notifications. It draws a blurred backdrop and fades away after a short delay.
+`DLabel`
 
-**Example Usage:**
-```lua
-local notice = vgui.Create("liaNotice")
-notice:SetText("Item picked up!")
-notice.start = CurTime() + 2
-```
+**Description:**
+
+Small label for quick notifications. It draws a blurred backdrop and fades away after a short delay.
 
 ### `noticePanel`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Expanded version of `liaNotice` supporting more text and optional buttons. Often used for yes/no prompts.
+`DPanel`
 
-**Example Usage:**
-```lua
-local prompt = vgui.Create("noticePanel")
-prompt.text:SetText("Are you sure?")
-prompt.yes.DoClick = function() print("confirmed") end
-```
+**Description:**
+
+Expanded version of `liaNotice` supporting more text and optional buttons. Often used for yes/no prompts.
 
 ### `liaChatBox`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** In-game chat window supporting multiple tabs, command prefix detection and color-coded messages.
+`DPanel`
 
-**Example Usage:**
-```lua
-local chatBox = vgui.Create("liaChatBox")
-chatBox:setActive(true)
-```
+**Description:**
+
+In-game chat window supporting multiple tabs, command prefix detection and color-coded messages.
 
 ### `liaSpawnIcon`
-**Base Panel:** `DModelPanel`
+**Base Panel:**
 
-**Description:** Improved spawn icon built on `DModelPanel`. It centers models and applies good lighting for use in inventories or lists.
+`DModelPanel`
 
-**Example Usage:**
-```lua
-local icon = vgui.Create("liaSpawnIcon", frame)
-icon:SetModel("models/props_c17/oildrum001.mdl")
-icon:SetSize(64, 64)
-icon.DoClick = function() print("clicked") end
-```
+**Description:**
+
+Improved spawn icon built on `DModelPanel`. It centers models and applies good lighting for use in inventories or lists.
 
 ### `VoicePanel`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** HUD element that lists players using voice chat. Each entry fades out after a player stops talking.
+`DPanel`
 
-**Example Usage:**
-```lua
-local voiceEntry = voiceList:Add("VoicePanel")
-voiceEntry:Setup(player)
-```
+**Description:**
+
+HUD element that lists players using voice chat. Each entry fades out after a player stops talking.
 
 ### `liaHorizontalScroll`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Container that arranges child panels in a single row. Often paired with a custom scrollbar when content overflows.
+`DPanel`
 
-**Example Usage:**
-```lua
-local scroll = vgui.Create("liaHorizontalScroll")
-scroll.bar = scroll:Add("liaHorizontalScrollBar")
-scroll.bar:Dock(BOTTOM)
-```
+**Description:**
+
+Container that arranges child panels in a single row. Often paired with a custom scrollbar when content overflows.
 
 ### `liaHorizontalScrollBar`
-**Base Panel:** `DVScrollBar`
+**Base Panel:**
 
-**Description:** Custom scrollbar paired with `liaHorizontalScroll`. It moves the canvas horizontally when items overflow.
+`DVScrollBar`
 
-**Example Usage:**
-```lua
-local bar = vgui.Create("liaHorizontalScrollBar")
-bar.TargetCanvas = scroll.canvas
-```
+**Description:**
+
+Custom scrollbar paired with `liaHorizontalScroll`. It moves the canvas horizontally when items overflow.
 
 ### `liaItemMenu`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Drop-down menu that appears when interacting with items in the world. Lets players pick up, examine or drop the item.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local menu = vgui.Create("liaItemMenu")
-menu:SetEntity(targetItem)
-menu:Open()
-menu:Center()
-```
+**Description:**
+
+Drop-down menu that appears when interacting with items in the world. Lets players pick up, examine or drop the item.
 
 ### `liaAttribBar`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Interactive bar used during character creation to assign starting attribute points.
+`DPanel`
 
-**Example Usage:**
-```lua
-local bar = vgui.Create("liaAttribBar", panel)
-bar:SetMax(10)
-bar:SetValue(0)
-```
+**Description:**
+
+Interactive bar used during character creation to assign starting attribute points.
 
 ### `liaCharacterAttribs`
-**Base Panel:** `liaCharacterCreateStep`
+**Base Panel:**
 
-**Description:** Character creation step panel for distributing attribute points across stats.
+`liaCharacterCreateStep`
 
-**Example Usage:**
-```lua
-local row = vgui.Create("liaCharacterAttribsRow", attributesPanel)
-row:setAttribute("strength", 5)
-```
+**Description:**
+
+Character creation step panel for distributing attribute points across stats.
 
 ### `liaCharacterAttribsRow`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Represents a single attribute with its description and current points, including buttons for adjustment.
+`DPanel`
 
-**Example Usage:**
-```lua
-local row = vgui.Create("liaCharacterAttribsRow")
-row:setAttribute("agility", 2)
-row:updateQuantity()
-```
+**Description:**
+
+Represents a single attribute with its description and current points, including buttons for adjustment.
 
 ### `liaItemIcon`
-**Base Panel:** `SpawnIcon`
+**Base Panel:**
 
-**Description:** Spawn icon specialised for Lilia item tables. Displays custom tooltips and supports right-click menus.
+`SpawnIcon`
 
-**Example Usage:**
-```lua
-local icon = vgui.Create("liaItemIcon", parent)
-icon:setItem(item)
-icon:SetTooltip(item:getName())
-```
+**Description:**
+
+Spawn icon specialised for Lilia item tables. Displays custom tooltips and supports right-click menus.
 
 ### `BlurredDFrame`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Frame that draws a screen blur behind its contents. Useful for overlay menus that shouldn't fully obscure the game.
+`DFrame`
 
-**Example Usage:**
-```lua
-local frame = vgui.Create("BlurredDFrame")
-frame:SetSize(300, 200)
-```
+**Description:**
+
+Frame that draws a screen blur behind its contents. Useful for overlay menus that shouldn't fully obscure the game.
 
 ### `SemiTransparentDFrame`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Simplified frame with a semi-transparent background, ideal for pop-up windows where the game should remain partially visible.
+`DFrame`
 
-**Example Usage:**
-```lua
-local frame = vgui.Create("SemiTransparentDFrame")
-frame:SetTitle("Notice")
-```
+**Description:**
+
+Simplified frame with a semi-transparent background, ideal for pop-up windows where the game should remain partially visible.
 
 ### `SemiTransparentDPanel`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Basic panel that paints itself with partial transparency. Often used inside `SemiTransparentDFrame` as an inner container.
+`DPanel`
 
-**Example Usage:**
-```lua
-local panel = vgui.Create("SemiTransparentDPanel", frame)
-panel:SetSize(200, 100)
-```
+**Description:**
+
+Basic panel that paints itself with partial transparency. Often used inside `SemiTransparentDFrame` as an inner container.
 
 ### `liaDoorMenu`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Interface for property doors showing ownership and faction access. Owners can lock, sell or share the door through this menu.
+`DFrame`
 
-**Example Usage:**
-```lua
-local doorMenu = vgui.Create("liaDoorMenu")
-doorMenu:setDoor(doorEntity, true)
-doorMenu:Center()
-```
+**Description:**
+
+Interface for property doors showing ownership and faction access. Owners can lock, sell or share the door through this menu.
 
 ### `liaScoreboard`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Replacement scoreboard that groups players by team or faction and displays additional stats like ping and play time.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local board = vgui.Create("liaScoreboard")
-board:Show()
-```
+**Description:**
+
+Replacement scoreboard that groups players by team or faction and displays additional stats like ping and play time.
 
 ### `liaCharacter`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Main panel of the character selection menu. Lists the player's characters with options to create, delete or load them.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local charMenu = vgui.Create("liaCharacter")
-charMenu:Dock(FILL)
-charMenu:populateList()
-```
+**Description:**
+
+Main panel of the character selection menu. Lists the player's characters with options to create, delete or load them.
 
 ### `liaCharBGMusic`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Small panel that plays ambient music when the main menu is open. It fades the track in and out as the menu is shown or closed.
+`DPanel`
 
-**Example Usage:**
-```lua
-local musicPanel = vgui.Create("liaCharBGMusic")
-musicPanel:Play("music/menu_theme.mp3")
-```
+**Description:**
+
+Small panel that plays ambient music when the main menu is open. It fades the track in and out as the menu is shown or closed.
 
 ### `liaCharacterCreation`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Parent panel that hosts each character creation step such as biography, faction and model. It provides navigation buttons and validates input before advancing.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local creator = vgui.Create("liaCharacterCreation")
-creator:nextStep()
-```
+**Description:**
+
+Parent panel that hosts each character creation step such as biography, faction and model. It provides navigation buttons and validates input before advancing.
 
 ### `liaCharacterCreateStep`
-**Base Panel:** `DScrollPanel`
+**Base Panel:**
 
-**Description:** Scroll panel used as the foundation for each creation step. Provides helpers for saving user input and moving forward in the flow.
+`DScrollPanel`
 
-**Example Usage:**
-```lua
-local step = vgui.Create("liaCharacterCreateStep")
-step:next()
-```
+**Description:**
+
+Scroll panel used as the foundation for each creation step. Provides helpers for saving user input and moving forward in the flow.
 
 ### `liaCharacterConfirm`
-**Base Panel:** `SemiTransparentDFrame`
+**Base Panel:**
 
-**Description:** Confirmation dialog used for dangerous actions like deleting a character. Inherits from `SemiTransparentDFrame` for a consistent overlay look.
+`SemiTransparentDFrame`
 
-**Example Usage:**
-```lua
-local confirm = vgui.Create("liaCharacterConfirm")
-confirm:setMessage("Are you sure?")
-confirm:onConfirm(function() print("confirmed") end)
-```
+**Description:**
+
+Confirmation dialog used for dangerous actions like deleting a character. Inherits from `SemiTransparentDFrame` for a consistent overlay look.
 
 ### `liaCharacterBiography`
-**Base Panel:** `liaCharacterCreateStep`
+**Base Panel:**
 
-**Description:** Step where players input their character's name and optional backstory. These values are validated and stored for later steps.
+`liaCharacterCreateStep`
 
-**Example Usage:**
-```lua
-step.nameEntry:SetValue("John")
-step.descEntry:SetMultiline(true)
-```
+**Description:**
+
+Step where players input their character's name and optional backstory. These values are validated and stored for later steps.
 
 ### `liaCharacterFaction`
-**Base Panel:** `liaCharacterCreateStep`
+**Base Panel:**
 
-**Description:** Allows the player to choose from available factions. The selected faction updates the model panel and determines accessible classes.
+`liaCharacterCreateStep`
 
-**Example Usage:**
-```lua
-step:setContext("faction", 1)
-step:updateModelPanel()
-```
+**Description:**
+
+Allows the player to choose from available factions. The selected faction updates the model panel and determines accessible classes.
 
 ### `liaCharacterModel`
-**Base Panel:** `liaCharacterCreateStep`
+**Base Panel:**
 
-**Description:** Lets the player browse and select a player model appropriate for the chosen faction. Clicking an icon saves the choice and refreshes the preview.
+`liaCharacterCreateStep`
 
-**Example Usage:**
-```lua
-function PANEL:onModelSelected(icon)
-    self:setContext("model", icon.index or 1)
-    self:updateModelPanel()
-    icon:SetSelected(true)
-end
-```
+**Description:**
+
+Lets the player browse and select a player model appropriate for the chosen faction. Clicking an icon saves the choice and refreshes the preview.
 
 ### `liaInventory`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Main inventory frame for characters. It listens for network updates and renders items in the layout provided by its subclass.
+`DFrame`
 
-**Example Usage:**
-```lua
-local invFrame = vgui.Create("liaInventory")
-invFrame:SetTitle("Inventory")
-```
+**Description:**
+
+Main inventory frame for characters. It listens for network updates and renders items in the layout provided by its subclass.
 
 ### `liaGridInventory`
-**Base Panel:** `liaInventory`
+**Base Panel:**
 
-**Description:** Subclass of `liaInventory` that arranges item icons into a fixed grid. Often used for storage containers or equipment screens.
+`liaInventory`
 
-**Example Usage:**
-```lua
-local grid = vgui.Create("liaGridInventory", invFrame)
-grid:setGridSize(5, 4, 64)
-grid:Dock(FILL)
-```
+**Description:**
+
+Subclass of `liaInventory` that arranges item icons into a fixed grid. Often used for storage containers or equipment screens.
 
 ### `liaGridInvItem`
-**Base Panel:** `liaItemIcon`
+**Base Panel:**
 
-**Description:** Specialized icon used by `liaGridInventory`. Supports drag-and-drop for moving items between slots.
+`liaItemIcon`
 
-**Example Usage:**
-```lua
-local icon = vgui.Create("liaGridInvItem", grid)
-icon:setItem(item)
-icon:SetPos(0, 0)
-```
+**Description:**
+
+Specialized icon used by `liaGridInventory`. Supports drag-and-drop for moving items between slots.
 
 ### `liaGridInventoryPanel`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Container responsible for laying out `liaGridInvItem` icons in rows and columns. Handles drag-and-drop and keeps the grid in sync with item data.
+`DPanel`
 
-**Example Usage:**
-```lua
-function PANEL:populateItems()
-    -- Rebuild icons after inventory change
-    self:InvalidateLayout()
-end
-```
+**Description:**
+
+Container responsible for laying out `liaGridInvItem` icons in rows and columns. Handles drag-and-drop and keeps the grid in sync with item data.
 
 ### `Vendor`
-**Base Panel:** `EditablePanel`
+**Base Panel:**
 
-**Description:** Main vendor window that lists items the NPC will buy or sell. Provides buttons for transactions and updates when the player's inventory changes.
+`EditablePanel`
 
-**Example Usage:**
-```lua
-local vendorUI = vgui.Create("Vendor")
-vendorUI:PopulateItems()
-```
+**Description:**
+
+Main vendor window that lists items the NPC will buy or sell. Provides buttons for transactions and updates when the player's inventory changes.
 
 ### `VendorItem`
-**Base Panel:** `DPanel`
+**Base Panel:**
 
-**Description:** Panel representing an individual item within the vendor list. Shows price information and handles clicks for buying or selling.
+`DPanel`
 
-**Example Usage:**
-```lua
-local itemRow = vgui.Create("VendorItem", vendorUI.list)
-itemRow:setItemType("ammo")
-itemRow.DoClick = function() vendorUI:buy("ammo") end
-itemRow:SetTall(40)
-```
+**Description:**
+
+Panel representing an individual item within the vendor list. Shows price information and handles clicks for buying or selling.
 
 ### `VendorEditor`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Administrative window for editing a vendor's inventory and settings, including item prices and faction permissions.
+`DFrame`
 
-**Example Usage:**
-```lua
-local editor = vgui.Create("VendorEditor")
-editor:SetZPos(99)
-```
+**Description:**
+
+Administrative window for editing a vendor's inventory and settings, including item prices and faction permissions.
 
 ### `VendorFactionEditor`
-**Base Panel:** `DFrame`
+**Base Panel:**
 
-**Description:** Secondary editor for selecting which factions and player classes can trade with the vendor.
+`DFrame`
 
-**Example Usage:**
-```lua
-factionButton.DoClick = function()
-    vgui.Create("VendorFactionEditor"):MoveLeftOf(factionButton, 4)
-end
-```
+**Description:**
+
+Secondary editor for selecting which factions and player classes can trade with the vendor.
+

--- a/docs/docs/hooks/attribute_hooks.md
+++ b/docs/docs/hooks/attribute_hooks.md
@@ -10,11 +10,24 @@ Attributes can define their own hooks to react when a player's attribute is crea
 
 ---
 
-#### `OnSetup(client, value)`
+### OnSetup
 
-**Type:** `function(client, number)`
+```lua
+function ATTRIBUTE:OnSetup(client, value)
+```
 
-**Description:** Called when the attribute is initialized on a player (e.g., at character load or creation). Use this hook to run custom logic, send notifications, apply effects, etc.
+**Description:**
+
+Called when the attribute is initialized on a player (for example, during character load or creation). Use this hook to run custom logic, send notifications or apply effects.
+
+**Parameters:**
+
+* `client` (`Player`) – The player the attribute belongs to.
+* `value` (`number`) – The value assigned to the attribute.
+
+**Realm:**
+
+* Server
 
 **Example Usage:**
 
@@ -28,3 +41,4 @@ function ATTRIBUTE:OnSetup(client, value)
     end
 end
 ```
+

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,49 +1,36 @@
 ## Installation Tutorial
-
 Lilia is a versatile roleplay framework for Garry's Mod. This tutorial guides you through installing Lilia on your server so you can create a stable roleplaying environment.
-
 > **Note**
 > Lilia runs beneath a roleplay schema. After installing Lilia, you must also install a schema and start your server using that schema's gamemode (for example, `+gamemode scprp`).
-
 ---
-
 ## Prerequisites
-
 Before you begin, make sure you have the following:
-
-- **A Working Garry's Mod Server:** Make sure your server is set up and running without issues.
-- **Basic Knowledge of Server Administration:** Familiarity with managing a Garry's Mod server is helpful.
-- **Command Line Proficiency:** You should be comfortable using the command line.
-- **Admin Menu:** We recommend [SAM](https://www.gmodstore.com/market/view/sam) for administrative tasks.
-- **Code Editor (optional):** If you don't already have one, a code editor makes development easier. Recommended editors include:
-  
+- **A Working Garry's Mod Server:**
+Make sure your server is set up and running without issues.
+- **Basic Knowledge of Server Administration:**
+Familiarity with managing a Garry's Mod server is helpful.
+- **Command Line Proficiency:**
+You should be comfortable using the command line.
+- **Admin Menu:**
+We recommend [SAM](https://www.gmodstore.com/market/view/sam) for administrative tasks.
+- **Code Editor (optional):**
+If you don't already have one, a code editor makes development easier. Recommended editors include:
   1. [Visual Studio Code](https://code.visualstudio.com/)
   2. [Notepad++](https://notepad-plus-plus.org/)
   3. [Sublime Text](https://www.sublimetext.com/)
   4. [Atom](https://atom.io/)
-
 ---
-
 ## Step 1: Setting Up Your Garry's Mod Server
-
 If you haven't already, set up your Garry's Mod server and ensure it is running smoothly before proceeding with the installation of Lilia.
-
 ---
-
 ## Step 2: Downloading Lilia
-
 1. **Visit the Lilia GitHub Repository:**
-
     Navigate to the [Lilia GitHub Repository](https://github.com/LiliaFramework/Lilia).
-
-2. **Download the ZIP File:**  
-    - Download the latest release directly from [here](https://github.com/LiliaFramework/Lilia/releases/download/release/lilia.zip).  
+2. **Download the ZIP File:**
+    - Download the latest release directly from [here](https://github.com/LiliaFramework/Lilia/releases/download/release/lilia.zip).
     - Save the ZIP file to a convenient location on your computer.
-
 ---
-
 ## Step 3: Extracting Lilia
-
 1. **Locate the Downloaded ZIP File:**
 
     Find the `Lilia.zip` file you downloaded.
@@ -57,11 +44,8 @@ If you haven't already, set up your Garry's Mod server and ensure it is running 
 
     - After extraction, you should see a folder named `lilia`.
     - Move the `lilia` folder to a separate location for easy access during the upload process.
-
 ---
-
 ## Step 4: Uploading Lilia to Your Server
-
 1. **Connect to Your Server:**
 
     Use an FTP or SFTP client (e.g., [FileZilla](https://filezilla-project.org/) or [WinSCP](https://winscp.net/eng/index.php)) to connect to your Garry's Mod server.
@@ -73,87 +57,55 @@ If you haven't already, set up your Garry's Mod server and ensure it is running 
 3. **Upload the Lilia Folder:**
 
     Upload the `lilia` folder you extracted earlier into the `gamemodes` directory.
-
     ```plaintext
     Server Directory Path:
     garrysmod/gamemodes/lilia
     ```
-
 ---
-
 ## Step 5: Installing a Roleplay Schema
-
 Enhance your roleplaying experience by installing a compatible roleplay schema for the Lilia framework. Follow the steps below:
-
 ### 1. Choose a Schema
-
 Select a schema that fits your server theme:
-
 - **Skeleton Schema**
     - [GitHub Repository](https://github.com/LiliaFramework/Skeleton)
     - [Direct Download](https://github.com/LiliaFramework/Skeleton/releases/download/release/skeleton.zip)
-
 - **SCPRP Schema**
     - [GitHub Repository](https://github.com/LiliaFramework/SCPRP)
     - [Direct Download](https://github.com/LiliaFramework/SCPRP/releases/download/release/scprp.zip)
-
 ---
-
 ### 2. Download the Schema
-
 Visit the schema's GitHub repository or use the direct download link, and download the ZIP file or clone the repository.
-
 ---
-
 ### 3. Extract and Upload
-
 Extract the schema files locally, then upload the extracted folder to your server:
-
 ```plaintext
 garrysmod/gamemodes/<SchemaName>
 ```
-
 ---
-
 ### 4. Configure the Schema
-
 Customize the following directories as needed for your server’s gameplay:
-
 ```plaintext
 Factions:  garrysmod/gamemodes/<SchemaName>/schema/factions/
 Classes:   garrysmod/gamemodes/<SchemaName>/schema/classes/
 Items:     garrysmod/gamemodes/<SchemaName>/schema/items/
 Modules:   garrysmod/gamemodes/<SchemaName>/modules/
 ```
-
 ---
-
 ## Step 6: Launching the Server with Your Schema
-
 1. **Set the Startup Gamemode**
-
     Edit your server's startup parameters so the server boots directly into your chosen schema:
-
     ```plaintext
     +gamemode <SchemaName>
     ```
-
     Example usage:
-
     ```plaintext
     +gamemode scprp
     ```
-
 2. **Start the Server**
-
     Launch or restart your Garry's Mod server. Lilia will load as the framework beneath the schema.
-
 3. **Verify the Installation**
-
     Watch the console for a line such as:
-
     ```plaintext
     [Lilia] [Bootstrap] Loaded successfully after X seconds.
     ```
-
     If no errors appear and the schema loads, you're ready to play.

--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -813,7 +813,7 @@ Determines if the player has whitelist access for a faction.
 
 **Returns:**
 
-**Example Usage:**True if whitelisted.
+* boolean – True if whitelisted.
 
 **Example Usage:**
 
@@ -837,7 +837,7 @@ Retrieves the class index of the player's character.
 
 * Shared
 
-**Example Usage:**
+**Returns:**
 
 * number|None – Class index or None.
 
@@ -860,8 +860,6 @@ Checks if the player's character is whitelisted for a class.
 * class (number) – Class index.
 
 **Realm:**
-
-**Example Usage:**
 
 **Returns:**
 
@@ -886,8 +884,6 @@ Returns the class table of the player's current class.
 * None
 
 **Realm:**
-
-**Example Usage:**
 
 * Shared
 
@@ -914,8 +910,6 @@ Compatibility helper for retrieving money with DarkRP-style calls.
 * var (string) – Currently only supports "money".
 
 **Realm:**
-
-**Example Usage:**
 
 * Shared
 

--- a/docs/docs/modules.md
+++ b/docs/docs/modules.md
@@ -4,7 +4,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Advert
 
-**Description:** Adds an Advert command
+**Description:**
+
+Adds an Advert command
 
 **Features:**
 
@@ -20,7 +22,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Alcoholism
 
-**Description:** Adds Alcohol and its effects
+**Description:**
+
+Adds Alcohol and its effects
 
 **Features:**
 
@@ -38,7 +42,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Auto Restarter
 
-**Description:** Automatically restarts the server every interval
+**Description:**
+
+Automatically restarts the server every interval
 
 **Features:**
 
@@ -54,7 +60,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Bodygrouper
 
-**Description:** Adds a bodygroup menu and bodygroup closet, akin to BodygroupR on GModStore
+**Description:**
+
+Adds a bodygroup menu and bodygroup closet, akin to BodygroupR on GModStore
 
 **Features:**
 
@@ -70,7 +78,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Broadcasts
 
-**Description:** Adds a Faction & Class broadcast command
+**Description:**
+
+Adds a Faction & Class broadcast command
 
 **Features:**
 
@@ -86,7 +96,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Captions
 
-**Description:** Adds an easy way of showing in-game captions
+**Description:**
+
+Adds an easy way of showing in-game captions
 
 **Features:**
 
@@ -102,7 +114,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Cards
 
-**Description:** Adds the ability to draw a random card from a deck
+**Description:**
+
+Adds the ability to draw a random card from a deck
 
 **Features:**
 
@@ -118,7 +132,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Chat Messages
 
-**Description:** Adds simple adverts
+**Description:**
+
+Adds simple adverts
 
 **Features:**
 
@@ -134,7 +150,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Cinematic Text
 
-**Description:** Cinematic-looking splash text for extra flair
+**Description:**
+
+Cinematic-looking splash text for extra flair
 
 **Features:**
 
@@ -150,7 +168,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Climb
 
-**Description:** Adds the ability to climb up ledges
+**Description:**
+
+Adds the ability to climb up ledges
 
 **Features:**
 
@@ -166,7 +186,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Code Utils
 
-**Description:** Adds a few extensions to the `lia.util` library
+**Description:**
+
+Adds a few extensions to the `lia.util` library
 
 **Features:**
 
@@ -182,7 +204,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Community Commands
 
-**Description:** Adds links to various community content
+**Description:**
+
+Adds links to various community content
 
 **Features:**
 
@@ -198,7 +222,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Corpse ID
 
-**Description:** Adds a corpse identification mechanic
+**Description:**
+
+Adds a corpse identification mechanic
 
 **Features:**
 
@@ -214,7 +240,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Cursor
 
-**Description:** Adds a cursor system
+**Description:**
+
+Adds a cursor system
 
 **Features:**
 
@@ -230,7 +258,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Simple Cutscenes
 
-**Description:** A system for simple cutscenes
+**Description:**
+
+A system for simple cutscenes
 
 **Features:**
 
@@ -246,7 +276,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Damage Numbers
 
-**Description:** Displays damage numbers when you hit someone or get hit
+**Description:**
+
+Displays damage numbers when you hit someone or get hit
 
 **Features:**
 
@@ -262,7 +294,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Development HUD
 
-**Description:** Adds a development HUD
+**Description:**
+
+Adds a development HUD
 
 **Features:**
 
@@ -278,7 +312,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Development Server
 
-**Description:** Adds the option for a development server that can run specific functions
+**Description:**
+
+Adds the option for a development server that can run specific functions
 
 **Features:**
 
@@ -294,7 +330,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Discord Relay
 
-**Description:** Relays logs to Discord
+**Description:**
+
+Relays logs to Discord
 
 **Features:**
 
@@ -310,7 +348,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Donator
 
-**Description:** Adds several donation-related libraries
+**Description:**
+
+Adds several donation-related libraries
 
 **Features:**
 
@@ -326,7 +366,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Door Kick
 
-**Description:** Allows you to kick doors open
+**Description:**
+
+Allows you to kick doors open
 
 **Features:**
 
@@ -342,7 +384,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Hospitals
 
-**Description:** Adds hospitals that spawn you after dying
+**Description:**
+
+Adds hospitals that spawn you after dying
 
 **Features:**
 
@@ -358,7 +402,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Extended Descriptions
 
-**Description:** Adds support for extended descriptions
+**Description:**
+
+Adds support for extended descriptions
 
 **Features:**
 
@@ -374,7 +420,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## First Person Effects
 
-**Description:** Realistic first-person effects
+**Description:**
+
+Realistic first-person effects
 
 **Features:**
 
@@ -390,7 +438,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Flashlight
 
-**Description:** Makes the flashlight more serious
+**Description:**
+
+Makes the flashlight more serious
 
 **Features:**
 
@@ -406,7 +456,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Free Look
 
-**Description:** Adds Free Look similar to EFT
+**Description:**
+
+Adds Free Look similar to EFT
 
 **Features:**
 
@@ -422,7 +474,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Gamemaster Teleport Points
 
-**Description:** Allows GMs to teleport to predefined points on the map
+**Description:**
+
+Allows GMs to teleport to predefined points on the map
 
 **Features:**
 
@@ -438,7 +492,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Extra HUD Elements
 
-**Description:** Implements extra HUD elements
+**Description:**
+
+Implements extra HUD elements
 
 **Features:**
 
@@ -454,7 +510,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Instant Killing
 
-**Description:** Enables instant kills on headshots
+**Description:**
+
+Enables instant kills on headshots
 
 **Features:**
 
@@ -470,7 +528,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Join Leave Messages
 
-**Description:** Adds join and leave messages
+**Description:**
+
+Adds join and leave messages
 
 **Features:**
 
@@ -486,7 +546,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Load Messages
 
-**Description:** Sends faction-based messages when players first load their character
+**Description:**
+
+Sends faction-based messages when players first load their character
 
 **Features:**
 
@@ -502,7 +564,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Loyalism
 
-**Description:** System for loyalist tiers
+**Description:**
+
+System for loyalist tiers
 
 **Features:**
 
@@ -518,7 +582,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Map Cleaner
 
-**Description:** Adds a map cleaner with configurable timings
+**Description:**
+
+Adds a map cleaner with configurable timings
 
 **Features:**
 
@@ -534,7 +600,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Model Pay
 
-**Description:** Adds a system to pay per model
+**Description:**
+
+Adds a system to pay per model
 
 **Features:**
 
@@ -550,7 +618,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Model Tweaker
 
-**Description:** Adds a Model-Tweaker entity
+**Description:**
+
+Adds a Model-Tweaker entity
 
 **Features:**
 
@@ -566,7 +636,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## NPC Drops
 
-**Description:** Adds NPCs that drop items
+**Description:**
+
+Adds NPCs that drop items
 
 **Features:**
 
@@ -582,7 +654,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## NPC Spawner
 
-**Description:** Adds automatic NPC spawning
+**Description:**
+
+Adds automatic NPC spawning
 
 **Features:**
 
@@ -598,7 +672,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Perma Remove
 
-**Description:** Allows staff to permanently remove map entities
+**Description:**
+
+Allows staff to permanently remove map entities
 
 **Features:**
 
@@ -614,7 +690,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Radio
 
-**Description:** Radio system
+**Description:**
+
+Radio system
 
 **Features:**
 
@@ -630,7 +708,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Raised Weapons
 
-**Description:** Adds a safety system that holsters sweps
+**Description:**
+
+Adds a safety system that holsters sweps
 
 **Features:**
 
@@ -646,7 +726,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Realistic Damage
 
-**Description:** Adds damage scalers for realism
+**Description:**
+
+Adds damage scalers for realism
 
 **Features:**
 
@@ -662,7 +744,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Realistic View
 
-**Description:** Adds a realistic 1st-person view that allows you to see the entire body
+**Description:**
+
+Adds a realistic 1st-person view that allows you to see the entire body
 
 **Features:**
 
@@ -678,7 +762,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Rumour
 
-**Description:** Adds a Rumour command
+**Description:**
+
+Adds a Rumour command
 
 **Features:**
 
@@ -694,7 +780,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Shoot Locks
 
-**Description:** Shoot locks to open doors
+**Description:**
+
+Shoot locks to open doors
 
 **Features:**
 
@@ -710,7 +798,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Lockpicking
 
-**Description:** Adds simple lockpicking to brute-force doors
+**Description:**
+
+Adds simple lockpicking to brute-force doors
 
 **Features:**
 
@@ -726,7 +816,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Slots
 
-**Description:** Adds a slot-machine entity
+**Description:**
+
+Adds a slot-machine entity
 
 **Features:**
 
@@ -742,7 +834,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Heavy Weapons
 
-**Description:** Slows movement when carrying heavy weapons
+**Description:**
+
+Slows movement when carrying heavy weapons
 
 **Features:**
 
@@ -758,7 +852,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Stun Gun
 
-**Description:** A stun gun reworked from CustomHQ
+**Description:**
+
+A stun gun reworked from CustomHQ
 
 **Features:**
 
@@ -774,7 +870,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Tying
 
-**Description:** Adds tying items that serve as handcuffs, enhancing role-play
+**Description:**
+
+Adds tying items that serve as handcuffs, enhancing role-play
 
 **Features:**
 
@@ -790,7 +888,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## View Bob
 
-**Description:** Adds custom view-bob
+**Description:**
+
+Adds custom view-bob
 
 **Features:**
 
@@ -806,7 +906,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## VManip
 
-**Description:** Adds VManip compatibility to Lilia
+**Description:**
+
+Adds VManip compatibility to Lilia
 
 **Features:**
 
@@ -822,7 +924,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Warrant
 
-**Description:** Adds warrants
+**Description:**
+
+Adds warrants
 
 **Features:**
 
@@ -838,7 +942,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## War Table
 
-**Description:** Adds an interactive war table
+**Description:**
+
+Adds an interactive war table
 
 **Features:**
 
@@ -854,7 +960,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Weight Inv
 
-**Description:** Adds a weight-based inventory
+**Description:**
+
+Adds a weight-based inventory
 
 **Features:**
 
@@ -870,7 +978,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Whitelist
 
-**Description:** Adds a server whitelist
+**Description:**
+
+Adds a server whitelist
 
 **Features:**
 
@@ -886,7 +996,9 @@ These free modules expand the base mechanics of Lilia. They are all open-source 
 
 ## Word Filter
 
-**Description:** Filters unwanted words out of the chat
+**Description:**
+
+Filters unwanted words out of the chat
 
 **Features:**
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -65,7 +65,6 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
         name = L("unknown"),
         desc = L("noDesc"),
         author = L("anonymous"),
-        identifier = "",
         enabled = true,
         IsValid = function() return true end
     }
@@ -103,12 +102,10 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
     if uniqueID ~= "schema" and not enabled then
         lia.bootstrap("Module", "Disabled module '" .. MODULE.name .. "'")
         lia.module.list[uniqueID] = nil
-        if MODULE.identifier ~= "" then _G[MODULE.identifier] = nil end
         _G[variable] = prev
         return
     end
 
-    if uniqueID ~= "schema" and MODULE.identifier ~= "" then _G[MODULE.identifier] = {} end
     loadPermissions(MODULE.CAMIPrivileges)
     if not isSingleFile then
         loadDependencies(MODULE.Dependencies)
@@ -177,7 +174,6 @@ function lia.module.initialize()
             local ok = isfunction(mod.enabled) and mod.enabled() or mod.enabled
             if not ok then
                 lia.module.list[id] = nil
-                if mod.identifier ~= "" then _G[mod.identifier] = nil end
             end
         end
     end


### PR DESCRIPTION
## Summary
- ensure line breaks for colon elements in installation instructions
- remove example usage from panel definitions
- remove `MODULE.identifier` field
- drop MODULE.identifier code from the modularity library

## Testing
- `mkdocs build -f docs/mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_e_6861fde936c8832786e4e1523b2c9a64