### PR TITLE
Add consistent spacing in definition docs

### DIFF
--- a/docs/docs/definitions/attribute.md
+++ b/docs/docs/definitions/attribute.md
@@ -1,17 +1,12 @@
 # Attribute Fields
 
-
 > This entry describes all configurable `ATTRIBUTE` fields in the codebase. Use these to control each attribute’s display, limits, and behavior when applied to players. Unspecified fields fall back to sensible defaults.
-
 
 ---
 
-
 ## Overview
 
-
 Each attribute is registered on the global `ATTRIBUTE` table. You can customize:
-
 
 * **Display**: The `name` and `desc` that players see in-game.
 
@@ -19,12 +14,9 @@ Each attribute is registered on the global `ATTRIBUTE` table. You can customize:
 
 * **Value limits**: The hard cap (`maxValue`) and the creation-time base cap (`startingMax`).
 
-
 ---
 
-
 ## Field Summary
-
 
 | Field          | Type      | Default | Description                                                                                    |
 | -------------- | --------- | ------- | ---------------------------------------------------------------------------------------------- |
@@ -36,65 +28,56 @@ Each attribute is registered on the global `ATTRIBUTE` table. You can customize:
 
 ---
 
-
 ## Field Details
-
 
 #### `name`
 
-
 Specify the human-readable title for the attribute.
-
 
 ```lua
 ATTRIBUTE.name = "Strength"
 ```
 
+---
 
 #### `desc`
 
-
 Provide a concise description for the attribute.
-
 
 ```lua
 ATTRIBUTE.desc = "Determines physical power and carrying capacity."
 ```
 
+---
 
 #### `startingMax`
 
-
 Defines the cap on the attribute’s base value at character creation.
-
 
 ```lua
 ATTRIBUTE.startingMax = 15
 ```
 
+---
 
 #### `noStartBonus`
-
 
 Controls whether this attribute is eligible for the startup bonus—the pool of points players assign when creating a character.
 
 If set to `true`, players cannot allocate any of their initial creation points to this attribute.
 
-
 ```lua
 ATTRIBUTE.noStartBonus = false
 ```
 
+---
 
 #### `maxValue`
 
-
 Sets the hard cap for this attribute.
-
 
 ```lua
 ATTRIBUTE.maxValue = 50
 ```
-
 
 ---

--- a/docs/docs/definitions/class.md
+++ b/docs/docs/definitions/class.md
@@ -1,23 +1,16 @@
 # Class Fields
 
-
 This document describes all configurable `CLASS` fields in the codebase. Each field controls a specific aspect of how a class behaves, appears, or is granted to players. Unspecified fields will use sensible defaults.
 
-
 ---
-
 
 ## Overview
 
-
 The global `CLASS` table defines per-class settings such as display name, lore, starting equipment, pay parameters, movement speeds, and visual appearance. Use these fields to fully customize each class’s behavior and presentation.
-
 
 ---
 
-
 ## Field Summary
-
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -48,512 +41,379 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 
 ---
 
-
 ## Field Details
 
-
 ### Basic Info
-
 
 #### `name`
 
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 The displayed name of the class.
-
 **Example Usage:**
 
 ```lua
 CLASS.name = "Engineer"
 ```
 
+---
 
 #### `desc`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 The description or lore of the class.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.desc = "Technicians who maintain equipment."
 ```
 
+---
 
 #### `index`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Unique numeric identifier (team index) for the class.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.index = CLASS_ENGINEER
 ```
 
-
 ---
-
 
 ### Affiliation & Availability
 
-
 #### `isDefault`
-
 
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Determines if the class is available to all players by default.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.isDefault = true
 ```
 
+---
 
 #### `isWhitelisted`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Indicates if the class requires a whitelist entry to be accessible.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.isWhitelisted = false
 ```
 
+---
 
 #### `faction`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Links this class to a specific faction index.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.faction = FACTION_CITIZEN
 ```
 
+---
 
 #### `color`
 
-
 **Type:**
 
-
 `Color`
-
 **Description:**
 
-
 UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.color = Color(255, 0, 0)
 ```
 
-
 ---
-
 
 ### Equipment & Economy
 
-
 #### `weapons`
-
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Weapons granted to members of this class on spawn.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
 ```
 
+---
 
 #### `pay`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Payment amount issued per pay interval.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.pay = 50
 ```
 
+---
 
 #### `payLimit`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Maximum accumulated pay a player can hold.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.payLimit = 1000
 ```
 
+---
 
 #### `payTimer`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Interval in seconds between salary payouts.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.payTimer = 3600
 ```
 
+---
 
 #### `limit`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Maximum number of players allowed in this class simultaneously.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.limit = 10
 ```
 
-
 ---
-
 
 ### Movement & Stats
 
-
 #### `health`
-
 
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Default starting health for class members.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.health = 150
 ```
 
+---
 
 #### `armor`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Default starting armor.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.armor = 50
 ```
 
+---
 
 #### `scale`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Multiplier for player model size.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.scale = 1.2
 ```
 
+---
 
 #### `runSpeed`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Default running speed.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.runSpeed = 250
 ```
 
+---
 
 #### `runSpeedMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Multiply base run speed instead of replacing it.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.runSpeedMultiplier = true
 ```
 
+---
 
 #### `walkSpeed`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Default walking speed.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.walkSpeed = 200
 ```
 
+---
 
 #### `walkSpeedMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Multiply base walk speed instead of replacing it.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.walkSpeedMultiplier = false
 ```
 
+---
 
 #### `jumpPower`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Default jump power.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.jumpPower = 200
 ```
 
+---
 
 #### `jumpPowerMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Multiply base jump power instead of replacing it.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.jumpPowerMultiplier = true
 ```
 
+---
 
 #### `bloodcolor`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Blood color enumeration constant for this class.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.bloodcolor = BLOOD_COLOR_RED
 ```
 
-
 ---
-
 
 ### Appearance & Identity
 
-
 #### `bodyGroups`
-
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Mapping of bodygroup indices to values applied on spawn.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.bodyGroups = {
@@ -562,23 +422,20 @@ CLASS.bodyGroups = {
 }
 ```
 
+---
 
 #### `model`
 
-
 **Type:**
 
-
 `string` or `table`
-
 **Description:**
 
-
 Model path (or list of paths) assigned to this class.
-
 **Example Usage:**
-
 
 ```lua
 CLASS.model = "models/player/alyx.mdl"
 ```
+
+---

--- a/docs/docs/definitions/command.md
+++ b/docs/docs/definitions/command.md
@@ -1,25 +1,18 @@
 # Command Fields
 
-
 This document describes all configurable fields accepted by `lia.command.add`. Use these to define command behavior, permissions, help text, and admin utility integration.
 
 All fields are optional unless noted otherwise.
 
-
 ---
-
 
 ## Overview
 
-
 When you register a command with `lia.command.add`, you provide a table of fields that control its names, who can run it, how it appears in help menus or admin utilities, and what code runs when it’s invoked. All fields are optional unless noted otherwise.
-
 
 ---
 
-
 ## Field Summary
-
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -32,181 +25,124 @@ When you register a command with `lia.command.add`, you provide a table of field
 | `AdminStick` | `table` | `nil` | Defines how the command appears in admin utilities. |
 | `onRun(client, args)` | `function(client, table)` | `nil` | Function executed when the command is invoked. |
 
-
 ---
-
 
 ## Field Details
 
-
 ### Aliases & Permissions
-
 
 #### `alias`
 
 **Type:**
 
-
 `string` or `table`
-
 **Description:**
 
-
 One or more alternative command names that trigger the same behavior.
-
 **Example Usage:**
 
 ```lua
 alias = {"chargiveflag", "giveflag"}
 ```
 
-
 ---
-
 
 #### `adminOnly`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, only players with the registered CAMI admin privilege (automatically created) may run the command.
-
 **Example Usage:**
-
 
 ```lua
 adminOnly = true
 ```
 
-
 ---
-
 
 #### `superAdminOnly`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, restricts usage to super administrators (automatically registers a CAMI privilege).
-
 **Example Usage:**
-
 
 ```lua
 superAdminOnly = true
 ```
 
-
 ---
-
 
 #### `privilege`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Custom CAMI privilege name checked when running the command. Defaults to the command’s primary name if omitted.
-
 **Example Usage:**
-
 
 ```lua
 privilege = "Manage Doors"
 ```
 
-
 ---
-
 
 ### Syntax & Description
 
-
 #### `syntax`
-
 
 **Type:**
 
-
 `string`
-
 **Description:**
-
 
 Human-readable syntax string shown in help menus. Does not affect argument parsing.
 
 You can use spaces in argument names for better readability.
 
 The in-game prompt only appears when every argument follows the `[type Name]` format.
-
 **Example Usage:**
-
 
 ```lua
 syntax = "[string Target Name] [number Amount]"
 ```
 
-
 ---
-
 
 #### `desc`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Short description of what the command does, displayed in command lists and menus.
-
 **Example Usage:**
-
 
 ```lua
 desc = "Purchase a door if it is available and you can afford it."
 ```
 
-
 ---
-
 
 ### AdminStick Integration
 
-
 #### `AdminStick`
-
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Defines how the command appears in admin utility menus. Common keys:
-
 
 * `Name` (string): Display text.
 
@@ -215,10 +151,7 @@ Defines how the command appears in admin utility menus. Common keys:
 * `SubCategory` (string): Secondary grouping.
 
 * `Icon` (string): 16×16 icon path.
-
-
 **Example Usage:**
-
 
 ```lua
 AdminStick = {
@@ -229,29 +162,19 @@ AdminStick = {
 }
 ```
 
-
 ---
-
 
 ### Execution Hook
 
-
 #### `onRun(client, args)`
-
 
 **Type:**
 
-
 `function(client, table)`
-
 **Description:**
 
-
 Function called when the command is executed. `args` is a table of parsed arguments. Return a string to send a message back to the caller, or return nothing for silent execution.
-
-
 **Example Usage:**
-
 
 ```lua
 onRun = function(client, arguments)
@@ -261,3 +184,5 @@ onRun = function(client, arguments)
     end
 end
 ```
+
+---

--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -1,25 +1,18 @@
 # Faction Fields
 
-
 This document describes all the configurable `FACTION` fields available in the codebase, with their descriptions and example usages.
 
 Unspecified fields will use sensible defaults.
 
-
 ---
-
 
 ## Overview
 
-
 Each faction in the game is defined by a set of fields on the global `FACTION` table. These fields control everything from display name and lore, to starting weapons and player statistics. All fields are optional; unspecified fields will fall back to sensible defaults.
-
 
 ---
 
-
 ## Field Summary
-
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -53,161 +46,119 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `RecognizesGlobally` | `boolean` | `false` | Global player recognition. |
 | `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 
-
 ---
-
 
 ## Field Details
 
-
 ### Basic Info
-
 
 #### `name`
 
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Display name shown for members of this faction.
-
 **Example Usage:**
 
 ```lua
 FACTION.name = "Minecrafters"
 ```
 
+---
 
 #### `desc`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Lore or descriptive text about the faction.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.desc = "Surviving and crafting in the blocky world."
 ```
 
+---
 
 #### `isDefault`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Set to `true` if players may select this faction without a whitelist.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.isDefault = false
 ```
 
+---
 
 #### `uniqueID`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Internal string identifier for referencing the faction.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.uniqueID = "staff"
 ```
 
+---
 
 #### `index`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Numeric identifier assigned during faction registration.
-
 **Example Usage:**
-
 
 ```lua
 FACTION_STAFF = FACTION.index
 ```
 
-
 ---
-
 
 ### Appearance & Models
 
-
 #### `color`
-
 
 **Type:**
 
-
 `Color`
-
 **Description:**
 
-
 Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.color = Color(255, 56, 252)
 ```
 
+---
 
 #### `models`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Table of player model paths available to faction members.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.models = {
@@ -216,22 +167,17 @@ FACTION.models = {
 }
 ```
 
+---
 
 #### `bodyGroups`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Mapping of bodygroup names to index values applied on spawn.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.bodyGroups = {
@@ -240,418 +186,311 @@ FACTION.bodyGroups = {
 }
 ```
 
-
 ---
-
 
 ### Economy & Limits
 
-
 #### `weapons`
-
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Weapons automatically granted on spawn.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.weapons = {"weapon_physgun", "gmod_tool"}
 ```
 
+---
 
 #### `items`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Item uniqueIDs automatically granted on character creation.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.items = {"radio", "handcuffs"}
 ```
 
+---
 
 #### `pay`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Payment amount for members each interval.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.pay = 50
 ```
 
+---
 
 #### `payLimit`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Maximum pay a member can accumulate.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.payLimit = 1000
 ```
 
+---
 
 #### `payTimer`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Interval in seconds between salary payouts.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.payTimer = 3600
 ```
 
+---
 
 #### `limit`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Maximum number of players allowed in this faction.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.limit = 20
 ```
 
+---
 
 #### `oneCharOnly`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, players may only create one character in this faction.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.oneCharOnly = true
 ```
 
-
 ---
-
 
 ### Movement & Stats
 
-
 #### `health`
-
 
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Starting health for faction members.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.health = 150
 ```
 
+---
 
 #### `armor`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Starting armor for faction members.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.armor = 25
 ```
 
+---
 
 #### `scale`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Player model scale multiplier.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.scale = 1.1
 ```
 
+---
 
 #### `runSpeed`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Base running speed.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.runSpeed = 250
 ```
 
+---
 
 #### `runSpeedMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, multiplies the base speed rather than replacing it.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.runSpeedMultiplier = false
 ```
 
+---
 
 #### `walkSpeed`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Base walking speed.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.walkSpeed = 200
 ```
 
+---
 
 #### `walkSpeedMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, multiplies the base walk speed rather than replacing it.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.walkSpeedMultiplier = true
 ```
 
+---
 
 #### `jumpPower`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Base jump power.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.jumpPower = 200
 ```
 
+---
 
 #### `jumpPowerMultiplier`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, multiplies the base jump power rather than replacing it.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.jumpPowerMultiplier = true
 ```
 
-
 ---
-
 
 ### Recognition & Relations
 
-
 #### `MemberToMemberAutoRecognition`
-
 
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Whether faction members automatically recognize each other on sight.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.MemberToMemberAutoRecognition = true
 ```
 
+---
 
 #### `RecognizesGlobally`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, members recognize all players globally, regardless of faction.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.RecognizesGlobally = false
 ```
 
+---
 
 #### `NPCRelations`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Mapping of NPC class names to disposition constants (`D_HT`, `D_LI`, etc.). NPCs are updated on spawn/creation.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.NPCRelations = {
@@ -660,44 +499,36 @@ FACTION.NPCRelations = {
 }
 ```
 
+---
 
 #### `bloodcolor`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Blood color enumeration constant for faction members.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.bloodcolor = BLOOD_COLOR_RED
 ```
 
+---
 
 #### `ScoreboardHidden`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 If `true`, members of this faction are hidden from the scoreboard.
-
 **Example Usage:**
-
 
 ```lua
 FACTION.ScoreboardHidden = false
 ```
+
+---

--- a/docs/docs/definitions/items.md
+++ b/docs/docs/definitions/items.md
@@ -1,25 +1,18 @@
 # Item Fields
 
-
 This document describes all configurable `ITEM` fields in the codebase. Use these to customize item behavior, appearance, interactions, and metadata.
 
 Unspecified fields will use sensible defaults.
 
-
 ---
-
 
 ## Overview
 
-
 The global `ITEM` table defines per-item settings such as sounds, inventory dimensions, restrictions, stats, and hooks. Unspecified fields will use sensible defaults.
-
 
 ---
 
-
 ## Field Summary
-
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -74,699 +67,523 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 
 ---
 
-
 ## Field Details
 
-
 ### Audio & Interaction
-
 
 #### `BagSound`
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Sound played when moving items to/from the bag; specified as `{path, volume}`.
-
 **Example Usage:**
 
 ```lua
 ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
 ```
 
+---
 
 #### `equipSound`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Sound played when equipping the item.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.equipSound = "items/ammo_pickup.wav"
 ```
 
+---
 
 #### `unequipSound`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Sound played when unequipping the item.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.unequipSound = "items/ammo_pickup.wav"
 ```
 
-
 ---
-
 
 ### Restrictions & Whitelists
 
-
 #### `DropOnDeath`
-
 
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Deletes the item upon player death.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.DropOnDeath = true
 ```
 
+---
 
 #### `FactionWhitelist`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Allowed faction indices for vendor interaction.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.FactionWhitelist = {FACTION_CITIZEN}
 ```
 
+---
 
 #### `RequiredSkillLevels`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Skill requirements needed to use the item.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.RequiredSkillLevels = {Strength = 5}
 ```
 
+---
 
 #### `SteamIDWhitelist`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Allowed Steam IDs for vendor interaction.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
 ```
 
+---
 
 #### `UsergroupWhitelist`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Allowed user groups for vendor interaction.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.UsergroupWhitelist = {"admin"}
 ```
 
+---
 
 #### `VIPWhitelist`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Restricts usage to VIP players.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.VIPWhitelist = true
 ```
 
-
 ---
-
 
 ### Inventory & Stacking
 
-
 #### `isBag`
-
 
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Marks the item as a bag providing extra inventory.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.isBag = true
 ```
 
+---
 
 #### `invWidth`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Internal bag inventory width.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.invWidth = 2
 ```
 
+---
 
 #### `invHeight`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Internal bag inventory height.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.invHeight = 2
 ```
 
+---
 
 #### `width`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Width in the external inventory grid.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.width = 2
 ```
 
+---
 
 #### `height`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Height in the external inventory grid.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.height = 1
 ```
 
+---
 
 #### `canSplit`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Whether the item stack can be divided.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.canSplit = true
 ```
 
+---
 
 #### `isStackable`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Allows stacking multiple quantities.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.isStackable = false
 ```
 
+---
 
 #### `maxQuantity`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Maximum stack size.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.maxQuantity = 10
 ```
 
+---
 
 #### `quantity`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Current amount in the item stack.
-
 **Example Usage:**
-
 
 ```lua
 print(item:getQuantity())
 ```
 
-
 ---
-
 
 ### Categorization & Metadata
 
-
 #### `base`
-
 
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Base item this item derives from.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.base = "weapon"
 ```
 
+---
 
 #### `isBase`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Indicates the table is a base item.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.isBase = true
 ```
 
+---
 
 #### `category`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Inventory grouping category.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.category = "Storage"
 ```
 
+---
 
 #### `name`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Displayed name of the item.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.name = "Example Item"
 ```
 
+---
 
 #### `desc`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Short description shown to players.
-
 **Example Usage:**
 
 ```lua
 ITEM.desc = "An example item"
 ```
 
+---
 
 #### `uniqueID`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Overrides the automatically generated unique identifier.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.uniqueID = "custom_unique_id"
 ```
 
+---
 
 #### `id`
 
-
 **Type:**
 
-
 `any`
-
 **Description:**
 
-
 Database identifier.
-
 **Example Usage:**
-
 
 ```lua
 print(item.id)
 ```
 
-
 ---
-
 
 ### Equipment & Stats
 
-
 #### `armor`
-
 
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Armor value granted when equipped.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.armor = 50
 ```
 
+---
 
 #### `health`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Amount of health restored when used.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.health = 50
 ```
 
+---
 
 #### `attribBoosts`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Attribute boosts applied on equip.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.attribBoosts = {strength = 5}
 ```
 
+---
 
 #### `isOutfit`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 Marks the item as an outfit.
-
 **Example Usage:**
 
 ```lua
 ITEM.isOutfit = true
 ```
 
+---
 
 #### `newSkin`
 
-
 **Type:**
 
-
 `number`
-
 **Description:**
 
-
 Skin index applied to the player model.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.newSkin = 1
 ```
 
+---
 
 #### `outfitCategory`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Slot or category for the outfit.
-
 **Example Usage:**
-
 
 ```lua
 ITEM.outfitCategory = "body"
 ```
 
+---
 
 #### `pacData`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 PAC3 customization information.
-
 **Example Usage:**
-
 
 ```lua
 -- This attaches an HGIBS gib model to the player’s eyes bone
@@ -796,22 +613,17 @@ ITEM.pacData = {
 }
 ```
 
+---
 
 #### `replacements`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Model replacements when equipped.
-
 **Example Usage:**
-
 
 ```lua
 -- This will change a certain part of the model.
@@ -844,6 +656,8 @@ ITEM.class = "weapon_pistol"
 
 ```
 
+---
+
 #### `isWeapon`
 
 **Type:**
@@ -859,6 +673,8 @@ Marks the item as a weapon.
 ITEM.isWeapon = true
 
 ```
+
+---
 
 #### `grenadeClass`
 
@@ -876,6 +692,8 @@ ITEM.grenadeClass = "weapon_frag"
 
 ```
 
+---
+
 #### `ammo`
 
 **Type:**
@@ -892,6 +710,8 @@ ITEM.ammo = "pistol"
 
 ```
 
+---
+
 #### `ammoAmount`
 
 **Type:**
@@ -907,6 +727,8 @@ Amount of ammo contained.
 ITEM.ammoAmount = 30
 
 ```
+
+---
 
 #### `weaponCategory`
 
@@ -964,6 +786,8 @@ ITEM.entityid = "item_suit"
 
 ```
 
+---
+
 #### `contents`
 
 **Type:**
@@ -1000,6 +824,8 @@ ITEM.price = 100
 
 ```
 
+---
+
 #### `flag`
 
 **Type:**
@@ -1016,6 +842,8 @@ ITEM.flag = "Y"
 
 ```
 
+---
+
 #### `rarity`
 
 **Type:**
@@ -1031,6 +859,8 @@ Rarity level affecting vendor color.
 ITEM.rarity = "Legendary"
 
 ```
+
+---
 
 #### `url`
 
@@ -1068,6 +898,8 @@ ITEM.functions = {}
 
 ```
 
+---
+
 #### `postHooks`
 
 **Type:**
@@ -1083,3 +915,5 @@ Table of post-hook callbacks.
 ITEM.postHooks = {}
 
 ```
+
+---

--- a/docs/docs/definitions/module.md
+++ b/docs/docs/definitions/module.md
@@ -1,25 +1,18 @@
 # Module Fields
 
-
 This document describes the default `MODULE` fields provided by the Lilia framework. Use these to configure module metadata, dependencies, loading behavior, and lifecycle hooks.
 
 Unspecified fields will use sensible defaults.
 
-
 ---
-
 
 ## Overview
 
-
 A `MODULE` table defines a self-contained add-on for the Lilia framework. Each field controls how the module is identified, loaded, and interacts with permissions and workshop content.
-
 
 ---
 
-
 ## Field Summary
-
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -40,92 +33,69 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 | `Public` | `boolean` | `false` | Participates in public version checks. |
 | `Private` | `boolean` | `false` | Uses private version checking. |
 
-
 ---
-
 
 ## Field Details
 
-
 ### Identification & Metadata
-
 
 #### `name`
 
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Identifies the module in logs and UI elements.
-
 **Example Usage:**
 
 ```lua
 MODULE.name = "My Module"
 ```
 
+---
 
 #### `author`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Name or SteamID64 of the module’s author.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.author = "Samael"
 ```
 
+---
 
 #### `discord`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Discord tag or support channel for the module.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.discord = "@liliaplayer"
 ```
 
+---
 
 #### `desc`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Short description of what the module provides.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.desc = "Adds a Chatbox"
@@ -133,94 +103,67 @@ MODULE.desc = "Adds a Chatbox"
 
 ---
 
-
 ### Version & Compatibility
-
 
 #### `version`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Version string used for compatibility checks.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.version = "1.0"
 ```
 
+---
 
 #### `Public`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 When true, the module participates in public version checks.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.Public = true
 ```
 
+---
 
 #### `Private`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 When true, the module uses private version checking.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.Private = true
 ```
 
-
 ---
-
 
 ### Dependencies & Content
 
-
 #### `CAMIPrivileges`
-
 
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 CAMI privileges required or provided by the module.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.CAMIPrivileges = {
@@ -228,43 +171,33 @@ MODULE.CAMIPrivileges = {
 }
 ```
 
+---
 
 #### `WorkshopContent`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Steam Workshop add-on IDs required by this module.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.WorkshopContent = { "2959728255" }
 ```
 
+---
 
 #### `Dependencies`
 
-
 **Type:**
 
-
 `table`
-
 **Description:**
 
-
 Files or folders that this module requires to run.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.Dependencies = {
@@ -272,70 +205,51 @@ MODULE.Dependencies = {
 }
 ```
 
-
 ---
-
 
 ### Loading & Lifecycle
 
-
 #### `enabled`
-
 
 **Type:**
 
-
 `boolean` or `function`
-
 **Description:**
 
-
 Controls whether the module loads. Can be a static boolean or a function returning a boolean.
-
 **Example Usage:**
-
 
 ```lua
 MODULE.enabled = true
 ```
 
+---
 
 #### `loading`
 
-
 **Type:**
 
-
 `boolean`
-
 **Description:**
 
-
 True while the module is in the process of loading.
-
 **Example Usage:**
-
 
 ```lua
 if MODULE.loading then return end
 ```
 
+---
 
 #### `ModuleLoaded`
 
-
 **Type:**
 
-
 `function`
-
 **Description:**
 
-
 Optional callback run after the module finishes loading.
-
 **Example Usage:**
-
 
 ```lua
 function MODULE:ModuleLoaded()
@@ -343,71 +257,54 @@ function MODULE:ModuleLoaded()
 end
 ```
 
-
 ---
-
 
 ### Access & Visibility
 
-
 #### `folder`
-
 
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Filesystem path where the module is located.
-
 **Example Usage:**
-
 
 ```lua
 print(MODULE.folder)
 ```
 
+---
 
 #### `path`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Absolute path to the module’s root directory.
-
 **Example Usage:**
-
 
 ```lua
 print(MODULE.path)
 ```
 
+---
 
 #### `uniqueID`
 
-
 **Type:**
 
-
 `string`
-
 **Description:**
 
-
 Identifier used internally for the module list.
-
 **Example Usage:**
-
 
 ```lua
 print(MODULE.uniqueID)
 ```
+
+---


### PR DESCRIPTION
## Summary
- normalize blank lines between sections in all definition documentation
- ensure a blank line surrounds each `---` separator

## Testing
- `luacheck . --no-redefined --no-global --no-self --no-max-line-length --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620da497f8832781dae90e4f495b94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and consistency across multiple documentation pages by removing excess blank lines and redundant separators.
  * Added or standardized horizontal rule separators between field descriptions for better readability.
  * Streamlined layout by condensing content and, in some cases, removing summary tables.
  * No changes to the actual content, field descriptions, or examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->