### PR TITLE
Fix docs formatting spacing

### DIFF
--- a/docs/Code_Of_Conduct.md
+++ b/docs/Code_Of_Conduct.md
@@ -1,8 +1,6 @@
 # Contributor Covenant Code of Conduct
 
-
 ## Our Pledge
-
 
 In the interest of fostering an open and welcoming environment, we as
 
@@ -16,14 +14,11 @@ level of experience, education, socio-economic status, nationality, personal
 
 appearance, race, religion, or sexual identity and orientation.
 
-
 ## Our Standards
-
 
 Examples of behavior that contributes to creating a positive environment
 
 include:
-
 
 * Using welcoming and inclusive language
 
@@ -37,7 +32,6 @@ include:
 
 
 Examples of unacceptable behavior by participants include:
-
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
 
@@ -55,16 +49,13 @@ Examples of unacceptable behavior by participants include:
 
  professional setting
 
-
 ## Our Responsibilities
-
 
 Project maintainers are responsible for clarifying the standards of acceptable
 
 behavior and are expected to take appropriate and fair corrective action in
 
 response to any instances of unacceptable behavior.
-
 
 Project maintainers have the right and responsibility to remove, edit, or
 
@@ -76,9 +67,7 @@ permanently any contributor for other behaviors that they deem inappropriate,
 
 threatening, offensive, or harmful.
 
-
 ## Scope
-
 
 This Code of Conduct applies both within project spaces and in public spaces
 
@@ -92,9 +81,7 @@ representative at an online or offline event. Representation of a project may be
 
 further defined and clarified by project maintainers.
 
-
 ## Enforcement
-
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 
@@ -108,21 +95,17 @@ obligated to maintain confidentiality with regard to the reporter of an incident
 
 Further details of specific enforcement policies may be posted separately.
 
-
 Project maintainers who do not follow or enforce the Code of Conduct in good
 
 faith may face temporary or permanent repercussions as determined by other
 
 members of the project's leadership.
 
-
 ## Attribution
-
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
 
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
 
 For answers to common questions about this code of conduct, see
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,6 @@
 # Lilia Documentation
 
-
 This repository contains the source files for the official Lilia Wiki documentation.
-
 
 > **Note:**
 
@@ -12,15 +10,11 @@ This repository contains the source files for the official Lilia Wiki documentat
 
 > Please do **not** open pull requests or push directly to this repo.
 
-
 ---
-
 
 ## 📖 Overview
 
-
 Lilia is a lightweight, modular framework for building Garry’s Mod addons in GLua. Its documentation covers:
-
 
 - **Getting Started:** installation, setup, and core concepts
 
@@ -33,9 +27,7 @@ Lilia is a lightweight, modular framework for building Garry’s Mod addons in G
 
 ---
 
-
 ## 🚀 Local Preview
-
 
 1. **Clone** this repo:
 

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -1,13 +1,10 @@
 # Addons with Improved Compatibility
 
-
 This page details the optional compatibility libraries bundled with Lilia. These libraries greatly expand support for a variety of popular addons used across the Garry's Mod community. Each section below is a standalone sub-section named after the addon, with its URL, key compatibility highlights, and a brief explanation.
-
 
 The compatibility layer covers administration suites such as ULX and SAM, vehicle frameworks like **LVS**, **Simfphys**, and **VCMod**, outfit systems including PAC3, and more. Installing these addons alongside Lilia will automatically enable the related integration.
 
 In recent releases the compatibility set has grown even larger. Popular community addons now work out of the box:
-
 
 - **Advanced Duplicator 2** and **Advanced Duplicator** integration
 
@@ -32,12 +29,9 @@ In recent releases the compatibility set has grown even larger. Popular communit
 
 Simply install these addons and the matching compatibility layer will load automatically.
 
-
 ## [Advanced Duplicator](https://steamcommunity.com/sharedfiles/filedetails/?id=163806212)
 
-
 **Compatibility Highlights:**
-
 
 * Prevents duplication of entities flagged as `NoDuplicate`.
 
@@ -50,18 +44,13 @@ Simply install these addons and the matching compatibility layer will load autom
 
 **Detailed Explanation:**
 
-
 Hooks into dupe placement checks to stop players from spawning unstable or restricted entities. Oversized props can crash a server, so this layer validates models before allowing a dupe to spawn.
-
 
 ---
 
-
 ## [Advanced Duplicator 2](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)
 
-
 **Compatibility Highlights:**
-
 
 * Performs the same safety checks as the original dupe compatibility library.
 
@@ -71,18 +60,13 @@ Hooks into dupe placement checks to stop players from spawning unstable or restr
 
 **Detailed Explanation:**
 
-
 Integrates with AD2’s duplication data system while still blocking problematic entities and scaling exploits.
-
 
 ---
 
-
 ## [DarkRP](https://github.com/FPtje/DarkRP)
 
-
 **Compatibility Highlights:**
-
 
 * Provides helper functions like `isEmpty`, `findEmptyPos`, and text wrapping.
 
@@ -92,36 +76,26 @@ Integrates with AD2’s duplication data system while still blocking problematic
 
 **Detailed Explanation:**
 
-
 Recreates widely used DarkRP globals and utilities so community addons run under Lilia without modification.
-
 
 ---
 
-
 ## [LVS](https://steamcommunity.com/workshop/browse/?appid=4000&searchtext=LVS+Base)
 
-
 **Compatibility Highlights:**
-
 
 * Filters out self-inflicted damage from the player's own vehicle.
 
 
 **Detailed Explanation:**
 
-
 Stops collisions or weapons fired from your own LVS vehicle from injuring you. Drivers can still take damage if an impact occurs close to their seat.
-
 
 ---
 
-
 ## [PAC3](https://steamcommunity.com/workshop/filedetails/?id=104691717)
 
-
 **Compatibility Highlights:**
-
 
 * Networks player outfit parts reliably between server and clients.
 
@@ -131,54 +105,39 @@ Stops collisions or weapons fired from your own LVS vehicle from injuring you. D
 
 **Detailed Explanation:**
 
-
 Exposes helper methods and network messages to synchronize PAC3 outfits, preventing missing or broken parts on clients.
-
 
 ---
 
-
 ## [PermaProps](https://steamcommunity.com/sharedfiles/filedetails/?id=220336312)
 
-
 **Compatibility Highlights:**
-
 
 * Blocks saving Lilia’s persistent entities or map-created props as permanent.
 
 
 **Detailed Explanation:**
 
-
 Prevents PermaProps from saving entities that would conflict with Lilia’s persistence system, avoiding errors on future loads.
-
 
 ---
 
-
 ## [Prone Mod](https://github.com/gspetrou/Prone-Mod)
 
-
 **Compatibility Highlights:**
-
 
 * Forces players out of prone when they die or change character.
 
 
 **Detailed Explanation:**
 
-
 Listens for death and character-switch events, automatically exiting prone to avoid players being stuck on respawn.
-
 
 ---
 
-
 ## [SAM](https://www.gmodstore.com/market/view/sam)
 
-
 **Compatibility Highlights:**
-
 
 * Recreates SAM chat commands via Lilia’s command system.
 
@@ -188,36 +147,26 @@ Listens for death and character-switch events, automatically exiting prone to av
 
 **Detailed Explanation:**
 
-
 Mirrors SAM commands and enforces Lilia’s permission checks so admins can use familiar tools seamlessly.
-
 
 ---
 
-
 ## [ServerGuard](https://www.gmodstore.com/market/view/serverguard)
 
-
 **Compatibility Highlights:**
-
 
 * Disables the built-in restrictions plugin so Lilia can manage permissions.
 
 
 **Detailed Explanation:**
 
-
 Turns off ServerGuard’s restriction module to ensure a single consistent permission system while retaining other features.
-
 
 ---
 
-
 ## [Simfphys Vehicles](https://steamcommunity.com/sharedfiles/filedetails/?id=771487490)
 
-
 **Compatibility Highlights:**
-
 
 * Applies crash damage to drivers on vehicle collisions.
 
@@ -230,18 +179,13 @@ Turns off ServerGuard’s restriction module to ensure a single consistent permi
 
 **Detailed Explanation:**
 
-
 Drivers only take damage when the vehicle is struck near their seat and a configurable delay is applied before entering cars. Vehicle editing remains gated behind an admin privilege.
-
 
 ---
 
-
 ## [Sit Anywhere](https://steamcommunity.com/sharedfiles/filedetails/?id=108176967)
 
-
 **Compatibility Highlights:**
-
 
 * Sets recommended console variables on load.
 
@@ -254,18 +198,13 @@ Drivers only take damage when the vehicle is struck near their seat and a config
 
 **Detailed Explanation:**
 
-
 Adjusts console settings and seat interactions to prevent trolling while maintaining roleplay utility.
-
 
 ---
 
-
 ## [ULX](https://steamcommunity.com/sharedfiles/filedetails/?id=557962280)
 
-
 **Compatibility Highlights:**
-
 
 * Removes obsolete hooks that conflict with recent versions of CAMI.
 
@@ -275,36 +214,26 @@ Adjusts console settings and seat interactions to prevent trolling while maintai
 
 **Detailed Explanation:**
 
-
 Keeps CAMI and ULX in sync so admin ranks and permissions behave correctly within Lilia.
-
 
 ---
 
-
 ## [VCMod Main](https://www.gmodstore.com/market/view/vcmod-main)
 
-
 **Compatibility Highlights:**
-
 
 * Redirects VCMod money hooks to a character’s funds.
 
 
 **Detailed Explanation:**
 
-
 Forwards vehicle purchase and upgrade transactions to the roleplay money system, ensuring consistency with character finances.
-
 
 ---
 
-
 ## [VJBase](https://steamcommunity.com/workshop/filedetails/?id=131759821)
 
-
 **Compatibility Highlights:**
-
 
 * Blocks dangerous network messages.
 
@@ -314,18 +243,13 @@ Forwards vehicle purchase and upgrade transactions to the roleplay money system,
 
 **Detailed Explanation:**
 
-
 Intercepts exploitable VJBase network messages and disables resource-intensive hooks to maintain server security and performance.
-
 
 ---
 
-
 ## [VManip](https://liliaframework.github.io/Modules/vmanip.html)
 
-
 **Compatibility Highlights:**
-
 
 * Synchronizes VManip animations between server and clients.
 
@@ -334,6 +258,5 @@ Intercepts exploitable VJBase network messages and disables resource-intensive h
 
 
 **Detailed Explanation:**
-
 
 Provides helper networking and event hooks so player animation gestures triggered through VManip play correctly for everyone.

--- a/docs/docs/definitions/class.md
+++ b/docs/docs/definitions/class.md
@@ -50,9 +50,11 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 **Type:**
 
 `string`
+
 **Description:**
 
 The displayed name of the class.
+
 **Example Usage:**
 
 ```lua
@@ -66,9 +68,11 @@ CLASS.name = "Engineer"
 **Type:**
 
 `string`
+
 **Description:**
 
 The description or lore of the class.
+
 **Example Usage:**
 
 ```lua
@@ -82,9 +86,11 @@ CLASS.desc = "Technicians who maintain equipment."
 **Type:**
 
 `number`
+
 **Description:**
 
 Unique numeric identifier (team index) for the class.
+
 **Example Usage:**
 
 ```lua
@@ -100,9 +106,11 @@ CLASS.index = CLASS_ENGINEER
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Determines if the class is available to all players by default.
+
 **Example Usage:**
 
 ```lua
@@ -116,9 +124,11 @@ CLASS.isDefault = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Indicates if the class requires a whitelist entry to be accessible.
+
 **Example Usage:**
 
 ```lua
@@ -132,9 +142,11 @@ CLASS.isWhitelisted = false
 **Type:**
 
 `number`
+
 **Description:**
 
 Links this class to a specific faction index.
+
 **Example Usage:**
 
 ```lua
@@ -148,9 +160,11 @@ CLASS.faction = FACTION_CITIZEN
 **Type:**
 
 `Color`
+
 **Description:**
 
 UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
+
 **Example Usage:**
 
 ```lua
@@ -166,9 +180,11 @@ CLASS.color = Color(255, 0, 0)
 **Type:**
 
 `table`
+
 **Description:**
 
 Weapons granted to members of this class on spawn.
+
 **Example Usage:**
 
 ```lua
@@ -182,9 +198,11 @@ CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
 **Type:**
 
 `number`
+
 **Description:**
 
 Payment amount issued per pay interval.
+
 **Example Usage:**
 
 ```lua
@@ -198,9 +216,11 @@ CLASS.pay = 50
 **Type:**
 
 `number`
+
 **Description:**
 
 Maximum accumulated pay a player can hold.
+
 **Example Usage:**
 
 ```lua
@@ -214,9 +234,11 @@ CLASS.payLimit = 1000
 **Type:**
 
 `number`
+
 **Description:**
 
 Interval in seconds between salary payouts.
+
 **Example Usage:**
 
 ```lua
@@ -230,9 +252,11 @@ CLASS.payTimer = 3600
 **Type:**
 
 `number`
+
 **Description:**
 
 Maximum number of players allowed in this class simultaneously.
+
 **Example Usage:**
 
 ```lua
@@ -248,9 +272,11 @@ CLASS.limit = 10
 **Type:**
 
 `number`
+
 **Description:**
 
 Default starting health for class members.
+
 **Example Usage:**
 
 ```lua
@@ -264,9 +290,11 @@ CLASS.health = 150
 **Type:**
 
 `number`
+
 **Description:**
 
 Default starting armor.
+
 **Example Usage:**
 
 ```lua
@@ -280,9 +308,11 @@ CLASS.armor = 50
 **Type:**
 
 `number`
+
 **Description:**
 
 Multiplier for player model size.
+
 **Example Usage:**
 
 ```lua
@@ -296,9 +326,11 @@ CLASS.scale = 1.2
 **Type:**
 
 `number`
+
 **Description:**
 
 Default running speed.
+
 **Example Usage:**
 
 ```lua
@@ -312,9 +344,11 @@ CLASS.runSpeed = 250
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Multiply base run speed instead of replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -328,9 +362,11 @@ CLASS.runSpeedMultiplier = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Default walking speed.
+
 **Example Usage:**
 
 ```lua
@@ -344,9 +380,11 @@ CLASS.walkSpeed = 200
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Multiply base walk speed instead of replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -360,9 +398,11 @@ CLASS.walkSpeedMultiplier = false
 **Type:**
 
 `number`
+
 **Description:**
 
 Default jump power.
+
 **Example Usage:**
 
 ```lua
@@ -376,9 +416,11 @@ CLASS.jumpPower = 200
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Multiply base jump power instead of replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -392,9 +434,11 @@ CLASS.jumpPowerMultiplier = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Blood color enumeration constant for this class.
+
 **Example Usage:**
 
 ```lua
@@ -410,9 +454,11 @@ CLASS.bloodcolor = BLOOD_COLOR_RED
 **Type:**
 
 `table`
+
 **Description:**
 
 Mapping of bodygroup indices to values applied on spawn.
+
 **Example Usage:**
 
 ```lua
@@ -429,9 +475,11 @@ CLASS.bodyGroups = {
 **Type:**
 
 `string` or `table`
+
 **Description:**
 
 Model path (or list of paths) assigned to this class.
+
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/command.md
+++ b/docs/docs/definitions/command.md
@@ -36,9 +36,11 @@ When you register a command with `lia.command.add`, you provide a table of field
 **Type:**
 
 `string` or `table`
+
 **Description:**
 
 One or more alternative command names that trigger the same behavior.
+
 **Example Usage:**
 
 ```lua
@@ -52,9 +54,11 @@ alias = {"chargiveflag", "giveflag"}
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, only players with the registered CAMI admin privilege (automatically created) may run the command.
+
 **Example Usage:**
 
 ```lua
@@ -68,9 +72,11 @@ adminOnly = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, restricts usage to super administrators (automatically registers a CAMI privilege).
+
 **Example Usage:**
 
 ```lua
@@ -84,9 +90,11 @@ superAdminOnly = true
 **Type:**
 
 `string`
+
 **Description:**
 
 Custom CAMI privilege name checked when running the command. Defaults to the command’s primary name if omitted.
+
 **Example Usage:**
 
 ```lua
@@ -102,6 +110,7 @@ privilege = "Manage Doors"
 **Type:**
 
 `string`
+
 **Description:**
 
 Human-readable syntax string shown in help menus. Does not affect argument parsing.
@@ -109,6 +118,7 @@ Human-readable syntax string shown in help menus. Does not affect argument parsi
 You can use spaces in argument names for better readability.
 
 The in-game prompt only appears when every argument follows the `[type Name]` format.
+
 **Example Usage:**
 
 ```lua
@@ -122,9 +132,11 @@ syntax = "[string Target Name] [number Amount]"
 **Type:**
 
 `string`
+
 **Description:**
 
 Short description of what the command does, displayed in command lists and menus.
+
 **Example Usage:**
 
 ```lua
@@ -140,6 +152,7 @@ desc = "Purchase a door if it is available and you can afford it."
 **Type:**
 
 `table`
+
 **Description:**
 
 Defines how the command appears in admin utility menus. Common keys:
@@ -172,6 +185,7 @@ AdminStick = {
 **Type:**
 
 `function(client, table)`
+
 **Description:**
 
 Function called when the command is executed. `args` is a table of parsed arguments. Return a string to send a message back to the caller, or return nothing for silent execution.

--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -57,9 +57,11 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 **Type:**
 
 `string`
+
 **Description:**
 
 Display name shown for members of this faction.
+
 **Example Usage:**
 
 ```lua
@@ -73,9 +75,11 @@ FACTION.name = "Minecrafters"
 **Type:**
 
 `string`
+
 **Description:**
 
 Lore or descriptive text about the faction.
+
 **Example Usage:**
 
 ```lua
@@ -89,9 +93,11 @@ FACTION.desc = "Surviving and crafting in the blocky world."
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Set to `true` if players may select this faction without a whitelist.
+
 **Example Usage:**
 
 ```lua
@@ -105,9 +111,11 @@ FACTION.isDefault = false
 **Type:**
 
 `string`
+
 **Description:**
 
 Internal string identifier for referencing the faction.
+
 **Example Usage:**
 
 ```lua
@@ -121,9 +129,11 @@ FACTION.uniqueID = "staff"
 **Type:**
 
 `number`
+
 **Description:**
 
 Numeric identifier assigned during faction registration.
+
 **Example Usage:**
 
 ```lua
@@ -139,9 +149,11 @@ FACTION_STAFF = FACTION.index
 **Type:**
 
 `Color`
+
 **Description:**
 
 Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
+
 **Example Usage:**
 
 ```lua
@@ -155,9 +167,11 @@ FACTION.color = Color(255, 56, 252)
 **Type:**
 
 `table`
+
 **Description:**
 
 Table of player model paths available to faction members.
+
 **Example Usage:**
 
 ```lua
@@ -174,9 +188,11 @@ FACTION.models = {
 **Type:**
 
 `table`
+
 **Description:**
 
 Mapping of bodygroup names to index values applied on spawn.
+
 **Example Usage:**
 
 ```lua
@@ -195,9 +211,11 @@ FACTION.bodyGroups = {
 **Type:**
 
 `table`
+
 **Description:**
 
 Weapons automatically granted on spawn.
+
 **Example Usage:**
 
 ```lua
@@ -211,9 +229,11 @@ FACTION.weapons = {"weapon_physgun", "gmod_tool"}
 **Type:**
 
 `table`
+
 **Description:**
 
 Item uniqueIDs automatically granted on character creation.
+
 **Example Usage:**
 
 ```lua
@@ -227,9 +247,11 @@ FACTION.items = {"radio", "handcuffs"}
 **Type:**
 
 `number`
+
 **Description:**
 
 Payment amount for members each interval.
+
 **Example Usage:**
 
 ```lua
@@ -243,9 +265,11 @@ FACTION.pay = 50
 **Type:**
 
 `number`
+
 **Description:**
 
 Maximum pay a member can accumulate.
+
 **Example Usage:**
 
 ```lua
@@ -259,9 +283,11 @@ FACTION.payLimit = 1000
 **Type:**
 
 `number`
+
 **Description:**
 
 Interval in seconds between salary payouts.
+
 **Example Usage:**
 
 ```lua
@@ -275,9 +301,11 @@ FACTION.payTimer = 3600
 **Type:**
 
 `number`
+
 **Description:**
 
 Maximum number of players allowed in this faction.
+
 **Example Usage:**
 
 ```lua
@@ -291,9 +319,11 @@ FACTION.limit = 20
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, players may only create one character in this faction.
+
 **Example Usage:**
 
 ```lua
@@ -309,9 +339,11 @@ FACTION.oneCharOnly = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Starting health for faction members.
+
 **Example Usage:**
 
 ```lua
@@ -325,9 +357,11 @@ FACTION.health = 150
 **Type:**
 
 `number`
+
 **Description:**
 
 Starting armor for faction members.
+
 **Example Usage:**
 
 ```lua
@@ -341,9 +375,11 @@ FACTION.armor = 25
 **Type:**
 
 `number`
+
 **Description:**
 
 Player model scale multiplier.
+
 **Example Usage:**
 
 ```lua
@@ -357,9 +393,11 @@ FACTION.scale = 1.1
 **Type:**
 
 `number`
+
 **Description:**
 
 Base running speed.
+
 **Example Usage:**
 
 ```lua
@@ -373,9 +411,11 @@ FACTION.runSpeed = 250
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, multiplies the base speed rather than replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -389,9 +429,11 @@ FACTION.runSpeedMultiplier = false
 **Type:**
 
 `number`
+
 **Description:**
 
 Base walking speed.
+
 **Example Usage:**
 
 ```lua
@@ -405,9 +447,11 @@ FACTION.walkSpeed = 200
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, multiplies the base walk speed rather than replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -421,9 +465,11 @@ FACTION.walkSpeedMultiplier = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Base jump power.
+
 **Example Usage:**
 
 ```lua
@@ -437,9 +483,11 @@ FACTION.jumpPower = 200
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, multiplies the base jump power rather than replacing it.
+
 **Example Usage:**
 
 ```lua
@@ -455,9 +503,11 @@ FACTION.jumpPowerMultiplier = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Whether faction members automatically recognize each other on sight.
+
 **Example Usage:**
 
 ```lua
@@ -471,9 +521,11 @@ FACTION.MemberToMemberAutoRecognition = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, members recognize all players globally, regardless of faction.
+
 **Example Usage:**
 
 ```lua
@@ -487,9 +539,11 @@ FACTION.RecognizesGlobally = false
 **Type:**
 
 `table`
+
 **Description:**
 
 Mapping of NPC class names to disposition constants (`D_HT`, `D_LI`, etc.). NPCs are updated on spawn/creation.
+
 **Example Usage:**
 
 ```lua
@@ -506,9 +560,11 @@ FACTION.NPCRelations = {
 **Type:**
 
 `number`
+
 **Description:**
 
 Blood color enumeration constant for faction members.
+
 **Example Usage:**
 
 ```lua
@@ -522,9 +578,11 @@ FACTION.bloodcolor = BLOOD_COLOR_RED
 **Type:**
 
 `boolean`
+
 **Description:**
 
 If `true`, members of this faction are hidden from the scoreboard.
+
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/items.md
+++ b/docs/docs/definitions/items.md
@@ -76,9 +76,11 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 **Type:**
 
 `table`
+
 **Description:**
 
 Sound played when moving items to/from the bag; specified as `{path, volume}`.
+
 **Example Usage:**
 
 ```lua
@@ -92,9 +94,11 @@ ITEM.BagSound = {"physics/cardboard/cardboard_box_impact_soft2.wav", 50}
 **Type:**
 
 `string`
+
 **Description:**
 
 Sound played when equipping the item.
+
 **Example Usage:**
 
 ```lua
@@ -108,9 +112,11 @@ ITEM.equipSound = "items/ammo_pickup.wav"
 **Type:**
 
 `string`
+
 **Description:**
 
 Sound played when unequipping the item.
+
 **Example Usage:**
 
 ```lua
@@ -126,9 +132,11 @@ ITEM.unequipSound = "items/ammo_pickup.wav"
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Deletes the item upon player death.
+
 **Example Usage:**
 
 ```lua
@@ -142,9 +150,11 @@ ITEM.DropOnDeath = true
 **Type:**
 
 `table`
+
 **Description:**
 
 Allowed faction indices for vendor interaction.
+
 **Example Usage:**
 
 ```lua
@@ -158,9 +168,11 @@ ITEM.FactionWhitelist = {FACTION_CITIZEN}
 **Type:**
 
 `table`
+
 **Description:**
 
 Skill requirements needed to use the item.
+
 **Example Usage:**
 
 ```lua
@@ -174,9 +186,11 @@ ITEM.RequiredSkillLevels = {Strength = 5}
 **Type:**
 
 `table`
+
 **Description:**
 
 Allowed Steam IDs for vendor interaction.
+
 **Example Usage:**
 
 ```lua
@@ -190,9 +204,11 @@ ITEM.SteamIDWhitelist = {"STEAM_0:1:123"}
 **Type:**
 
 `table`
+
 **Description:**
 
 Allowed user groups for vendor interaction.
+
 **Example Usage:**
 
 ```lua
@@ -206,9 +222,11 @@ ITEM.UsergroupWhitelist = {"admin"}
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Restricts usage to VIP players.
+
 **Example Usage:**
 
 ```lua
@@ -224,9 +242,11 @@ ITEM.VIPWhitelist = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Marks the item as a bag providing extra inventory.
+
 **Example Usage:**
 
 ```lua
@@ -240,9 +260,11 @@ ITEM.isBag = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Internal bag inventory width.
+
 **Example Usage:**
 
 ```lua
@@ -256,9 +278,11 @@ ITEM.invWidth = 2
 **Type:**
 
 `number`
+
 **Description:**
 
 Internal bag inventory height.
+
 **Example Usage:**
 
 ```lua
@@ -272,9 +296,11 @@ ITEM.invHeight = 2
 **Type:**
 
 `number`
+
 **Description:**
 
 Width in the external inventory grid.
+
 **Example Usage:**
 
 ```lua
@@ -288,9 +314,11 @@ ITEM.width = 2
 **Type:**
 
 `number`
+
 **Description:**
 
 Height in the external inventory grid.
+
 **Example Usage:**
 
 ```lua
@@ -304,9 +332,11 @@ ITEM.height = 1
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Whether the item stack can be divided.
+
 **Example Usage:**
 
 ```lua
@@ -320,9 +350,11 @@ ITEM.canSplit = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Allows stacking multiple quantities.
+
 **Example Usage:**
 
 ```lua
@@ -336,9 +368,11 @@ ITEM.isStackable = false
 **Type:**
 
 `number`
+
 **Description:**
 
 Maximum stack size.
+
 **Example Usage:**
 
 ```lua
@@ -352,9 +386,11 @@ ITEM.maxQuantity = 10
 **Type:**
 
 `number`
+
 **Description:**
 
 Current amount in the item stack.
+
 **Example Usage:**
 
 ```lua
@@ -370,9 +406,11 @@ print(item:getQuantity())
 **Type:**
 
 `string`
+
 **Description:**
 
 Base item this item derives from.
+
 **Example Usage:**
 
 ```lua
@@ -386,9 +424,11 @@ ITEM.base = "weapon"
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Indicates the table is a base item.
+
 **Example Usage:**
 
 ```lua
@@ -402,9 +442,11 @@ ITEM.isBase = true
 **Type:**
 
 `string`
+
 **Description:**
 
 Inventory grouping category.
+
 **Example Usage:**
 
 ```lua
@@ -418,9 +460,11 @@ ITEM.category = "Storage"
 **Type:**
 
 `string`
+
 **Description:**
 
 Displayed name of the item.
+
 **Example Usage:**
 
 ```lua
@@ -434,9 +478,11 @@ ITEM.name = "Example Item"
 **Type:**
 
 `string`
+
 **Description:**
 
 Short description shown to players.
+
 **Example Usage:**
 
 ```lua
@@ -450,9 +496,11 @@ ITEM.desc = "An example item"
 **Type:**
 
 `string`
+
 **Description:**
 
 Overrides the automatically generated unique identifier.
+
 **Example Usage:**
 
 ```lua
@@ -466,9 +514,11 @@ ITEM.uniqueID = "custom_unique_id"
 **Type:**
 
 `any`
+
 **Description:**
 
 Database identifier.
+
 **Example Usage:**
 
 ```lua
@@ -484,9 +534,11 @@ print(item.id)
 **Type:**
 
 `number`
+
 **Description:**
 
 Armor value granted when equipped.
+
 **Example Usage:**
 
 ```lua
@@ -500,9 +552,11 @@ ITEM.armor = 50
 **Type:**
 
 `number`
+
 **Description:**
 
 Amount of health restored when used.
+
 **Example Usage:**
 
 ```lua
@@ -516,9 +570,11 @@ ITEM.health = 50
 **Type:**
 
 `table`
+
 **Description:**
 
 Attribute boosts applied on equip.
+
 **Example Usage:**
 
 ```lua
@@ -532,9 +588,11 @@ ITEM.attribBoosts = {strength = 5}
 **Type:**
 
 `boolean`
+
 **Description:**
 
 Marks the item as an outfit.
+
 **Example Usage:**
 
 ```lua
@@ -548,9 +606,11 @@ ITEM.isOutfit = true
 **Type:**
 
 `number`
+
 **Description:**
 
 Skin index applied to the player model.
+
 **Example Usage:**
 
 ```lua
@@ -564,9 +624,11 @@ ITEM.newSkin = 1
 **Type:**
 
 `string`
+
 **Description:**
 
 Slot or category for the outfit.
+
 **Example Usage:**
 
 ```lua
@@ -580,9 +642,11 @@ ITEM.outfitCategory = "body"
 **Type:**
 
 `table`
+
 **Description:**
 
 PAC3 customization information.
+
 **Example Usage:**
 
 ```lua
@@ -620,9 +684,11 @@ ITEM.pacData = {
 **Type:**
 
 `string`
+
 **Description:**
 
 Model replacements when equipped.
+
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/module.md
+++ b/docs/docs/definitions/module.md
@@ -44,9 +44,11 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 **Type:**
 
 `string`
+
 **Description:**
 
 Identifies the module in logs and UI elements.
+
 **Example Usage:**
 
 ```lua
@@ -60,9 +62,11 @@ MODULE.name = "My Module"
 **Type:**
 
 `string`
+
 **Description:**
 
 Name or SteamID64 of the module’s author.
+
 **Example Usage:**
 
 ```lua
@@ -76,9 +80,11 @@ MODULE.author = "Samael"
 **Type:**
 
 `string`
+
 **Description:**
 
 Discord tag or support channel for the module.
+
 **Example Usage:**
 
 ```lua
@@ -92,9 +98,11 @@ MODULE.discord = "@liliaplayer"
 **Type:**
 
 `string`
+
 **Description:**
 
 Short description of what the module provides.
+
 **Example Usage:**
 
 ```lua
@@ -110,9 +118,11 @@ MODULE.desc = "Adds a Chatbox"
 **Type:**
 
 `string`
+
 **Description:**
 
 Version string used for compatibility checks.
+
 **Example Usage:**
 
 ```lua
@@ -126,9 +136,11 @@ MODULE.version = "1.0"
 **Type:**
 
 `boolean`
+
 **Description:**
 
 When true, the module participates in public version checks.
+
 **Example Usage:**
 
 ```lua
@@ -142,9 +154,11 @@ MODULE.Public = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 When true, the module uses private version checking.
+
 **Example Usage:**
 
 ```lua
@@ -160,9 +174,11 @@ MODULE.Private = true
 **Type:**
 
 `table`
+
 **Description:**
 
 CAMI privileges required or provided by the module.
+
 **Example Usage:**
 
 ```lua
@@ -178,9 +194,11 @@ MODULE.CAMIPrivileges = {
 **Type:**
 
 `table`
+
 **Description:**
 
 Steam Workshop add-on IDs required by this module.
+
 **Example Usage:**
 
 ```lua
@@ -194,9 +212,11 @@ MODULE.WorkshopContent = { "2959728255" }
 **Type:**
 
 `table`
+
 **Description:**
 
 Files or folders that this module requires to run.
+
 **Example Usage:**
 
 ```lua
@@ -214,9 +234,11 @@ MODULE.Dependencies = {
 **Type:**
 
 `boolean` or `function`
+
 **Description:**
 
 Controls whether the module loads. Can be a static boolean or a function returning a boolean.
+
 **Example Usage:**
 
 ```lua
@@ -230,9 +252,11 @@ MODULE.enabled = true
 **Type:**
 
 `boolean`
+
 **Description:**
 
 True while the module is in the process of loading.
+
 **Example Usage:**
 
 ```lua
@@ -246,9 +270,11 @@ if MODULE.loading then return end
 **Type:**
 
 `function`
+
 **Description:**
 
 Optional callback run after the module finishes loading.
+
 **Example Usage:**
 
 ```lua
@@ -266,9 +292,11 @@ end
 **Type:**
 
 `string`
+
 **Description:**
 
 Filesystem path where the module is located.
+
 **Example Usage:**
 
 ```lua
@@ -282,9 +310,11 @@ print(MODULE.folder)
 **Type:**
 
 `string`
+
 **Description:**
 
 Absolute path to the module’s root directory.
+
 **Example Usage:**
 
 ```lua
@@ -298,9 +328,11 @@ print(MODULE.path)
 **Type:**
 
 `string`
+
 **Description:**
 
 Identifier used internally for the module list.
+
 **Example Usage:**
 
 ```lua

--- a/docs/docs/definitions/panels.md
+++ b/docs/docs/definitions/panels.md
@@ -538,4 +538,3 @@ Administrative window for editing a vendor's inventory and settings, including i
 **Description:**
 
 Secondary editor for selecting which factions and player classes can trade with the vendor.
-

--- a/docs/docs/feature_list.md
+++ b/docs/docs/feature_list.md
@@ -1,11 +1,8 @@
 # Feature List
 
-
 ---
 
-
 This page provides an extensive overview of the core modules and libraries included with Lilia. Use it as a quick reference for the capabilities baked into the framework. The framework ships with numerous optional compatibility layers so popular Garry's Mod addons work seamlessly alongside these features. For a breakdown of those integrations see the [compatibility guide](./compatibility.md).
-
 
 ### Grid Inventory
 
@@ -828,16 +825,12 @@ This page provides an extensive overview of the core modules and libraries inclu
 
 ### Configuration Options
 
-
 - Modules load automatically when compatible addons are detected
 
 The `config` library exposes numerous settings allowing you to control walk and run speeds, voice chat, crosshair usage, salary intervals, theme colors, workshop downloads, and much more. These options can be tweaked in game via the configuration menu.
 
-
 ### Addon Compatibility
 
-
 Lilia includes built-in modules that expand support for many common Garry's Mod addons. These integrations cover administration suites, vehicle packs, and utility tools so you can drop your favorite addons in without conflicts. See the [compatibility guide](./compatibility.md) for details.
-
 
 ---

--- a/docs/docs/hooks/attribute_hooks.md
+++ b/docs/docs/hooks/attribute_hooks.md
@@ -1,20 +1,14 @@
 # Attribute Hooks
 
-
 This document lists hooks related to attribute setup and changes.
 
-
 ---
-
 
 ## Overview
 
-
 Attributes can define their own hooks to react when a player's attribute is created or its value changes. Implement these functions on the `ATTRIBUTE` table to run custom logic. All hooks are optional; if a hook is omitted the default behavior is used.
 
-
 ---
-
 
 ### OnSetup
 

--- a/docs/docs/hooks/class_hooks.md
+++ b/docs/docs/hooks/class_hooks.md
@@ -1,53 +1,38 @@
 # Class Hooks
 
-
 This document describes all `CLASS` function hooks defined within the codebase. Use these to customize behavior before and after class changes and spawns.
-
 
 ---
 
-
 ## Overview
-
 
 Each class can implement lifecycle hooks to control access, initialize settings, and respond to events such as joining, leaving, spawning, or being transferred. All hooks are optional; unspecified hooks will not alter default behavior.
 
 These hooks live on the class tables created under `schema/classes` and only run there rather than acting as global gamemode hooks.
 
-
-
-
 ---
 
-
 ### OnCanBe
-
 
 ```lua
 function CLASS:OnCanBe(client) → boolean
 ```
 
-
 **Description:**
-
 
 Determines whether a player is permitted to switch to this class. Evaluated before the class change occurs.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The player attempting to switch to the class.
 
 
 **Returns:**
 
-
 * `boolean` – `true` to allow the switch; `false` to deny.
 
 
 **Example Usage:**
-
 
 ```lua
 function CLASS:OnCanBe(client)
@@ -55,38 +40,29 @@ function CLASS:OnCanBe(client)
 end
 ```
 
-
 ---
 
-
 ### OnLeave
-
 
 ```lua
 function CLASS:OnLeave(client)
 ```
 
-
 **Description:**
-
 
 Triggered when a player leaves the class. Useful for resetting models or other class-specific attributes.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The player who has left the class.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function CLASS:OnLeave(client)
@@ -95,38 +71,29 @@ function CLASS:OnLeave(client)
 end
 ```
 
-
 ---
 
-
 ### OnSet
-
 
 ```lua
 function CLASS:OnSet(client)
 ```
 
-
 **Description:**
-
 
 Called when a player successfully joins the class. Initialize class-specific settings here.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The player who has joined the class.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function CLASS:OnSet(client)
@@ -134,38 +101,29 @@ function CLASS:OnSet(client)
 end
 ```
 
-
 ---
 
-
 ### OnSpawn
-
 
 ```lua
 function CLASS:OnSpawn(client)
 ```
 
-
 **Description:**
-
 
 Invoked when a class member spawns. Use this for spawn-specific setup like health, armor, or weapons.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The player who has just spawned.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function CLASS:OnSpawn(client)
@@ -174,38 +132,29 @@ function CLASS:OnSpawn(client)
 end
 ```
 
-
 ---
 
-
 ### OnTransferred
-
 
 ```lua
 function CLASS:OnTransferred(character)
 ```
 
-
 **Description:**
-
 
 Executes actions when a character is transferred into this class (e.g., by an admin or system transfer).
 
-
 **Parameters:**
-
 
 * `character` (`Character`) – The character that was transferred.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function CLASS:OnTransferred(character)

--- a/docs/docs/hooks/faction_hooks.md
+++ b/docs/docs/hooks/faction_hooks.md
@@ -1,14 +1,10 @@
 # Faction Hooks
 
-
 This document describes all `FACTION` function hooks defined within the codebase. Use these to customize default naming, descriptions, and lifecycle events when characters are created, spawned, or transferred within a faction.
-
 
 ---
 
-
 ## Overview
-
 
 These hooks belong to tables under `schema/factions` and are most often used to set up characters when they first join the faction.
 
@@ -16,34 +12,27 @@ Each faction can implement these shared- and server-side hooks to control how ch
 
 ### GetDefaultName
 
-
 ```lua
 function FACTION:GetDefaultName(client)
     -- return string
 end
 ```
 
-
 **Description:**
-
 
 Retrieves the default name for a newly created character in this faction.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The client for whom the default name is being generated.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Example Usage:**
-
 
 ```lua
 function FACTION:GetDefaultName(client)
@@ -51,12 +40,9 @@ function FACTION:GetDefaultName(client)
 end
 ```
 
-
 ---
 
-
 ### GetDefaultDesc
-
 
 ```lua
 function FACTION:GetDefaultDesc(client, faction)
@@ -64,15 +50,11 @@ function FACTION:GetDefaultDesc(client, faction)
 end
 ```
 
-
 **Description:**
-
 
 Retrieves the default description for a newly created character in this faction.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The client for whom the default description is being generated.
 
@@ -82,12 +64,10 @@ Retrieves the default description for a newly created character in this faction.
 
 **Realm:**
 
-
 * Shared
 
 
 **Example Usage:**
-
 
 ```lua
 function FACTION:GetDefaultDesc(client, faction)
@@ -95,27 +75,20 @@ function FACTION:GetDefaultDesc(client, faction)
 end
 ```
 
-
 ---
 
-
 ### OnCharCreated
-
 
 ```lua
 function FACTION:OnCharCreated(client, character)
 end
 ```
 
-
 **Description:**
-
 
 Executes actions when a new character is created and assigned to this faction. Ideal for initializing inventories or character data.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The client that owns the new character.
 
@@ -125,12 +98,10 @@ Executes actions when a new character is created and assigned to this faction. I
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function FACTION:OnCharCreated(client, character)
@@ -139,39 +110,30 @@ function FACTION:OnCharCreated(client, character)
 end
 ```
 
-
 ---
 
-
 ### OnSpawn
-
 
 ```lua
 function FACTION:OnSpawn(client)
 end
 ```
 
-
 **Description:**
-
 
 Invoked when a faction member spawns into the world. Use this for per-spawn setup such as notifications or custom status.
 
-
 **Parameters:**
-
 
 * `client` (`Player`) – The player who has just spawned.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function FACTION:OnSpawn(client)
@@ -179,39 +141,30 @@ function FACTION:OnSpawn(client)
 end
 ```
 
-
 ---
 
-
 ### OnTransferred
-
 
 ```lua
 function FACTION:OnTransferred(character)
 end
 ```
 
-
 **Description:**
-
 
 Executes actions when an existing character is transferred into this faction (e.g., via admin or system transfer).
 
-
 **Parameters:**
-
 
 * `character` (`Character`) – The character that was moved into this faction.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Example Usage:**
-
 
 ```lua
 function FACTION:OnTransferred(character)

--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -1,8 +1,6 @@
 # Gamemode Hooks
 
-
 This document lists global hooks triggered by the gamemode. You can define them on the `GM` table, inside a `MODULE`, on the `SCHEMA`, or call them anywhere with `hook.Add`.
-
 
 - **MODULE** functions load only from `/modules`.
 
@@ -13,48 +11,36 @@ This document lists global hooks triggered by the gamemode. You can define them 
 
 If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, the one loaded last overrides the others.
 
-
 ---
-
 
 ## Overview
 
-
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.
-
 
 ---
 
-
 ### LoadCharInformation
-
 
 **Description:**
 
-
 Called after the F1 menu panel is created so additional sections can be added. Populates the character information sections of the F1 menu.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds a custom hunger info field after the menu is ready.
@@ -73,39 +59,30 @@ hook.Add("LoadCharInformation", "AddHungerField", function()
 end)
 ```
 
-
 ---
-
 
 ### CreateMenuButtons
 
-
 **Description:**
-
 
 Executed during menu creation allowing you to define custom tabs. Allows modules to insert additional tabs into the F1 menu.
 
-
 **Parameters:**
-
 
 * tabs (table) – Table to add menu definitions to.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Inserts a custom "Help" tab listing available commands.
@@ -129,21 +106,15 @@ hook.Add("CreateMenuButtons", "AddHelpTab", function(tabs)
 end)
 ```
 
-
 ---
-
 
 ### DrawLiliaModelView
 
-
 **Description:**
-
 
 Runs every frame when the character model panel draws. Lets code draw over the model view used in character menus.
 
-
 **Parameters:**
-
 
 * panel (Panel) – The model panel being drawn.
 
@@ -153,18 +124,15 @@ Runs every frame when the character model panel draws. Lets code draw over the m
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Overlays the player's name above the preview model.
@@ -187,21 +155,15 @@ hook.Add("DrawLiliaModelView", "ShowName", function(panel, entity)
 end)
 ```
 
-
 ---
-
 
 ### ShouldAllowScoreboardOverride
 
-
 **Description:**
-
 
 Determines if a scoreboard field such as a player's name or model can be replaced.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being displayed.
 
@@ -211,18 +173,15 @@ Determines if a scoreboard field such as a player's name or model can be replace
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – Return true to allow override
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allows other hooks to replace player names on the scoreboard.
@@ -233,39 +192,30 @@ hook.Add("ShouldAllowScoreboardOverride", "OverrideNames", function(ply, field)
 end)
 ```
 
-
 ---
-
 
 ### GetDisplayedName
 
-
 **Description:**
-
 
 Returns the name text to display for a player in UI panels.
 
-
 **Parameters:**
-
 
 * client (Player) – Player to query.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * string or nil – Name text to display
 
 
 **Example Usage:**
-
 
 ```lua
 -- Displays player names with an admin prefix.
@@ -276,39 +226,30 @@ hook.Add("GetDisplayedName", "AdminPrefix", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### PlayerEndVoice
 
-
 **Description:**
-
 
 Fired when the voice panel for a player is removed from the HUD.
 
-
 **Parameters:**
-
 
 * client (Player) – Player whose panel ended.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Announces in chat and plays a sound when someone stops using voice chat.
@@ -318,39 +259,30 @@ hook.Add("PlayerEndVoice", "NotifyVoiceStop", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### SpawnlistContentChanged
 
-
 **Description:**
-
 
 Triggered when a spawn icon is removed from the extended spawn menu. Fired when content is removed from the spawn menu.
 
-
 **Parameters:**
-
 
 * icon (Panel) – Icon affected.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Plays a sound and prints which model was removed from the spawn menu.
@@ -361,21 +293,15 @@ hook.Add("SpawnlistContentChanged", "IconRemovedNotify", function(icon)
 end)
 ```
 
-
 ---
-
 
 ### ItemPaintOver
 
-
 **Description:**
-
 
 Gives a chance to draw additional info over item icons. Allows drawing over item icons in inventories.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Icon panel.
 
@@ -391,18 +317,15 @@ Gives a chance to draw additional info over item icons. Allows drawing over item
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Draws the item quantity in the bottom-right corner.
@@ -411,21 +334,15 @@ hook.Add("ItemPaintOver", "ShowQuantity", function(panel, item, w, h)
 end)
 ```
 
-
 ---
-
 
 ### OnCreateItemInteractionMenu
 
-
 **Description:**
-
 
 Allows extensions to populate the right-click menu for an item. Allows overriding the context menu for an item icon.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Icon panel.
 
@@ -438,18 +355,15 @@ Allows extensions to populate the right-click menu for an item. Allows overridin
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds an "Inspect" choice to an item's context menu.
@@ -460,21 +374,15 @@ hook.Add("OnCreateItemInteractionMenu", "AddInspect", function(panel, menu, item
 end)
 ```
 
-
 ---
-
 
 ### CanRunItemAction
 
-
 **Description:**
-
 
 Determines whether an item action should be displayed. Determines whether a specific item action is allowed.
 
-
 **Parameters:**
-
 
 * itemTable (table) – Item data.
 
@@ -484,18 +392,15 @@ Determines whether an item action should be displayed. Determines whether a spec
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – True if the action can run.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disables the drop action for all items.
@@ -506,39 +411,30 @@ hook.Add("CanRunItemAction", "BlockDrop", function(item, action)
 end)
 ```
 
-
 ---
-
 
 ### ShouldShowPlayerOnScoreboard
 
-
 **Description:**
-
 
 Return false to omit players from the scoreboard. Determines if a player should appear on the scoreboard.
 
-
 **Parameters:**
-
 
 * player (Player) – Player to test.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to hide the player
 
 
 **Example Usage:**
-
 
 ```lua
 -- Stops bots from showing up on the scoreboard.
@@ -549,21 +445,15 @@ hook.Add("ShouldShowPlayerOnScoreboard", "HideBots", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ShowPlayerOptions
 
-
 **Description:**
-
 
 Populate the scoreboard context menu with extra options. Allows modules to add scoreboard options for a player.
 
-
 **Parameters:**
-
 
 * player (Player) – Target player.
 
@@ -573,18 +463,15 @@ Populate the scoreboard context menu with extra options. Allows modules to add s
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds a friendly "Wave" choice in the scoreboard menu.
@@ -599,21 +486,15 @@ hook.Add("ShowPlayerOptions", "WaveOption", function(ply, options)
 end)
 ```
 
-
 ---
-
 
 ### GetDisplayedDescription
 
-
 **Description:**
-
 
 Supplies the description text shown on the scoreboard. Returns the description text to display for a player.
 
-
 **Parameters:**
-
 
 * player (Player) – Target player.
 
@@ -623,18 +504,15 @@ Supplies the description text shown on the scoreboard. Returns the description t
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * string – Description text
 
 
 **Example Usage:**
-
 
 ```lua
 -- Shows an OOC description when requested by the scoreboard.
@@ -645,39 +523,30 @@ hook.Add("GetDisplayedDescription", "OOCDesc", function(ply, isOOC)
 end)
 ```
 
-
 ---
-
 
 ### ChatTextChanged
 
-
 **Description:**
-
 
 Runs whenever the chat entry text is modified. Called whenever the chat entry text changes.
 
-
 **Parameters:**
-
 
 * text (string) – Current text.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Displays a hint when the user types "/help".
@@ -688,39 +557,30 @@ hook.Add("ChatTextChanged", "CommandHint", function(text)
 end)
 ```
 
-
 ---
-
 
 ### FinishChat
 
-
 **Description:**
-
 
 Fires when the chat box closes. Fired when the chat box is closed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Fade out the chat box when it closes.
@@ -733,39 +593,30 @@ hook.Add("FinishChat", "ChatClosed", function()
 end)
 ```
 
-
 ---
-
 
 ### StartChat
 
-
 **Description:**
-
 
 Fires when the chat box opens. Fired when the chat box is opened.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Plays a sound and focuses the chat window when it opens.
@@ -777,21 +628,15 @@ hook.Add("StartChat", "ChatOpened", function()
 end)
 ```
 
-
 ---
-
 
 ### ChatAddText
 
-
 **Description:**
-
 
 Allows modification of the markup before chat messages are printed. Allows modification of markup before chat text is shown.
 
-
 **Parameters:**
-
 
 * text (string) – Base markup text.
 
@@ -801,18 +646,15 @@ Allows modification of the markup before chat messages are printed. Allows modif
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * string – Modified markup text.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Turns chat messages green and prefixes the time before they appear.
@@ -822,21 +664,15 @@ hook.Add("ChatAddText", "GreenSystem", function(text, ...)
 end)
 ```
 
-
 ---
-
 
 ### DisplayItemRelevantInfo
 
-
 **Description:**
-
 
 Add extra lines to an item tooltip. Populates additional information for an item tooltip.
 
-
 **Parameters:**
-
 
 * extra (table) – Info table to fill.
 
@@ -849,18 +685,15 @@ Add extra lines to an item tooltip. Populates additional information for an item
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds the item's weight to its tooltip.
@@ -869,39 +702,30 @@ hook.Add("DisplayItemRelevantInfo", "ShowWeight", function(extra, client, item)
 end)
 ```
 
-
 ---
-
 
 ### GetMainMenuPosition
 
-
 **Description:**
-
 
 Returns the camera position and angle for the main menu character preview. Provides the camera position and angle for the main menu model.
 
-
 **Parameters:**
-
 
 * character (Character) – Character being viewed.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * Vector, Angle – Position and angle values.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Positions the main menu camera with a slight offset.
@@ -910,39 +734,30 @@ hook.Add("GetMainMenuPosition", "OffsetCharView", function(character)
 end)
 ```
 
-
 ---
-
 
 ### CanDeleteChar
 
-
 **Description:**
-
 
 Return false here to prevent character deletion. Determines if a character can be deleted.
 
-
 **Parameters:**
-
 
 * characterID (number) – Identifier of the character.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to disallow deletion.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Blocks deletion of the first character slot.
@@ -953,21 +768,15 @@ hook.Add("CanDeleteChar", "ProtectSlot1", function(id)
 end)
 ```
 
-
 ---
-
 
 ### LoadMainMenuInformation
 
-
 **Description:**
-
 
 Lets modules insert additional information on the main menu info panel. Allows modules to populate extra information on the main menu panel.
 
-
 **Parameters:**
-
 
 * info (table) – Table to receive information.
 
@@ -977,18 +786,15 @@ Lets modules insert additional information on the main menu info panel. Allows m
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds the character's faction to the menu info panel.
@@ -997,39 +803,30 @@ hook.Add("LoadMainMenuInformation", "AddFactionInfo", function(info, character)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerCreateChar
 
-
 **Description:**
-
 
 Checks if the local player may start creating a character. Determines if the player may create a new character.
 
-
 **Parameters:**
-
 
 * player (Player) – Local player.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to disallow creation.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Restricts character creation to admins only.
@@ -1040,21 +837,15 @@ hook.Add("CanPlayerCreateChar", "AdminsOnly", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ModifyCharacterModel
 
-
 **Description:**
-
 
 Lets you edit the clientside model used in the main menu. Allows adjustments to the character model in menus.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Model entity.
 
@@ -1064,18 +855,15 @@ Lets you edit the clientside model used in the main menu. Allows adjustments to 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Changes a bodygroup on the preview model.
@@ -1084,39 +872,30 @@ hook.Add("ModifyCharacterModel", "ApplyBodygroup", function(ent, character)
 end)
 ```
 
-
 ---
-
 
 ### ConfigureCharacterCreationSteps
 
-
 **Description:**
-
 
 Add or reorder steps in the character creation flow. Lets modules alter the character creation step layout.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Creation panel.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds a custom "background" step to the character creator.
@@ -1125,39 +904,30 @@ hook.Add("ConfigureCharacterCreationSteps", "InsertBackground", function(panel)
 end)
 ```
 
-
 ---
-
 
 ### GetMaxPlayerChar
 
-
 **Description:**
-
 
 Override to change how many characters a player can have. Returns the maximum number of characters a player can have.
 
-
 **Parameters:**
-
 
 * player (Player) – Local player.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * number – Maximum character count.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Gives admins extra character slots.
@@ -1166,39 +936,30 @@ hook.Add("GetMaxPlayerChar", "AdminSlots", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ShouldMenuButtonShow
 
-
 **Description:**
-
 
 Return false and a reason to hide buttons on the main menu. Determines if a button should be visible on the main menu.
 
-
 **Parameters:**
-
 
 * name (string) – Button identifier.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean, string – False and reason to hide.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Hides the delete button when the feature is locked.
@@ -1209,39 +970,30 @@ hook.Add("ShouldMenuButtonShow", "HideDelete", function(name)
 end)
 ```
 
-
 ---
-
 
 ### ResetCharacterPanel
 
-
 **Description:**
-
 
 Called when the character creation panel should reset. Called to reset the character creation panel.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notifies whenever the creation panel resets.
@@ -1250,39 +1002,30 @@ hook.Add("ResetCharacterPanel", "ClearFields", function()
 end)
 ```
 
-
 ---
-
 
 ### EasyIconsLoaded
 
-
 **Description:**
-
 
 Notifies when the EasyIcons font sheet has loaded. Fired when the EasyIcons library has loaded.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Rebuild icons using the font after it loads.
@@ -1293,21 +1036,15 @@ hook.Add("EasyIconsLoaded", "Notify", function()
 end)
 ```
 
-
 ---
-
 
 ### CAMI.OnUsergroupRegistered
 
-
 **Description:**
-
 
 Called when CAMI registers a new usergroup. CAMI notification that a usergroup was registered.
 
-
 **Parameters:**
-
 
 * usergroup (table) – Registered usergroup data.
 
@@ -1317,18 +1054,15 @@ Called when CAMI registers a new usergroup. CAMI notification that a usergroup w
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Logs newly registered CAMI usergroups.
@@ -1337,21 +1071,15 @@ hook.Add("CAMI.OnUsergroupRegistered", "LogGroup", function(group)
 end)
 ```
 
-
 ---
-
 
 ### CAMI.OnUsergroupUnregistered
 
-
 **Description:**
-
 
 Called when a usergroup is removed from CAMI. CAMI notification that a usergroup was removed.
 
-
 **Parameters:**
-
 
 * usergroup (table) – Unregistered usergroup data.
 
@@ -1361,18 +1089,15 @@ Called when a usergroup is removed from CAMI. CAMI notification that a usergroup
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Logs whenever a usergroup is removed from CAMI.
@@ -1381,39 +1106,30 @@ hook.Add("CAMI.OnUsergroupUnregistered", "LogRemoval", function(group)
 end)
 ```
 
-
 ---
-
 
 ### CAMI.OnPrivilegeRegistered
 
-
 **Description:**
-
 
 Fired when a privilege is created in CAMI. CAMI notification that a privilege was registered.
 
-
 **Parameters:**
-
 
 * privilege (table) – Privilege data.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reports when a new CAMI privilege is registered.
@@ -1422,39 +1138,30 @@ hook.Add("CAMI.OnPrivilegeRegistered", "LogPrivilege", function(priv)
 end)
 ```
 
-
 ---
-
 
 ### CAMI.OnPrivilegeUnregistered
 
-
 **Description:**
-
 
 Fired when a privilege is removed from CAMI. CAMI notification that a privilege was unregistered.
 
-
 **Parameters:**
-
 
 * privilege (table) – Privilege data.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reports when a CAMI privilege is removed.
@@ -1463,21 +1170,15 @@ hook.Add("CAMI.OnPrivilegeUnregistered", "LogPrivRemoval", function(priv)
 end)
 ```
 
-
 ---
-
 
 ### CAMI.PlayerHasAccess
 
-
 **Description:**
-
 
 Allows an override of player privilege checks. Allows external libraries to override privilege checks.
 
-
 **Parameters:**
-
 
 * handler (function) – Default handler.
 
@@ -1499,18 +1200,15 @@ Allows an override of player privilege checks. Allows external libraries to over
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Lets superadmins bypass privilege checks.
@@ -1522,21 +1220,15 @@ hook.Add("CAMI.PlayerHasAccess", "AllowSuperadmins", function(_, actor, priv, cb
 end)
 ```
 
-
 ---
-
 
 ### CAMI.SteamIDHasAccess
 
-
 **Description:**
-
 
 Allows an override of SteamID-based privilege checks. Similar to PlayerHasAccess but for SteamIDs.
 
-
 **Parameters:**
-
 
 * handler (function) – Default handler.
 
@@ -1558,18 +1250,15 @@ Allows an override of SteamID-based privilege checks. Similar to PlayerHasAccess
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grants access for a specific SteamID.
@@ -1581,21 +1270,15 @@ hook.Add("CAMI.SteamIDHasAccess", "AllowSteamID", function(_, steamID, priv, cb)
 end)
 ```
 
-
 ---
-
 
 ### CAMI.PlayerUsergroupChanged
 
-
 **Description:**
-
 
 Notification that a player's group changed. Fired when a player's usergroup has changed.
 
-
 **Parameters:**
-
 
 * player (Player) – Affected player.
 
@@ -1611,18 +1294,15 @@ Notification that a player's group changed. Fired when a player's usergroup has 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Announces when a player's usergroup changes.
@@ -1631,21 +1311,15 @@ hook.Add("CAMI.PlayerUsergroupChanged", "AnnounceChange", function(ply, old, new
 end)
 ```
 
-
 ---
-
 
 ### CAMI.SteamIDUsergroupChanged
 
-
 **Description:**
-
 
 Notification that a SteamID's group changed. Fired when a SteamID's usergroup has changed.
 
-
 **Parameters:**
-
 
 * steamID (string) – Affected SteamID.
 
@@ -1661,18 +1335,15 @@ Notification that a SteamID's group changed. Fired when a SteamID's usergroup ha
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Logs usergroup changes by SteamID.
@@ -1681,39 +1352,30 @@ hook.Add("CAMI.SteamIDUsergroupChanged", "LogSIDChange", function(sid, old, new)
 end)
 ```
 
-
 ---
-
 
 ### TooltipLayout
 
-
 **Description:**
-
 
 Customize tooltip sizing and layout before it appears.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Tooltip panel being laid out.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Sets a fixed width for tooltips before layout.
@@ -1722,21 +1384,15 @@ hook.Add("TooltipLayout", "FixedWidth", function(panel)
 end)
 ```
 
-
 ---
-
 
 ### TooltipPaint
 
-
 **Description:**
-
 
 Draw custom visuals on the tooltip, returning true skips default painting.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Tooltip panel.
 
@@ -1749,18 +1405,15 @@ Draw custom visuals on the tooltip, returning true skips default painting.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds a dark background and skips default paint.
@@ -1771,21 +1424,15 @@ hook.Add("TooltipPaint", "BlurBackground", function(panel, w, h)
 end)
 ```
 
-
 ---
-
 
 ### TooltipInitialize
 
-
 **Description:**
-
 
 Runs when a tooltip is opened for a panel.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Tooltip panel.
 
@@ -1795,18 +1442,15 @@ Runs when a tooltip is opened for a panel.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Fades tooltips in when they are created.
@@ -1816,39 +1460,30 @@ hook.Add("TooltipInitialize", "SetupFade", function(panel, target)
 end)
 ```
 
-
 ---
-
 
 ### PlayerLoadout
 
-
 **Description:**
-
 
 Runs when a player spawns and equips items. Allows modification of the default loadout.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being loaded out.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Gives players a crowbar and ammo on spawn.
@@ -1859,21 +1494,15 @@ hook.Add("PlayerLoadout", "GiveCrowbar", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### PlayerShouldPermaKill
 
-
 **Description:**
-
 
 Determines if a player's death should permanently kill their character. Return true to mark the character for deletion.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that died.
 
@@ -1886,18 +1515,15 @@ Determines if a player's death should permanently kill their character. Return t
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – Return true to mark for permanent death
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent permanent death from fall damage.
@@ -1908,21 +1534,15 @@ hook.Add("PlayerShouldPermaKill", "NoFallPK", function(ply, inflictor)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerDropItem
 
-
 **Description:**
-
 
 Checks if a player may drop an item. Return false to block dropping.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to drop.
 
@@ -1932,18 +1552,15 @@ Checks if a player may drop an item. Return false to block dropping.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to block dropping
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disallow dropping locked items.
@@ -1954,21 +1571,15 @@ hook.Add("CanPlayerDropItem", "NoLockedDrop", function(ply, item)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerTakeItem
 
-
 **Description:**
-
 
 Determines if a player can pick up an item. Return false to prevent taking.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting pickup.
 
@@ -1978,18 +1589,15 @@ Determines if a player can pick up an item. Return false to prevent taking.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to prevent pickup
 
 
 **Example Usage:**
-
 
 ```lua
 -- Block taking admin items.
@@ -2000,21 +1608,15 @@ hook.Add("CanPlayerTakeItem", "NoAdminPickup", function(ply, item)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerEquipItem
 
-
 **Description:**
-
 
 Queries if a player can equip an item. Returning false stops the equip action.
 
-
 **Parameters:**
-
 
 * client (Player) – Player equipping.
 
@@ -2024,18 +1626,15 @@ Queries if a player can equip an item. Returning false stops the equip action.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to block equipping
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allow equipping only if level requirement met.
@@ -2046,21 +1645,15 @@ hook.Add("CanPlayerEquipItem", "CheckLevel", function(ply, item)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerUnequipItem
 
-
 **Description:**
-
 
 Called before an item is unequipped. Return false to keep the item equipped.
 
-
 **Parameters:**
-
 
 * client (Player) – Player unequipping.
 
@@ -2070,18 +1663,15 @@ Called before an item is unequipped. Return false to keep the item equipped.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to prevent unequipping
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent unequipping cursed gear.
@@ -2092,21 +1682,15 @@ hook.Add("CanPlayerUnequipItem", "Cursed", function(ply, item)
 end)
 ```
 
-
 ---
-
 
 ### PostPlayerSay
 
-
 **Description:**
-
 
 Runs after chat messages are processed. Allows reacting to player chat.
 
-
 **Parameters:**
-
 
 * client (Player) – Speaking player.
 
@@ -2122,18 +1706,15 @@ Runs after chat messages are processed. Allows reacting to player chat.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log all OOC chat.
@@ -2144,39 +1725,30 @@ hook.Add("PostPlayerSay", "LogOOC", function(ply, msg, chatType)
 end)
 ```
 
-
 ---
-
 
 ### ShouldSpawnClientRagdoll
 
-
 **Description:**
-
 
 Decides if a corpse ragdoll should spawn for a player. Return false to skip ragdoll creation.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that died.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to skip ragdoll
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disable ragdolls for bots.
@@ -2187,39 +1759,30 @@ hook.Add("ShouldSpawnClientRagdoll", "NoBotRagdoll", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### SaveData
 
-
 **Description:**
-
 
 Called when the framework saves persistent data. Modules can store custom information here.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Save a timestamp to file.
@@ -2228,39 +1791,30 @@ hook.Add("SaveData", "RecordTime", function()
 end)
 ```
 
-
 ---
-
 
 ### PersistenceSave
 
-
 **Description:**
-
 
 Fires when map persistence should be written to disk. Allows adding extra persistent entities.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Backs up all persistent entities to a data file whenever saving occurs.
@@ -2279,39 +1833,30 @@ hook.Add("PersistenceSave", "BackupEntities", function()
 end)
 ```
 
-
 ---
-
 
 ### CanPersistEntity
 
-
 **Description:**
-
 
 Invoked before an entity is saved as persistent. Return false to disallow persisting the entity.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Entity being considered for persistence.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to prevent the entity from being saved.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Skip weapons when marking props permanent.
@@ -2322,39 +1867,30 @@ hook.Add("CanPersistEntity", "BlockWeapons", function(entity)
 end)
 ```
 
-
 ---
-
 
 ### LoadData
 
-
 **Description:**
-
 
 Triggered when stored data should be loaded. Modules can restore custom information here.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Restores map props from a saved JSON file on disk.
@@ -2374,39 +1910,30 @@ hook.Add("LoadData", "LoadCustomProps", function()
 end)
 ```
 
-
 ---
-
 
 ### PostLoadData
 
-
 **Description:**
-
 
 Called after all persistent data has loaded. Useful for post-processing.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Spawns a supply crate at a stored position once everything is loaded.
@@ -2421,39 +1948,30 @@ hook.Add("PostLoadData", "SpawnCrate", function()
 end)
 ```
 
-
 ---
-
 
 ### ShouldDataBeSaved
 
-
 **Description:**
-
 
 Queries if data saving should occur during shutdown. Return false to cancel saving.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to cancel saving
 
 
 **Example Usage:**
-
 
 ```lua
 -- Skip saving during quick restarts.
@@ -2462,21 +1980,15 @@ hook.Add("ShouldDataBeSaved", "NoSave", function()
 end)
 ```
 
-
 ---
-
 
 ### OnCharDisconnect
 
-
 **Description:**
-
 
 Called when a player's character disconnects. Provides a last chance to handle data.
 
-
 **Parameters:**
-
 
 * client (Player) – Disconnecting player.
 
@@ -2486,18 +1998,15 @@ Called when a player's character disconnects. Provides a last chance to handle d
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Store the character's last position so it can be restored later.
@@ -2506,39 +2015,30 @@ hook.Add("OnCharDisconnect", "SaveLogoutPos", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### SetupBotPlayer
 
-
 **Description:**
-
 
 Initializes a bot's character when it first joins. Allows custom bot setup.
 
-
 **Parameters:**
-
 
 * client (Player) – Bot player.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Give the bot a starter pistol and set up a small inventory.
@@ -2549,39 +2049,30 @@ hook.Add("SetupBotPlayer", "InitBot", function(bot)
 end)
 ```
 
-
 ---
-
 
 ### PlayerLiliaDataLoaded
 
-
 **Description:**
-
 
 Fired after a player's personal data has loaded. Useful for syncing additional info.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that loaded data.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Cache the player's faction color from saved data for use after their character loads.
@@ -2594,39 +2085,30 @@ hook.Add("PlayerLiliaDataLoaded", "CacheFactionColor", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### PostPlayerInitialSpawn
 
-
 **Description:**
-
 
 Runs after the player entity has spawned and data is ready. Allows post-initialization logic.
 
-
 **Parameters:**
-
 
 * client (Player) – Newly spawned player.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Initialize some default variables for new players.
@@ -2636,39 +2118,30 @@ hook.Add("PostPlayerInitialSpawn", "SetupTutorialState", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### FactionOnLoadout
 
-
 **Description:**
-
 
 Gives factions a chance to modify player loadouts. Runs before weapons are equipped.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being equipped.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when FactionOnLoadout is triggered
@@ -2679,39 +2152,30 @@ hook.Add("FactionOnLoadout", "GiveRadio", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ClassOnLoadout
 
-
 **Description:**
-
 
 Allows classes to modify the player's starting gear. Executed prior to PostPlayerLoadout.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being equipped.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ClassOnLoadout is triggered
@@ -2722,39 +2186,30 @@ hook.Add("ClassOnLoadout", "MedicItems", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### PostPlayerLoadout
 
-
 **Description:**
-
 
 Called after the player has been equipped. Last chance to modify the loadout.
 
-
 **Parameters:**
-
 
 * client (Player) – Player loaded out.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PostPlayerLoadout is triggered
@@ -2763,39 +2218,30 @@ hook.Add("PostPlayerLoadout", "SetColor", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### FactionPostLoadout
 
-
 **Description:**
-
 
 Runs after faction loadout logic completes. Allows post-loadout tweaks.
 
-
 **Parameters:**
-
 
 * client (Player) – Player affected.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when FactionPostLoadout is triggered
@@ -2806,39 +2252,30 @@ hook.Add("FactionPostLoadout", "Shout", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ClassPostLoadout
 
-
 **Description:**
-
 
 Runs after class loadout logic completes. Allows post-loadout tweaks for classes.
 
-
 **Parameters:**
-
 
 * client (Player) – Player affected.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ClassPostLoadout is triggered
@@ -2847,39 +2284,30 @@ hook.Add("ClassPostLoadout", "Pose", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### GetDefaultInventoryType
 
-
 **Description:**
-
 
 Returns the inventory type used for new characters. Modules can override to provide custom types.
 
-
 **Parameters:**
-
 
 * character (Character) – Character being created.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * string – Inventory type
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetDefaultInventoryType is triggered
@@ -2888,39 +2316,30 @@ hook.Add("GetDefaultInventoryType", "UseGrid", function()
 end)
 ```
 
-
 ---
-
 
 ### ShouldDeleteSavedItems
 
-
 **Description:**
-
 
 Decides whether saved persistent items should be deleted on load. Return true to wipe them from the database.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – True to delete items
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove stored items if too many exist on the map.
@@ -2931,39 +2350,30 @@ hook.Add("ShouldDeleteSavedItems", "ClearDrops", function()
 end)
 ```
 
-
 ---
-
 
 ### OnSavedItemLoaded
 
-
 **Description:**
-
 
 Called after map items have been loaded from storage. Provides the table of created items.
 
-
 **Parameters:**
-
 
 * items (table) – Loaded item entities.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adjusts item collision settings after loading from storage.
@@ -2975,39 +2385,30 @@ hook.Add("OnSavedItemLoaded", "PrintCount", function(items)
 end)
 ```
 
-
 ---
-
 
 ### ShouldDrawEntityInfo
 
-
 **Description:**
-
 
 Determines if world-space info should be rendered for an entity. Return false to hide the tooltip.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Entity being considered.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to hide info
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldDrawEntityInfo is triggered
@@ -3018,21 +2419,15 @@ hook.Add("ShouldDrawEntityInfo", "HideNPCs", function(ent)
 end)
 ```
 
-
 ---
-
 
 ### DrawEntityInfo
 
-
 **Description:**
-
 
 Allows custom drawing of entity information in the world. Drawn every frame while visible.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Entity to draw info for.
 
@@ -3045,18 +2440,15 @@ Allows custom drawing of entity information in the world. Drawn every frame whil
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when DrawEntityInfo is triggered
@@ -3065,39 +2457,30 @@ hook.Add("DrawEntityInfo", "LabelProps", function(ent, a, pos)
 end)
 ```
 
-
 ---
-
 
 ### GetInjuredText
 
-
 **Description:**
-
 
 Provides the health status text and color for a player. Return a table with text and color values.
 
-
 **Parameters:**
-
 
 * client (Player) – Player to check.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table – {text, color} info
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetInjuredText is triggered
@@ -3108,39 +2491,30 @@ hook.Add("GetInjuredText", "SimpleHealth", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### ShouldDrawPlayerInfo
 
-
 **Description:**
-
 
 Determines if character info should draw above a player. Return false to suppress drawing.
 
-
 **Parameters:**
-
 
 * player (Player) – Player being rendered.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to hide info
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldDrawPlayerInfo is triggered
@@ -3151,21 +2525,15 @@ hook.Add("ShouldDrawPlayerInfo", "HideLocal", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### DrawCharInfo
 
-
 **Description:**
-
 
 Allows modules to add lines to the character info display. Called when building the info table.
 
-
 **Parameters:**
-
 
 * player (Player) – Player being displayed.
 
@@ -3178,18 +2546,15 @@ Allows modules to add lines to the character info display. Called when building 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when DrawCharInfo is triggered
@@ -3198,39 +2563,30 @@ hook.Add("DrawCharInfo", "JobTitle", function(ply, char, info)
 end)
 ```
 
-
 ---
-
 
 ### ItemShowEntityMenu
 
-
 **Description:**
-
 
 Opens the context menu for a world item when used. Allows replacing the default menu.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Item entity clicked.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ItemShowEntityMenu is triggered
@@ -3239,39 +2595,30 @@ hook.Add("ItemShowEntityMenu", "QuickTake", function(ent)
 end)
 ```
 
-
 ---
-
 
 ### PreLiliaLoaded
 
-
 **Description:**
-
 
 Fired just before the client finishes loading the framework. Useful for setup tasks.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PreLiliaLoaded is triggered
@@ -3280,39 +2627,30 @@ hook.Add("PreLiliaLoaded", "Prep", function()
 end)
 ```
 
-
 ---
-
 
 ### LiliaLoaded
 
-
 **Description:**
-
 
 Indicates the client finished initializing the framework. Modules can start creating panels here.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when LiliaLoaded is triggered
@@ -3321,21 +2659,15 @@ hook.Add("LiliaLoaded", "Ready", function()
 end)
 ```
 
-
 ---
-
 
 ### InventoryDataChanged
 
-
 **Description:**
-
 
 Notifies when inventory metadata changes. Provides old and new values.
 
-
 **Parameters:**
-
 
 * inventory (table) – Inventory affected.
 
@@ -3351,18 +2683,15 @@ Notifies when inventory metadata changes. Provides old and new values.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InventoryDataChanged is triggered
@@ -3373,39 +2702,30 @@ hook.Add("InventoryDataChanged", "TrackWeight", function(inv, k, old, new)
 end)
 ```
 
-
 ---
-
 
 ### ItemInitialized
 
-
 **Description:**
-
 
 Called when a new item instance is created clientside. Allows additional setup for the item.
 
-
 **Parameters:**
-
 
 * item (table) – Item created.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ItemInitialized is triggered
@@ -3414,39 +2734,30 @@ hook.Add("ItemInitialized", "PrintID", function(item)
 end)
 ```
 
-
 ---
-
 
 ### InventoryInitialized
 
-
 **Description:**
-
 
 Fired when an inventory instance finishes loading. Modules may modify it here.
 
-
 **Parameters:**
-
 
 * inventory (table) – Inventory initialized.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InventoryInitialized is triggered
@@ -3455,21 +2766,15 @@ hook.Add("InventoryInitialized", "AnnounceInv", function(inv)
 end)
 ```
 
-
 ---
-
 
 ### InventoryItemAdded
 
-
 **Description:**
-
 
 Invoked when an item is placed into an inventory. Lets code react to the addition.
 
-
 **Parameters:**
-
 
 * inventory (table) – Inventory receiving the item.
 
@@ -3479,18 +2784,15 @@ Invoked when an item is placed into an inventory. Lets code react to the additio
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InventoryItemAdded is triggered
@@ -3499,21 +2801,15 @@ hook.Add("InventoryItemAdded", "NotifyAdd", function(inv, item)
 end)
 ```
 
-
 ---
-
 
 ### InventoryItemRemoved
 
-
 **Description:**
-
 
 Called when an item is removed from an inventory. Runs after the item table is updated.
 
-
 **Parameters:**
-
 
 * inventory (table) – Inventory modified.
 
@@ -3523,18 +2819,15 @@ Called when an item is removed from an inventory. Runs after the item table is u
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InventoryItemRemoved is triggered
@@ -3543,39 +2836,30 @@ hook.Add("InventoryItemRemoved", "NotifyRemove", function(inv, item)
 end)
 ```
 
-
 ---
-
 
 ### InventoryDeleted
 
-
 **Description:**
-
 
 Signals that an inventory was deleted clientside. Allows cleanup of references.
 
-
 **Parameters:**
-
 
 * inventory (table) – Deleted inventory.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InventoryDeleted is triggered
@@ -3584,39 +2868,30 @@ hook.Add("InventoryDeleted", "Clear", function(inv)
 end)
 ```
 
-
 ---
-
 
 ### ItemDeleted
 
-
 **Description:**
-
 
 Fired when an item is removed entirely. Modules should clear any cached data.
 
-
 **Parameters:**
-
 
 * item (table) – Item that was deleted.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ItemDeleted is triggered
@@ -3625,21 +2900,15 @@ hook.Add("ItemDeleted", "Log", function(item)
 end)
 ```
 
-
 ---
-
 
 ### OnCharVarChanged
 
-
 **Description:**
-
 
 Runs when a networked character variable changes. Gives both old and new values.
 
-
 **Parameters:**
-
 
 * character (Character) – Affected character.
 
@@ -3655,18 +2924,15 @@ Runs when a networked character variable changes. Gives both old and new values.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnCharVarChanged is triggered
@@ -3677,21 +2943,15 @@ hook.Add("OnCharVarChanged", "WatchMoney", function(char, k, old, new)
 end)
 ```
 
-
 ---
-
 
 ### OnCharLocalVarChanged
 
-
 **Description:**
-
 
 Similar to OnCharVarChanged but for local-only variables. Called after the table updates.
 
-
 **Parameters:**
-
 
 * character (Character) – Affected character.
 
@@ -3707,18 +2967,15 @@ Similar to OnCharVarChanged but for local-only variables. Called after the table
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnCharLocalVarChanged is triggered
@@ -3729,21 +2986,15 @@ hook.Add("OnCharLocalVarChanged", "WatchFlags", function(char, k, old, new)
 end)
 ```
 
-
 ---
-
 
 ### ItemDataChanged
 
-
 **Description:**
-
 
 Called when item data values change clientside. Provides both the old and new values.
 
-
 **Parameters:**
-
 
 * item (table) – Item modified.
 
@@ -3759,18 +3010,15 @@ Called when item data values change clientside. Provides both the old and new va
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ItemDataChanged is triggered
@@ -3781,21 +3029,15 @@ hook.Add("ItemDataChanged", "TrackDurability", function(item, key)
 end)
 ```
 
-
 ---
-
 
 ### ItemQuantityChanged
 
-
 **Description:**
-
 
 Runs when an item's quantity value updates. Allows reacting to stack changes.
 
-
 **Parameters:**
-
 
 * item (table) – Item affected.
 
@@ -3808,18 +3050,15 @@ Runs when an item's quantity value updates. Allows reacting to stack changes.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ItemQuantityChanged is triggered
@@ -3828,21 +3067,15 @@ hook.Add("ItemQuantityChanged", "CountStacks", function(item, old, new)
 end)
 ```
 
-
 ---
-
 
 ### KickedFromChar
 
-
 **Description:**
-
 
 Indicates that a character was forcefully removed. isCurrentChar denotes if it was the active one.
 
-
 **Parameters:**
-
 
 * id (number) – Character identifier.
 
@@ -3852,18 +3085,15 @@ Indicates that a character was forcefully removed. isCurrentChar denotes if it w
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when KickedFromChar is triggered
@@ -3872,21 +3102,15 @@ hook.Add("KickedFromChar", "Notify", function(id, current)
 end)
 ```
 
-
 ---
-
 
 ### HandleItemTransferRequest
 
-
 **Description:**
-
 
 Server receives a request to move an item. Modules can validate or modify the transfer.
 
-
 **Parameters:**
-
 
 * client (Player) – Requesting player.
 
@@ -3905,18 +3129,15 @@ Server receives a request to move an item. Modules can validate or modify the tr
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when HandleItemTransferRequest is triggered
@@ -3925,39 +3146,30 @@ hook.Add("HandleItemTransferRequest", "LogMove", function(ply, itemID, x, y)
 end)
 ```
 
-
 ---
-
 
 ### CharLoaded
 
-
 **Description:**
-
 
 Fired when a character object is fully loaded. Receives the character ID.
 
-
 **Parameters:**
-
 
 * id (number) – Character identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharLoaded is triggered
@@ -3966,39 +3178,30 @@ hook.Add("CharLoaded", "Notify", function(id)
 end)
 ```
 
-
 ---
-
 
 ### PreCharDelete
 
-
 **Description:**
-
 
 Called before a character is removed. Return false to cancel deletion.
 
-
 **Parameters:**
-
 
 * id (number) – Character identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PreCharDelete is triggered
@@ -4009,21 +3212,15 @@ hook.Add("PreCharDelete", "Protect", function(id)
 end)
 ```
 
-
 ---
-
 
 ### OnCharDelete
 
-
 **Description:**
-
 
 Fired when a character is deleted. Provides the owning player if available.
 
-
 **Parameters:**
-
 
 * client (Player) – Player who deleted.
 
@@ -4033,18 +3230,15 @@ Fired when a character is deleted. Provides the owning player if available.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnCharDelete is triggered
@@ -4053,21 +3247,15 @@ hook.Add("OnCharDelete", "Announce", function(ply, id)
 end)
 ```
 
-
 ---
-
 
 ### OnCharCreated
 
-
 **Description:**
-
 
 Invoked after a new character is created. Supplies the character table and creation data.
 
-
 **Parameters:**
-
 
 * client (Player) – Owner player.
 
@@ -4080,18 +3268,15 @@ Invoked after a new character is created. Supplies the character table and creat
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnCharCreated is triggered
@@ -4100,39 +3285,30 @@ hook.Add("OnCharCreated", "Welcome", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### OnTransferred
 
-
 **Description:**
-
 
 Runs when a player transfers to another server. Useful for cleanup.
 
-
 **Parameters:**
-
 
 * client (Player) – Transferring player.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnTransferred is triggered
@@ -4141,39 +3317,30 @@ hook.Add("OnTransferred", "Goodbye", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### CharPreSave
 
-
 **Description:**
-
 
 Executed before a character is saved to disk. Allows writing custom data.
 
-
 **Parameters:**
-
 
 * character (Character) – Character being saved.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharPreSave is triggered
@@ -4182,39 +3349,30 @@ hook.Add("CharPreSave", "Record", function(char)
 end)
 ```
 
-
 ---
-
 
 ### CharListLoaded
 
-
 **Description:**
-
 
 Called when the character selection list finishes loading. Provides the loaded list table.
 
-
 **Parameters:**
-
 
 * newCharList (table) – Table of characters.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharListLoaded is triggered
@@ -4223,21 +3381,15 @@ hook.Add("CharListLoaded", "CountChars", function(list)
 end)
 ```
 
-
 ---
-
 
 ### CharListUpdated
 
-
 **Description:**
-
 
 Fires when the character list is refreshed. Gives both old and new tables.
 
-
 **Parameters:**
-
 
 * oldCharList (table) – Previous list.
 
@@ -4247,18 +3399,15 @@ Fires when the character list is refreshed. Gives both old and new tables.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharListUpdated is triggered
@@ -4267,39 +3416,30 @@ hook.Add("CharListUpdated", "Diff", function(old, new)
 end)
 ```
 
-
 ---
-
 
 ### getCharMaxStamina
 
-
 **Description:**
-
 
 Returns the maximum stamina for a character. Override to change stamina capacity.
 
-
 **Parameters:**
-
 
 * character (Character) – Character queried.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when getCharMaxStamina is triggered
@@ -4308,21 +3448,15 @@ hook.Add("getCharMaxStamina", "Double", function(char)
 end)
 ```
 
-
 ---
-
 
 ### AdjustStaminaOffsetRunning
 
-
 **Description:**
-
 
 Alters the stamina offset applied each tick while sprinting. Return a new cost to modify how quickly stamina drains when running.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that is sprinting.
 
@@ -4332,18 +3466,15 @@ Alters the stamina offset applied each tick while sprinting. Return a new cost t
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Modified stamina cost.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when AdjustStaminaOffsetRunning is triggered
@@ -4352,21 +3483,15 @@ hook.Add("AdjustStaminaOffsetRunning", "EnduranceBonus", function(ply, cost)
 end)
 ```
 
-
 ---
-
 
 ### AdjustStaminaRegeneration
 
-
 **Description:**
-
 
 Allows changing how quickly stamina regenerates when not sprinting. Return a new amount to modify regeneration speed.
 
-
 **Parameters:**
-
 
 * client (Player) – Player recovering stamina.
 
@@ -4376,18 +3501,15 @@ Allows changing how quickly stamina regenerates when not sprinting. Return a new
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Modified regeneration amount.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when AdjustStaminaRegeneration is triggered
@@ -4398,21 +3520,15 @@ hook.Add("AdjustStaminaRegeneration", "RestAreaBoost", function(ply, amount)
 end)
 ```
 
-
 ---
-
 
 ### AdjustStaminaOffset
 
-
 **Description:**
-
 
 Final hook for tweaking the calculated stamina offset. Return the modified offset value to apply each tick.
 
-
 **Parameters:**
-
 
 * client (Player) – Player whose stamina is updating.
 
@@ -4422,18 +3538,15 @@ Final hook for tweaking the calculated stamina offset. Return the modified offse
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – New offset to apply.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when AdjustStaminaOffset is triggered
@@ -4442,21 +3555,15 @@ hook.Add("AdjustStaminaOffset", "MinimumDrain", function(ply, off)
 end)
 ```
 
-
 ---
-
 
 ### PostLoadFonts
 
-
 **Description:**
-
 
 Runs after all font files have loaded. Allows registering additional fonts.
 
-
 **Parameters:**
-
 
 * currentFont (string) – Name of the primary UI font.
 
@@ -4466,18 +3573,15 @@ Runs after all font files have loaded. Allows registering additional fonts.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PostLoadFonts is triggered
@@ -4486,21 +3590,15 @@ hook.Add("PostLoadFonts", "LogoFont", function()
 end)
 ```
 
-
 ---
-
 
 ### AddBarField
 
-
 **Description:**
-
 
 Called when the F1 menu builds status bars so new fields can be added.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Section identifier.
 
@@ -4522,18 +3620,15 @@ Called when the F1 menu builds status bars so new fields can be added.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Adds a custom thirst bar next to stamina.
@@ -4542,21 +3637,15 @@ hook.Add("AddBarField", "AddThirstBar", function(section, id, label, min, max, v
 end)
 ```
 
-
 ---
-
 
 ### AddSection
 
-
 **Description:**
-
 
 Fired when building the F1 menu so modules can insert additional sections.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Name of the section.
 
@@ -4572,18 +3661,15 @@ Fired when building the F1 menu so modules can insert additional sections.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Add a custom "Settings" tab.
@@ -4595,21 +3681,15 @@ hook.Add("AddSection", "AddSettingsSection", function(name, color, priority)
 end)
 ```
 
-
 ---
-
 
 ### CanItemBeTransfered
 
-
 **Description:**
-
 
 Determines whether an item may move between inventories.
 
-
 **Parameters:**
-
 
 * item (Item) – Item being transferred.
 
@@ -4625,18 +3705,15 @@ Determines whether an item may move between inventories.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean, string – False and reason to block
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent quest items from being dropped.
@@ -4647,39 +3724,30 @@ hook.Add("CanItemBeTransfered", "BlockQuestItemDrop", function(item, newInv, old
 end)
 ```
 
-
 ---
-
 
 ### CanOpenBagPanel
 
-
 **Description:**
-
 
 Called right before a bag inventory UI opens. Return false to block opening.
 
-
 **Parameters:**
-
 
 * item (Item) – Bag item being opened.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to block opening.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disallow bag use while fighting.
@@ -4690,39 +3758,30 @@ hook.Add("CanOpenBagPanel", "BlockBagInCombat", function(item)
 end)
 ```
 
-
 ---
-
 
 ### CanOutfitChangeModel
 
-
 **Description:**
-
 
 Checks if an outfit is allowed to change the player model.
 
-
 **Parameters:**
-
 
 * item (Item) – Outfit item attempting to change the model.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to block the change.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Restrict model swaps for certain factions.
@@ -4733,21 +3792,15 @@ hook.Add("CanOutfitChangeModel", "RestrictModelSwap", function(item)
 end)
 ```
 
-
 ---
-
 
 ### CanPerformVendorEdit
 
-
 **Description:**
-
 
 Determines if a player can modify a vendor's settings.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting the edit.
 
@@ -4757,18 +3810,15 @@ Determines if a player can modify a vendor's settings.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to disallow editing.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allow only admins to edit vendors.
@@ -4777,21 +3827,15 @@ hook.Add("CanPerformVendorEdit", "AdminVendorEdit", function(client)
 end)
 ```
 
-
 ---
-
 
 ### CanPickupMoney
 
-
 **Description:**
-
 
 Called when a player attempts to pick up a money entity.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to pick up the money.
 
@@ -4801,18 +3845,15 @@ Called when a player attempts to pick up a money entity.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to disallow pickup.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent money pickup while handcuffed.
@@ -4823,21 +3864,15 @@ hook.Add("CanPickupMoney", "BlockWhileCuffed", function(client)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerAccessDoor
 
-
 **Description:**
-
 
 Determines if a player can open or lock a door entity.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting access.
 
@@ -4850,18 +3885,15 @@ Determines if a player can open or lock a door entity.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to deny access.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Only police can unlock jail cells.
@@ -4872,21 +3904,15 @@ hook.Add("CanPlayerAccessDoor", "PoliceDoors", function(client, door, access)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerAccessVendor
 
-
 **Description:**
-
 
 Checks if a player is permitted to open a vendor menu.
 
-
 **Parameters:**
-
 
 * client (Player) – Player requesting access.
 
@@ -4896,18 +3922,15 @@ Checks if a player is permitted to open a vendor menu.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to deny access.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Block access unless the vendor allows the player's faction.
@@ -4918,21 +3941,15 @@ hook.Add("CanPlayerAccessVendor", "CheckVendorFaction", function(client, vendor)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerHoldObject
 
-
 **Description:**
-
 
 Determines if the player can pick up an entity with the hands swep.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to hold the entity.
 
@@ -4942,18 +3959,15 @@ Determines if the player can pick up an entity with the hands swep.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to prevent holding.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent grabbing heavy physics objects.
@@ -4964,21 +3978,15 @@ hook.Add("CanPlayerHoldObject", "WeightLimit", function(client, ent)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerInteractItem
 
-
 **Description:**
-
 
 Called when a player tries to use or drop an item.
 
-
 **Parameters:**
-
 
 * client (Player) – Player interacting with the item.
 
@@ -4991,18 +3999,15 @@ Called when a player tries to use or drop an item.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to block the action.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Block medkit use inside safe zones.
@@ -5013,21 +4018,15 @@ hook.Add("CanPlayerInteractItem", "SafeZoneBlock", function(client, action, item
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerKnock
 
-
 **Description:**
-
 
 Called when a player attempts to knock on a door.
 
-
 **Parameters:**
-
 
 * client (Player) – Player knocking.
 
@@ -5037,18 +4036,15 @@ Called when a player attempts to knock on a door.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to block knocking.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent knocking while disguised.
@@ -5059,21 +4055,15 @@ hook.Add("CanPlayerKnock", "BlockDisguisedKnock", function(client, door)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerSpawnStorage
 
-
 **Description:**
-
 
 Checks if the player is allowed to spawn a storage container.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to spawn.
 
@@ -5086,18 +4076,15 @@ Checks if the player is allowed to spawn a storage container.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to deny spawning.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Limit players to one storage crate.
@@ -5108,39 +4095,30 @@ hook.Add("CanPlayerSpawnStorage", "LimitStorage", function(client, ent, data)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerThrowPunch
 
-
 **Description:**
-
 
 Called when the fists weapon tries to punch.
 
-
 **Parameters:**
-
 
 * client (Player) – Player performing the punch.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False to block punching.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent punching while restrained.
@@ -5151,21 +4129,15 @@ hook.Add("CanPlayerThrowPunch", "NoPunchWhenTied", function(client)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerTradeWithVendor
 
-
 **Description:**
-
 
 Checks whether a vendor trade is allowed.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting the trade.
 
@@ -5181,18 +4153,15 @@ Checks whether a vendor trade is allowed.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean, string – False and reason to deny trade
 
 
 **Example Usage:**
-
 
 ```lua
 -- Block selling stolen goods.
@@ -5203,39 +4172,30 @@ hook.Add("CanPlayerTradeWithVendor", "DisallowStolenItems", function(client, ven
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerViewInventory
 
-
 **Description:**
-
 
 Called before any inventory menu is shown.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – False to prevent opening
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent opening inventory while in a cutscene.
@@ -5244,21 +4204,15 @@ hook.Add("CanPlayerViewInventory", "BlockDuringCutscene", function()
 end)
 ```
 
-
 ---
-
 
 ### CanSaveData
 
-
 **Description:**
-
 
 Called before persistent storage saves.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Storage entity being saved.
 
@@ -5268,18 +4222,15 @@ Called before persistent storage saves.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to cancel saving
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disable saving during special events.
@@ -5290,21 +4241,15 @@ hook.Add("CanSaveData", "NoEventSaves", function(entity, inv)
 end)
 ```
 
-
 ---
-
 
 ### CharHasFlags
 
-
 **Description:**
-
 
 Allows custom checks for a character's permission flags.
 
-
 **Parameters:**
-
 
 * character (Character) – Character to check.
 
@@ -5314,18 +4259,15 @@ Allows custom checks for a character's permission flags.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grant extra access for characters owned by admins.
@@ -5337,39 +4279,30 @@ hook.Add("CharHasFlags", "AdminExtraFlags", function(char, flags)
 end)
 ```
 
-
 ---
-
 
 ### CharPostSave
 
-
 **Description:**
-
 
 Runs after a character's data has been saved to the database.
 
-
 **Parameters:**
-
 
 * character (Character) – Character that finished saving.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log every time characters save data.
@@ -5378,39 +4311,30 @@ hook.Add("CharPostSave", "LogCharSaves", function(char)
 end)
 ```
 
-
 ---
-
 
 ### DatabaseConnected
 
-
 **Description:**
-
 
 Fired after the database has been successfully connected.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prepare custom tables once the DB connects.
@@ -5419,21 +4343,15 @@ hook.Add("DatabaseConnected", "CreateCustomTables", function()
 end)
 ```
 
-
 ---
-
 
 ### DrawItemDescription
 
-
 **Description:**
-
 
 Called when an item entity draws its description text.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Item entity being drawn.
 
@@ -5452,18 +4370,15 @@ Called when an item entity draws its description text.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Display remaining uses next to item name.
@@ -5472,39 +4387,30 @@ hook.Add("DrawItemDescription", "AddUseCount", function(item, x, y, color, alpha
 end)
 ```
 
-
 ---
-
 
 ### GetDefaultInventorySize
 
-
 **Description:**
-
 
 Returns the default width and height for new inventories.
 
-
 **Parameters:**
-
 
 * client (Player) – Player the inventory belongs to.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * number, number – Width and height
 
 
 **Example Usage:**
-
 
 ```lua
 -- Expand default bags for admins.
@@ -5515,39 +4421,30 @@ hook.Add("GetDefaultInventorySize", "AdminBags", function(client)
 end)
 ```
 
-
 ---
-
 
 ### GetMoneyModel
 
-
 **Description:**
-
 
 Allows overriding the entity model used for dropped money.
 
-
 **Parameters:**
-
 
 * amount (number) – Money amount being dropped.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Model path to use
 
 
 **Example Usage:**
-
 
 ```lua
 -- Use a golden model for large sums.
@@ -5558,21 +4455,15 @@ hook.Add("GetMoneyModel", "GoldMoneyModel", function(amount)
 end)
 ```
 
-
 ---
-
 
 ### GetPlayerPunchDamage
 
-
 **Description:**
-
 
 Lets addons modify how much damage the fists weapon deals.
 
-
 **Parameters:**
-
 
 * client (Player) – Punching player.
 
@@ -5585,18 +4476,15 @@ Lets addons modify how much damage the fists weapon deals.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Scale punch damage by strength attribute.
@@ -5605,21 +4493,15 @@ hook.Add("GetPlayerPunchDamage", "StrengthPunch", function(client, dmg, context)
 end)
 ```
 
-
 ---
-
 
 ### InterceptClickItemIcon
 
-
 **Description:**
-
 
 Allows overriding default clicks on inventory icons.
 
-
 **Parameters:**
-
 
 * self (Panel) – Inventory panel.
 
@@ -5632,18 +4514,15 @@ Allows overriding default clicks on inventory icons.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Shift-click to quickly move items.
@@ -5654,21 +4533,15 @@ hook.Add("InterceptClickItemIcon", "ShiftQuickMove", function(panel, icon, key)
 end)
 ```
 
-
 ---
-
 
 ### ItemCombine
 
-
 **Description:**
-
 
 Called when the system attempts to combine one item with another in an inventory.
 
-
 **Parameters:**
-
 
 * client (Player) – Owning player.
 
@@ -5681,18 +4554,15 @@ Called when the system attempts to combine one item with another in an inventory
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – true if combination succeeds and items are consumed, false otherwise.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Combine two ammo boxes into one stack.
@@ -5705,21 +4575,15 @@ hook.Add("ItemCombine", "StackAmmo", function(client, base, other)
 end)
 ```
 
-
 ---
-
 
 ### ItemDraggedOutOfInventory
 
-
 **Description:**
-
 
 Called when an item icon is dragged completely out of an inventory.
 
-
 **Parameters:**
-
 
 * client (Player) – Player dragging the item.
 
@@ -5729,18 +4593,15 @@ Called when an item icon is dragged completely out of an inventory.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Drop the item into the world when removed.
@@ -5749,21 +4610,15 @@ hook.Add("ItemDraggedOutOfInventory", "DropOnDragOut", function(_, item)
 end)
 ```
 
-
 ---
-
 
 ### ItemFunctionCalled
 
-
 **Description:**
-
 
 Triggered whenever an item function is executed by a player.
 
-
 **Parameters:**
-
 
 * item (Item) – Item on which the function ran.
 
@@ -5782,18 +4637,15 @@ Triggered whenever an item function is executed by a player.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log item function usage for analytics.
@@ -5802,39 +4654,30 @@ hook.Add("ItemFunctionCalled", "TrackItemUse", function(item, action, client, en
 end)
 ```
 
-
 ---
-
 
 ### ItemTransfered
 
-
 **Description:**
-
 
 Runs after an item successfully moves between inventories.
 
-
 **Parameters:**
-
 
 * context (table) – Transfer context table containing client, item, from and to inventories.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notify the player about the transfer result.
@@ -5843,21 +4686,15 @@ hook.Add("ItemTransfered", "NotifyTransfer", function(context)
 end)
 ```
 
-
 ---
-
 
 ### OnCharFallover
 
-
 **Description:**
-
 
 Called when a character ragdolls or is forced to fall over.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being ragdolled.
 
@@ -5870,18 +4707,15 @@ Called when a character ragdolls or is forced to fall over.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Apply a stun effect when knocked down.
@@ -5892,21 +4726,15 @@ hook.Add("OnCharFallover", "ApplyStun", function(client, _, forced)
 end)
 ```
 
-
 ---
-
 
 ### OnCharKick
 
-
 **Description:**
-
 
 Called when a character is kicked from the server.
 
-
 **Parameters:**
-
 
 * character (Character) – Character that was kicked.
 
@@ -5916,18 +4744,15 @@ Called when a character is kicked from the server.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Record the kick reason.
@@ -5936,21 +4761,15 @@ hook.Add("OnCharKick", "LogKickReason", function(char, client)
 end)
 ```
 
-
 ---
-
 
 ### OnCharPermakilled
 
-
 **Description:**
-
 
 Called when a character is permanently killed.
 
-
 **Parameters:**
-
 
 * character (Character) – Character being permanently killed.
 
@@ -5960,18 +4779,15 @@ Called when a character is permanently killed.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Announce permadeath in chat.
@@ -5980,39 +4796,30 @@ hook.Add("OnCharPermakilled", "AnnouncePK", function(char, time)
 end)
 ```
 
-
 ---
-
 
 ### OnCharRecognized
 
-
 **Description:**
-
 
 Called clientside when your character recognizes another.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that initiated recognition.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a sound whenever someone becomes recognized.
@@ -6021,21 +4828,15 @@ hook.Add("OnCharRecognized", "PlayRecognizeSound", function(client)
 end)
 ```
 
-
 ---
-
 
 ### OnCharTradeVendor
 
-
 **Description:**
-
 
 Called after a character buys from or sells to a vendor.
 
-
 **Parameters:**
-
 
 * client (Player) – Player completing the trade.
 
@@ -6060,18 +4861,15 @@ Called after a character buys from or sells to a vendor.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log vendor transactions to the console.
@@ -6080,21 +4878,15 @@ hook.Add("OnCharTradeVendor", "LogVendorTrade", function(client, vendor, item, s
 end)
 ```
 
-
 ---
-
 
 ### OnCreatePlayerRagdoll
 
-
 **Description:**
-
 
 Called when a ragdoll entity is created for a player.
 
-
 **Parameters:**
-
 
 * client (Player) – The player the ragdoll belongs to.
 
@@ -6107,18 +4899,15 @@ Called when a ragdoll entity is created for a player.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Tint death ragdolls red.
@@ -6129,21 +4918,15 @@ hook.Add("OnCreatePlayerRagdoll", "RedRagdoll", function(client, ent, dead)
 end)
 ```
 
-
 ---
-
 
 ### OnCreateStoragePanel
 
-
 **Description:**
-
 
 Called when both the player's inventory and storage panels are created.
 
-
 **Parameters:**
-
 
 * localPanel (Panel) – The player's inventory panel.
 
@@ -6156,18 +4939,15 @@ Called when both the player's inventory and storage panels are created.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Add a custom tab to storage windows.
@@ -6178,21 +4958,15 @@ hook.Add("OnCreateStoragePanel", "AddSortTab", function(localPanel, storagePanel
 end)
 ```
 
-
 ---
-
 
 ### OnItemAdded
 
-
 **Description:**
-
 
 Called when a new item instance is placed into an inventory.
 
-
 **Parameters:**
-
 
 * client (Player|nil) – Owner of the inventory the item was added to.
 
@@ -6202,18 +4976,15 @@ Called when a new item instance is placed into an inventory.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a sound when ammo is picked up.
@@ -6224,21 +4995,15 @@ hook.Add("OnItemAdded", "AmmoPickupSound", function(ply, item)
 end)
 ```
 
-
 ---
-
 
 ### OnItemCreated
 
-
 **Description:**
-
 
 Called when a new item instance table is initialized.
 
-
 **Parameters:**
-
 
 * itemTable (table) – Item definition table.
 
@@ -6248,18 +5013,15 @@ Called when a new item instance table is initialized.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Set custom data on freshly made items.
@@ -6268,39 +5030,30 @@ hook.Add("OnItemCreated", "InitCustomData", function(item)
 end)
 ```
 
-
 ---
-
 
 ### OnItemSpawned
 
-
 **Description:**
-
 
 Called when an item entity has been spawned in the world.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Spawned item entity.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a sound when rare items appear.
@@ -6311,21 +5064,15 @@ hook.Add("OnItemSpawned", "RareSpawnSound", function(itemEnt)
 end)
 ```
 
-
 ---
-
 
 ### OnOpenVendorMenu
 
-
 **Description:**
-
 
 Called when the vendor dialog panel is opened.
 
-
 **Parameters:**
-
 
 * panel (Panel) – The vendor menu panel.
 
@@ -6335,18 +5082,15 @@ Called when the vendor dialog panel is opened.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Automatically switch to the buy tab.
@@ -6355,21 +5099,15 @@ hook.Add("OnOpenVendorMenu", "DefaultBuyTab", function(panel, vendor)
 end)
 ```
 
-
 ---
-
 
 ### OnPickupMoney
 
-
 **Description:**
-
 
 Called after a player picks up a money entity.
 
-
 **Parameters:**
-
 
 * client (Player) – The player picking up the money.
 
@@ -6379,18 +5117,15 @@ Called after a player picks up a money entity.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reward an achievement for looting money.
@@ -6399,21 +5134,15 @@ hook.Add("OnPickupMoney", "MoneyAchievement", function(client, ent)
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerEnterSequence
 
-
 **Description:**
-
 
 Fired when a scripted animation sequence begins.
 
-
 **Parameters:**
-
 
 * client (Player) – Player starting the sequence.
 
@@ -6432,18 +5161,15 @@ Fired when a scripted animation sequence begins.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Freeze the player during the sequence.
@@ -6454,21 +5180,15 @@ hook.Add("OnPlayerEnterSequence", "FreezeDuringSeq", function(client, seq, callb
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerInteractItem
 
-
 **Description:**
-
 
 Runs after a player has interacted with an item.
 
-
 **Parameters:**
-
 
 * client (Player) – Player performing the interaction.
 
@@ -6487,18 +5207,15 @@ Runs after a player has interacted with an item.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Send analytics for item usage.
@@ -6507,21 +5224,15 @@ hook.Add("OnPlayerInteractItem", "Analytics", function(client, action, item, res
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerJoinClass
 
-
 **Description:**
-
 
 Called when a player changes to a new class.
 
-
 **Parameters:**
-
 
 * client (Player) – The player switching classes.
 
@@ -6534,18 +5245,15 @@ Called when a player changes to a new class.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Give class specific weapons.
@@ -6556,39 +5264,30 @@ hook.Add("OnPlayerJoinClass", "ClassWeapons", function(client, class, oldClass)
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerLeaveSequence
 
-
 **Description:**
-
 
 Fired when a scripted animation sequence ends for a player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that finished the sequence.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unfreeze the player after the sequence.
@@ -6597,39 +5296,30 @@ hook.Add("OnPlayerLeaveSequence", "UnfreezeAfterSeq", function(client)
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerLostStackItem
 
-
 **Description:**
-
 
 Called if a stackable item is removed unexpectedly.
 
-
 **Parameters:**
-
 
 * item (Item) – The item that disappeared.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Warn players when their ammo stack disappears.
@@ -6640,21 +5330,15 @@ hook.Add("OnPlayerLostStackItem", "WarnLostAmmo", function(item)
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerSwitchClass
 
-
 **Description:**
-
 
 Occurs right before a player's class changes.
 
-
 **Parameters:**
-
 
 * client (Player) – Player who is switching.
 
@@ -6667,18 +5351,15 @@ Occurs right before a player's class changes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent switching while in combat.
@@ -6689,21 +5370,15 @@ hook.Add("OnPlayerSwitchClass", "NoCombatSwap", function(client, class, oldClass
 end)
 ```
 
-
 ---
-
 
 ### OnRequestItemTransfer
 
-
 **Description:**
-
 
 Called when the UI asks to move an item between inventories.
 
-
 **Parameters:**
-
 
 * panel (Panel) – Inventory panel requesting the move.
 
@@ -6722,18 +5397,15 @@ Called when the UI asks to move an item between inventories.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Validate transfers before sending to the server.
@@ -6742,39 +5414,30 @@ hook.Add("OnRequestItemTransfer", "ValidateTransfer", function(panel, itemID, in
 end)
 ```
 
-
 ---
-
 
 ### PersistenceLoad
 
-
 **Description:**
-
 
 Called when map persistence data is loaded.
 
-
 **Parameters:**
-
 
 * name (string) – Name of the persistence file.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Verify entities when the map reloads.
@@ -6783,21 +5446,15 @@ hook.Add("PersistenceLoad", "CheckPersistent", function(name)
 end)
 ```
 
-
 ---
-
 
 ### PlayerAccessVendor
 
-
 **Description:**
-
 
 Occurs when a player successfully opens a vendor.
 
-
 **Parameters:**
-
 
 * client (Player) – Player accessing the vendor.
 
@@ -6807,18 +5464,15 @@ Occurs when a player successfully opens a vendor.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Track how often players browse vendors.
@@ -6827,39 +5481,30 @@ hook.Add("PlayerAccessVendor", "VendorAnalytics", function(client, vendor)
 end)
 ```
 
-
 ---
-
 
 ### PlayerStaminaGained
 
-
 **Description:**
-
 
 Called when a player regenerates stamina points.
 
-
 **Parameters:**
-
 
 * client (Player) – Player gaining stamina.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the player's stamina amount whenever it increases.
@@ -6870,39 +5515,30 @@ hook.Add("PlayerStaminaGained", "PrintStaminaGain", function(client)
 end)
 ```
 
-
 ---
-
 
 ### PlayerStaminaLost
 
-
 **Description:**
-
 
 Called when a player's stamina decreases.
 
-
 **Parameters:**
-
 
 * client (Player) – Player losing stamina.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a sound when the player runs out of stamina.
@@ -6913,21 +5549,15 @@ hook.Add("PlayerStaminaLost", "TiredSound", function(client)
 end)
 ```
 
-
 ---
-
 
 ### PlayerThrowPunch
 
-
 **Description:**
-
 
 Fires when a player lands a punch with the fists weapon.
 
-
 **Parameters:**
-
 
 * client (Player) – Punching player.
 
@@ -6937,18 +5567,15 @@ Fires when a player lands a punch with the fists weapon.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a custom sound on punch.
@@ -6957,21 +5584,15 @@ hook.Add("PlayerThrowPunch", "PunchSound", function(client, trace)
 end)
 ```
 
-
 ---
-
 
 ### PostDrawInventory
 
-
 **Description:**
-
 
 Called each frame after the inventory panel draws.
 
-
 **Parameters:**
-
 
 * panel (Panel) – The inventory panel being drawn.
 
@@ -6981,18 +5602,15 @@ Called each frame after the inventory panel draws.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Draw a watermark over the inventory.
@@ -7001,21 +5619,15 @@ hook.Add("PostDrawInventory", "InventoryWatermark", function(panel)
 end)
 ```
 
-
 ---
-
 
 ### PrePlayerInteractItem
 
-
 **Description:**
-
 
 Called just before a player interacts with an item.
 
-
 **Parameters:**
-
 
 * client (Player) – Player performing the action.
 
@@ -7028,18 +5640,15 @@ Called just before a player interacts with an item.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Deny using keys on locked chests.
@@ -7050,39 +5659,30 @@ hook.Add("PrePlayerInteractItem", "BlockChestKeys", function(client, action, ite
 end)
 ```
 
-
 ---
-
 
 ### SetupBagInventoryAccessRules
 
-
 **Description:**
-
 
 Allows modules to define who can access a bag inventory.
 
-
 **Parameters:**
-
 
 * inventory (Inventory) – Bag inventory object.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Only the bag owner may open it.
@@ -7091,39 +5691,30 @@ hook.Add("SetupBagInventoryAccessRules", "OwnerOnlyBags", function(inv)
 end)
 ```
 
-
 ---
-
 
 ### SetupDatabase
 
-
 **Description:**
-
 
 Runs before the gamemode initializes its database connection.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Register additional tables.
@@ -7132,21 +5723,15 @@ hook.Add("SetupDatabase", "AddExtraTables", function()
 end)
 ```
 
-
 ---
-
 
 ### StorageCanTransferItem
 
-
 **Description:**
-
 
 Determines if an item can move in or out of a storage entity.
 
-
 **Parameters:**
-
 
 * client (Player) – Player moving the item.
 
@@ -7159,18 +5744,15 @@ Determines if an item can move in or out of a storage entity.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – False to disallow transfer
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent weapons from being stored in car trunks.
@@ -7181,21 +5763,15 @@ hook.Add("StorageCanTransferItem", "NoWeaponsInCars", function(client, storage, 
 end)
 ```
 
-
 ---
-
 
 ### StorageEntityRemoved
 
-
 **Description:**
-
 
 Fired when a storage entity is removed from the world.
 
-
 **Parameters:**
-
 
 * entity (Entity) – The storage entity being removed.
 
@@ -7205,18 +5781,15 @@ Fired when a storage entity is removed from the world.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Drop items when a crate is destroyed.
@@ -7225,21 +5798,15 @@ hook.Add("StorageEntityRemoved", "DropContents", function(entity, inv)
 end)
 ```
 
-
 ---
-
 
 ### StorageInventorySet
 
-
 **Description:**
-
 
 Called when a storage entity is assigned an inventory.
 
-
 **Parameters:**
-
 
 * entity (Entity) – The storage entity.
 
@@ -7252,18 +5819,15 @@ Called when a storage entity is assigned an inventory.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Send a notification when storage is initialized.
@@ -7274,21 +5838,15 @@ hook.Add("StorageInventorySet", "NotifyStorage", function(entity, inv, isCar)
 end)
 ```
 
-
 ---
-
 
 ### StorageOpen
 
-
 **Description:**
-
 
 Called clientside when a storage menu is opened.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Storage entity opened.
 
@@ -7298,18 +5856,15 @@ Called clientside when a storage menu is opened.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Display storage name in the chat.
@@ -7318,21 +5873,15 @@ hook.Add("StorageOpen", "AnnounceStorage", function(entity, isCar)
 end)
 ```
 
-
 ---
-
 
 ### StorageRestored
 
-
 **Description:**
-
 
 Called when a storage's contents are loaded from disk.
 
-
 **Parameters:**
-
 
 * storage (Entity) – Storage entity.
 
@@ -7342,18 +5891,15 @@ Called when a storage's contents are loaded from disk.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log how many items were restored.
@@ -7362,39 +5908,30 @@ hook.Add("StorageRestored", "PrintRestore", function(storage, inv)
 end)
 ```
 
-
 ---
-
 
 ### StorageUnlockPrompt
 
-
 **Description:**
-
 
 Called clientside when you must enter a storage password.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Storage entity being opened.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Auto-fill a remembered password.
@@ -7403,39 +5940,30 @@ hook.Add("StorageUnlockPrompt", "AutoFill", function(entity)
 end)
 ```
 
-
 ---
-
 
 ### VendorClassUpdated
 
-
 **Description:**
-
 
 Called when a vendor's allowed classes are updated.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- React to class access changes.
@@ -7444,39 +5972,30 @@ hook.Add("VendorClassUpdated", "LogVendorClassChange", function(vendor, id, allo
 end)
 ```
 
-
 ---
-
 
 ### VendorEdited
 
-
 **Description:**
-
 
 Called after a delay when a vendor's data is edited.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log which key changed.
@@ -7485,39 +6004,30 @@ hook.Add("VendorEdited", "PrintVendorEdit", function(vendor, key)
 end)
 ```
 
-
 ---
-
 
 ### VendorExited
 
-
 **Description:**
-
 
 Called when a player exits from interacting with a vendor.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notify the player when they leave a vendor.
@@ -7526,39 +6036,30 @@ hook.Add("VendorExited", "PrintVendorExit", function()
 end)
 ```
 
-
 ---
-
 
 ### VendorFactionUpdated
 
-
 **Description:**
-
 
 Called when a vendor's allowed factions are updated.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print updated faction permissions.
@@ -7567,39 +6068,30 @@ hook.Add("VendorFactionUpdated", "LogVendorFactionUpdate", function(vendor, id, 
 end)
 ```
 
-
 ---
-
 
 ### VendorItemMaxStockUpdated
 
-
 **Description:**
-
 
 Called when a vendor's item max stock value changes.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log stock limit changes.
@@ -7608,39 +6100,30 @@ hook.Add("VendorItemMaxStockUpdated", "LogVendorStockLimits", function(vendor, i
 end)
 ```
 
-
 ---
-
 
 ### VendorItemModeUpdated
 
-
 **Description:**
-
 
 Called when a vendor's item mode is changed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the new mode value.
@@ -7649,39 +6132,30 @@ hook.Add("VendorItemModeUpdated", "PrintVendorMode", function(vendor, itemType, 
 end)
 ```
 
-
 ---
-
 
 ### VendorItemPriceUpdated
 
-
 **Description:**
-
 
 Called when a vendor's item price is changed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the new item price.
@@ -7690,39 +6164,30 @@ hook.Add("VendorItemPriceUpdated", "LogVendorItemPrice", function(vendor, itemTy
 end)
 ```
 
-
 ---
-
 
 ### VendorItemStockUpdated
 
-
 **Description:**
-
 
 Called when a vendor's item stock value changes.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log remaining stock for the item.
@@ -7731,39 +6196,30 @@ hook.Add("VendorItemStockUpdated", "LogVendorItemStock", function(vendor, itemTy
 end)
 ```
 
-
 ---
-
 
 ### VendorMoneyUpdated
 
-
 **Description:**
-
 
 Called when a vendor's available money changes.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the vendor's new money amount.
@@ -7772,39 +6228,30 @@ hook.Add("VendorMoneyUpdated", "LogVendorMoney", function(vendor, money, oldMone
 end)
 ```
 
-
 ---
-
 
 ### VendorOpened
 
-
 **Description:**
-
 
 Called when a vendor menu is opened on the client.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print which vendor was opened.
@@ -7813,39 +6260,30 @@ hook.Add("VendorOpened", "PrintVendorOpened", function(vendor)
 end)
 ```
 
-
 ---
-
 
 ### VendorSynchronized
 
-
 **Description:**
-
 
 Called when vendor synchronization data is received.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print a message when vendor data syncs.
@@ -7854,39 +6292,30 @@ hook.Add("VendorSynchronized", "LogVendorSync", function(vendor)
 end)
 ```
 
-
 ---
-
 
 ### VendorTradeEvent
 
-
 **Description:**
-
 
 Called when a player attempts to trade with a vendor.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log all vendor trades to the console.
@@ -7896,39 +6325,30 @@ hook.Add("VendorTradeEvent", "LogVendorTrades", function(client, entity, uniqueI
 end)
 ```
 
-
 ---
-
 
 ### getItemDropModel
 
-
 **Description:**
-
 
 Returns an alternate model path for a dropped item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * string|nil – Alternate model path or nil for default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Replace drop model for weapons.
@@ -7939,39 +6359,30 @@ hook.Add("getItemDropModel", "CustomDropModelForWeapons", function(itemTable, en
 end)
 ```
 
-
 ---
-
 
 ### getPriceOverride
 
-
 **Description:**
-
 
 Allows modules to override a vendor item's price dynamically.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * integer|nil – New price or nil for default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Increase price for rare items when buying from the vendor.
@@ -7986,39 +6397,30 @@ hook.Add("getPriceOverride", "DynamicPricing", function(vendor, uniqueID, price,
 end)
 ```
 
-
 ---
-
 
 ### isCharFakeRecognized
 
-
 **Description:**
-
 
 Checks if a character is fake recognized rather than truly known.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Flag suspicious characters as fake.
@@ -8029,39 +6431,30 @@ hook.Add("isCharFakeRecognized", "DetectFakeCharacters", function(character, id)
 end)
 ```
 
-
 ---
-
 
 ### isCharRecognized
 
-
 **Description:**
-
 
 Determines whether one character recognizes another.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Only recognize characters from the same faction.
@@ -8070,39 +6463,30 @@ hook.Add("isCharRecognized", "ValidateCharacterRecognition", function(character,
 end)
 ```
 
-
 ---
-
 
 ### isRecognizedChatType
 
-
 **Description:**
-
 
 Determines if a chat type counts toward recognition.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Mark admin chat as recognized to reveal player names.
@@ -8112,39 +6496,30 @@ hook.Add("isRecognizedChatType", "ValidateRecognitionChat", function(chatType)
 end)
 ```
 
-
 ---
-
 
 ### isSuitableForTrunk
 
-
 **Description:**
-
 
 Determines whether an entity can be used as trunk storage.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Only vehicles are valid trunk containers.
@@ -8153,21 +6528,15 @@ hook.Add("isSuitableForTrunk", "AllowOnlyCars", function(entity)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerEarnSalary
 
-
 **Description:**
-
 
 Determines if a player is allowed to earn salary.
 
-
 **Parameters:**
-
 
 * client (Player) – Player to check.
 
@@ -8180,18 +6549,15 @@ Determines if a player is allowed to earn salary.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerEarnSalary is triggered
@@ -8203,21 +6569,15 @@ hook.Add("CanPlayerEarnSalary", "RestrictSalaryToActivePlayers", function(client
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerJoinClass
 
-
 **Description:**
-
 
 Determines whether a player can join a certain class. Return `false` to block.
 
-
 **Parameters:**
-
 
 * client (Player) – Player requesting the class.
 
@@ -8230,18 +6590,15 @@ Determines whether a player can join a certain class. Return `false` to block.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean|nil: false to block, nil to allow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerJoinClass is triggered
@@ -8252,21 +6609,15 @@ hook.Add("CanPlayerJoinClass", "RestrictEliteClass", function(client, class, inf
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerUseCommand
 
-
 **Description:**
-
 
 Determines if a player can use a specific command. Return `false` to block usage.
 
-
 **Parameters:**
-
 
 * client (Player) – Player running the command.
 
@@ -8276,18 +6627,15 @@ Determines if a player can use a specific command. Return `false` to block usage
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean|nil: false to block, nil to allow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerUseCommand is triggered
@@ -8299,21 +6647,15 @@ hook.Add("CanPlayerUseCommand", "BlockSensitiveCommands", function(client, comma
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerUseDoor
 
-
 **Description:**
-
 
 Determines if a player is allowed to use a door entity, such as opening, locking, or unlocking. Return `false` to prevent the action.
 
-
 **Parameters:**
-
 
 * client (Player) – The player attempting to use the door.
 
@@ -8326,18 +6668,15 @@ Determines if a player is allowed to use a door entity, such as opening, locking
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean: false to block, nil or true to allow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerUseDoor is triggered
@@ -8349,39 +6688,30 @@ hook.Add("CanPlayerUseDoor", "AllowOnlyOwners", function(client, door, access)
 end)
 ```
 
-
 ---
-
 
 ### CharCleanUp
 
-
 **Description:**
-
 
 Used during character cleanup routines for additional steps when removing or transitioning a character.
 
-
 **Parameters:**
-
 
 * character (Character) – The character being cleaned up.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharCleanUp is triggered
@@ -8396,39 +6726,30 @@ hook.Add("CharCleanUp", "RemoveTemporaryItems", function(character)
 end)
 ```
 
-
 ---
-
 
 ### CharRestored
 
-
 **Description:**
-
 
 Called after a character has been restored from the database. Useful for post-restoration logic such as awarding default items or setting up data.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharRestored is triggered
@@ -8441,39 +6762,30 @@ hook.Add("CharRestored", "AwardWelcomePackage", function(character)
 end)
 ```
 
-
 ---
-
 
 ### CreateDefaultInventory
 
-
 **Description:**
-
 
 Called when creating a default inventory for a character. Should return a [deferred](https://github.com/Be1zebub/luassert-deferred) (or similar promise) object that resolves with the new inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CreateDefaultInventory is triggered
@@ -8492,21 +6804,15 @@ hook.Add("CreateDefaultInventory", "InitializeStarterInventory", function(charac
 end)
 ```
 
-
 ---
-
 
 ### CreateInventoryPanel
 
-
 **Description:**
-
 
 Client-side call when creating the graphical representation of an inventory.
 
-
 **Parameters:**
-
 
 * inventory (Inventory) – Inventory instance to draw.
 
@@ -8516,18 +6822,15 @@ Client-side call when creating the graphical representation of an inventory.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CreateInventoryPanel is triggered
@@ -8552,39 +6855,30 @@ hook.Add("CreateInventoryPanel", "CustomInventoryUI", function(inventory, parent
 end)
 ```
 
-
 ---
-
 
 ### CreateSalaryTimer
 
-
 **Description:**
-
 
 Creates a timer to manage player salary.
 
-
 **Parameters:**
-
 
 * client (Player) – Player receiving the salary timer.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CreateSalaryTimer is triggered
@@ -8601,21 +6895,15 @@ hook.Add("CreateSalaryTimer", "SetupSalaryTimer", function(client)
 end)
 ```
 
-
 ---
-
 
 ### DoModuleIncludes
 
-
 **Description:**
-
 
 Called when modules include submodules. Useful for advanced module handling or dependency management.
 
-
 **Parameters:**
-
 
 * path (string) – Directory path containing the submodule.
 
@@ -8625,18 +6913,15 @@ Called when modules include submodules. Useful for advanced module handling or d
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when DoModuleIncludes is triggered
@@ -8647,21 +6932,15 @@ hook.Add("DoModuleIncludes", "TrackModuleDependencies", function(path, module)
 end)
 ```
 
-
 ---
-
 
 ### GetDefaultCharDesc
 
-
 **Description:**
-
 
 Retrieves a default description for a character during creation. Return `(defaultDesc, overrideBool)`.
 
-
 **Parameters:**
-
 
 * client (Player) – Player creating the character.
 
@@ -8671,12 +6950,10 @@ Retrieves a default description for a character during creation. Return `(defaul
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * string: The default description.
 
@@ -8685,7 +6962,6 @@ Retrieves a default description for a character during creation. Return `(defaul
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetDefaultCharDesc is triggered
@@ -8696,21 +6972,15 @@ hook.Add("GetDefaultCharDesc", "CitizenDefaultDesc", function(client, faction)
 end)
 ```
 
-
 ---
-
 
 ### GetDefaultCharName
 
-
 **Description:**
-
 
 Retrieves a default name for a character during creation. Return `(defaultName, overrideBool)`.
 
-
 **Parameters:**
-
 
 * client (Player) – Player creating the character.
 
@@ -8723,12 +6993,10 @@ Retrieves a default name for a character during creation. Return `(defaultName, 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * string: The default name.
 
@@ -8737,7 +7005,6 @@ Retrieves a default name for a character during creation. Return `(defaultName, 
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetDefaultCharName is triggered
@@ -8748,21 +7015,15 @@ hook.Add("GetDefaultCharName", "PoliceDefaultName", function(client, faction, da
 end)
 ```
 
-
 ---
-
 
 ### GetSalaryAmount
 
-
 **Description:**
-
 
 Retrieves the amount of salary a player should receive.
 
-
 **Parameters:**
-
 
 * client (Player) – Player receiving salary.
 
@@ -8775,18 +7036,15 @@ Retrieves the amount of salary a player should receive.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any: The salary amount
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetSalaryAmount is triggered
@@ -8797,21 +7055,15 @@ hook.Add("GetSalaryAmount", "CalculateDynamicSalary", function(client, faction, 
 end)
 ```
 
-
 ---
-
 
 ### GetSalaryLimit
 
-
 **Description:**
-
 
 Retrieves the salary limit for a player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being checked.
 
@@ -8824,18 +7076,15 @@ Retrieves the salary limit for a player.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any: The salary limit
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetSalaryLimit is triggered
@@ -8848,39 +7097,30 @@ hook.Add("GetSalaryLimit", "SetSalaryLimitsBasedOnRole", function(client, factio
 end)
 ```
 
-
 ---
-
 
 ### InitializedConfig
 
-
 **Description:**
-
 
 Called when `lia.config` is fully initialized.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when this hook is triggered
@@ -8894,39 +7134,30 @@ function MODULE:InitializedConfig()
 end
 ```
 
-
 ---
-
 
 ### InitializedItems
 
-
 **Description:**
-
 
 Called once all item modules have been loaded from a directory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InitializedItems is triggered
@@ -8944,39 +7175,30 @@ hook.Add("InitializedItems", "SetupSpecialItems", function()
 end)
 ```
 
-
 ---
-
 
 ### InitializedModules
 
-
 **Description:**
-
 
 Called after all modules are fully initialized.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InitializedModules is triggered
@@ -8986,39 +7208,30 @@ hook.Add("InitializedModules", "FinalizeModuleSetup", function()
 end)
 ```
 
-
 ---
-
 
 ### InitializedOptions
 
-
 **Description:**
-
 
 Called when `lia.option` is fully initialized.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when this hook is triggered
@@ -9027,39 +7240,30 @@ function MODULE:InitializedOptions()
 end
 ```
 
-
 ---
-
 
 ### InitializedSchema
 
-
 **Description:**
-
 
 Called after the schema has finished initializing.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InitializedSchema is triggered
@@ -9069,21 +7273,15 @@ hook.Add("InitializedSchema", "SchemaReadyNotification", function()
 end)
 ```
 
-
 ---
-
 
 ### KeyLock
 
-
 **Description:**
-
 
 Called when a player attempts to lock a door.
 
-
 **Parameters:**
-
 
 * owner (Player) – Player locking the door.
 
@@ -9096,18 +7294,15 @@ Called when a player attempts to lock a door.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when KeyLock is triggered
@@ -9121,21 +7316,15 @@ hook.Add("KeyLock", "LogDoorLock", function(owner, entity, time)
 end)
 ```
 
-
 ---
-
 
 ### KeyUnlock
 
-
 **Description:**
-
 
 Called when a player attempts to unlock a door.
 
-
 **Parameters:**
-
 
 * owner (Player) – Player unlocking the door.
 
@@ -9148,18 +7337,15 @@ Called when a player attempts to unlock a door.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when KeyUnlock is triggered
@@ -9173,39 +7359,30 @@ hook.Add("KeyUnlock", "LogDoorUnlock", function(owner, entity, time)
 end)
 ```
 
-
 ---
-
 
 ### LiliaTablesLoaded
 
-
 **Description:**
-
 
 Called after all essential DB tables have been loaded.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when LiliaTablesLoaded is triggered
@@ -9216,39 +7393,30 @@ hook.Add("LiliaTablesLoaded", "InitializeGameState", function()
 end)
 ```
 
-
 ---
-
 
 ### OnItemRegistered
 
-
 **Description:**
-
 
 Called after an item has been registered. Useful for customizing item behavior or adding properties.
 
-
 **Parameters:**
-
 
 * item (Item) – Item definition being registered.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnItemRegistered is triggered
@@ -9267,39 +7435,30 @@ hook.Add("OnItemRegistered", "AddItemDurability", function(item)
 end)
 ```
 
-
 ---
-
 
 ### OnLoadTables
 
-
 **Description:**
-
 
 Called before the faction tables are loaded. Good spot for data setup prior to factions being processed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnLoadTables is triggered
@@ -9310,39 +7469,30 @@ hook.Add("OnLoadTables", "SetupFactionDefaults", function()
 end)
 ```
 
-
 ---
-
 
 ### OnMySQLOOConnected
 
-
 **Description:**
-
 
 Called when MySQLOO successfully connects to the database. Use to register prepared statements or init DB logic.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnMySQLOOConnected is triggered
@@ -9361,21 +7511,15 @@ hook.Add("OnMySQLOOConnected", "PrepareDatabaseStatements", function()
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerPurchaseDoor
 
-
 **Description:**
-
 
 Called when a player purchases or sells a door.
 
-
 **Parameters:**
-
 
 * client (Player) – Player buying or selling the door.
 
@@ -9391,18 +7535,15 @@ Called when a player purchases or sells a door.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnPlayerPurchaseDoor is triggered
@@ -9420,21 +7561,15 @@ hook.Add("OnPlayerPurchaseDoor", "HandleDoorPurchase", function(client, entity, 
 end)
 ```
 
-
 ---
-
 
 ### OnServerLog
 
-
 **Description:**
-
 
 Called whenever a new log message is added. Allows for custom logic or modifications to log handling.
 
-
 **Parameters:**
-
 
 * client (Player) – Player associated with the log or nil.
 
@@ -9453,18 +7588,15 @@ Called whenever a new log message is added. Allows for custom logic or modificat
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnServerLog is triggered
@@ -9479,39 +7611,30 @@ hook.Add("OnServerLog", "AlertAdminsOnHighSeverity", function(client, logType, l
 end)
 ```
 
-
 ---
-
 
 ### OnWipeTables
 
-
 **Description:**
-
 
 Called after wiping tables in the DB, typically after major resets/cleanups.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnWipeTables is triggered
@@ -9522,21 +7645,15 @@ hook.Add("OnWipeTables", "ReinitializeDefaults", function()
 end)
 ```
 
-
 ---
-
 
 ### PlayerMessageSend
 
-
 **Description:**
-
 
 Called before a chat message is sent. Return `false` to cancel, or modify the message if returning a string.
 
-
 **Parameters:**
-
 
 * speaker (Player) – Player sending the message.
 
@@ -9552,18 +7669,15 @@ Called before a chat message is sent. Return `false` to cancel, or modify the me
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean|nil|modifiedString: false to cancel, or return a modified string to change the message.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PlayerMessageSend is triggered
@@ -9575,21 +7689,15 @@ hook.Add("PlayerMessageSend", "FilterProfanity", function(speaker, chatType, mes
 end)
 ```
 
-
 ---
-
 
 ### PlayerModelChanged
 
-
 **Description:**
-
 
 Called when a player's model changes.
 
-
 **Parameters:**
-
 
 * client (Player) – The player whose model changed.
 
@@ -9599,18 +7707,15 @@ Called when a player's model changes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PlayerModelChanged is triggered
@@ -9621,21 +7726,15 @@ hook.Add("PlayerModelChanged", "UpdatePlayerAppearance", function(client, model)
 end)
 ```
 
-
 ---
-
 
 ### PlayerUseDoor
 
-
 **Description:**
-
 
 Called when a player attempts to use a door entity.
 
-
 **Parameters:**
-
 
 * client (Player) – Player using the door.
 
@@ -9645,18 +7744,15 @@ Called when a player attempts to use a door entity.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil: false to disallow, true to allow, or nil to let other hooks decide.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PlayerUseDoor is triggered
@@ -9669,39 +7765,30 @@ hook.Add("PlayerUseDoor", "LogDoorUsage", function(client, entity)
 end)
 ```
 
-
 ---
-
 
 ### RegisterPreparedStatements
 
-
 **Description:**
-
 
 Called for registering DB prepared statements post-MySQLOO connection.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Set up a prepared SQL statement for later use.
@@ -9710,39 +7797,30 @@ hook.Add("RegisterPreparedStatements", "InitLogStatement", function()
 end)
 ```
 
-
 ---
-
 
 ### ShouldBarDraw
 
-
 **Description:**
-
 
 Determines whether a specific HUD bar should be drawn.
 
-
 **Parameters:**
-
 
 * barName (string) – HUD bar identifier, e.g. "health" or "armor".
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean|nil: false to hide, nil to allow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldBarDraw is triggered
@@ -9753,39 +7831,30 @@ hook.Add("ShouldBarDraw", "HideArmorHUD", function(barName)
 end)
 ```
 
-
 ---
-
 
 ### ShouldDisableThirdperson
 
-
 **Description:**
-
 
 Checks if third-person view is allowed or disabled.
 
-
 **Parameters:**
-
 
 * client (Player) – Player to test.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean (true if 3rd-person should be disabled)
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldDisableThirdperson is triggered
@@ -9796,39 +7865,30 @@ hook.Add("ShouldDisableThirdperson", "DisableForInvisibles", function(client)
 end)
 ```
 
-
 ---
-
 
 ### ShouldHideBars
 
-
 **Description:**
-
 
 Determines whether all HUD bars should be hidden.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean|nil: true to hide, nil to allow rendering.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldHideBars is triggered
@@ -9839,39 +7899,30 @@ hook.Add("ShouldHideBars", "HideHUDInCinematic", function()
 end)
 ```
 
-
 ---
-
 
 ### thirdPersonToggled
 
-
 **Description:**
-
 
 Called when third-person mode is toggled on or off. Allows for custom handling of third-person mode changes.
 
-
 **Parameters:**
-
 
 * state (boolean) – true if third-person is enabled, false if disabled.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when thirdPersonToggled is triggered
@@ -9885,21 +7936,15 @@ hook.Add("thirdPersonToggled", "NotifyThirdPersonChange", function(state)
 end)
 ```
 
-
 ---
-
 
 ### AddTextField
 
-
 **Description:**
-
 
 Called when a text field is added to an F1 menu information section. Allows modules to modify or monitor the field being inserted.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Target section name.
 
@@ -9915,18 +7960,15 @@ Called when a text field is added to an F1 menu information section. Allows modu
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Change the money field label.
@@ -9937,21 +7979,15 @@ hook.Add("AddTextField", "RenameMoneyField", function(section, name, label, valu
 end)
 ```
 
-
 ---
-
 
 ### F1OnAddTextField
 
-
 **Description:**
-
 
 Fired after AddTextField so other modules can react to new fields.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Section name that received the field.
 
@@ -9967,18 +8003,15 @@ Fired after AddTextField so other modules can react to new fields.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log newly added fields.
@@ -9987,21 +8020,15 @@ hook.Add("F1OnAddTextField", "LogFields", function(section, name)
 end)
 ```
 
-
 ---
-
 
 ### F1OnAddBarField
 
-
 **Description:**
-
 
 Triggered after AddBarField inserts a status bar into the F1 menu.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Section identifier.
 
@@ -10023,18 +8050,15 @@ Triggered after AddBarField inserts a status bar into the F1 menu.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when F1OnAddBarField is triggered
@@ -10043,39 +8067,30 @@ hook.Add("F1OnAddBarField", "TrackBars", function(section, name)
 end)
 ```
 
-
 ---
-
 
 ### CreateInformationButtons
 
-
 **Description:**
-
 
 Called while building the F1 information menu to populate navigation buttons.
 
-
 **Parameters:**
-
 
 * pages (table) – Table to add page definitions into.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CreateInformationButtons is triggered
@@ -10084,39 +8099,30 @@ hook.Add("CreateInformationButtons", "AddHelpPage", function(pages)
 end)
 ```
 
-
 ---
-
 
 ### PopulateConfigurationButtons
 
-
 **Description:**
-
 
 Invoked when the settings tab is constructed allowing new configuration pages.
 
-
 **Parameters:**
-
 
 * pages (table) – Table to populate with config pages.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PopulateConfigurationButtons is triggered
@@ -10125,39 +8131,30 @@ hook.Add("PopulateConfigurationButtons", "AddControlsPage", function(pages)
 end)
 ```
 
-
 ---
-
 
 ### InitializedKeybinds
 
-
 **Description:**
-
 
 Called after keybinds have been loaded from disk.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when InitializedKeybinds is triggered
@@ -10166,39 +8163,30 @@ hook.Add("InitializedKeybinds", "NotifyKeybinds", function()
 end)
 ```
 
-
 ---
-
 
 ### getOOCDelay
 
-
 **Description:**
-
 
 Allows modification of the cooldown delay between OOC messages.
 
-
 **Parameters:**
-
 
 * client (Player) – Player sending OOC chat.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * number|nil – Custom cooldown in seconds.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when getOOCDelay is triggered
@@ -10209,21 +8197,15 @@ hook.Add("getOOCDelay", "AdminOOC", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### OnChatReceived
 
-
 **Description:**
-
 
 Runs on the client when chat text is received before display. Returning modified text will replace the message.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that sent the chat.
 
@@ -10239,18 +8221,15 @@ Runs on the client when chat text is received before display. Returning modified
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * string|nil – Replacement text.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnChatReceived is triggered
@@ -10259,21 +8238,15 @@ hook.Add("OnChatReceived", "CensorChat", function(ply, type, msg)
 end)
 ```
 
-
 ---
-
 
 ### getAdjustedPartData
 
-
 **Description:**
-
 
 Requests PAC3 part data after adjustments have been applied.
 
-
 **Parameters:**
-
 
 * wearer (Entity) – Entity wearing the outfit.
 
@@ -10283,18 +8256,15 @@ Requests PAC3 part data after adjustments have been applied.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table|nil – Adjusted part data.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when getAdjustedPartData is triggered
@@ -10303,21 +8273,15 @@ hook.Add("getAdjustedPartData", "DebugParts", function(ply, partID)
 end)
 ```
 
-
 ---
-
 
 ### AdjustPACPartData
 
-
 **Description:**
-
 
 Allows modules to modify PAC3 part data before it is attached.
 
-
 **Parameters:**
-
 
 * wearer (Entity) – Entity wearing the part.
 
@@ -10330,18 +8294,15 @@ Allows modules to modify PAC3 part data before it is attached.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table|nil – Modified data table.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when AdjustPACPartData is triggered
@@ -10351,21 +8312,15 @@ hook.Add("AdjustPACPartData", "ColorParts", function(ply, partID, d)
 end)
 ```
 
-
 ---
-
 
 ### attachPart
 
-
 **Description:**
-
 
 Called when a PAC3 part should be attached to a player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player receiving the part.
 
@@ -10375,18 +8330,15 @@ Called when a PAC3 part should be attached to a player.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when attachPart is triggered
@@ -10395,21 +8347,15 @@ hook.Add("attachPart", "AnnouncePart", function(ply, partID)
 end)
 ```
 
-
 ---
-
 
 ### removePart
 
-
 **Description:**
-
 
 Triggered when a PAC3 part is removed from a player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player losing the part.
 
@@ -10419,18 +8365,15 @@ Triggered when a PAC3 part is removed from a player.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when removePart is triggered
@@ -10439,39 +8382,30 @@ hook.Add("removePart", "LogPartRemoval", function(ply, partID)
 end)
 ```
 
-
 ---
-
 
 ### OnPAC3PartTransfered
 
-
 **Description:**
-
 
 Fired when a PAC3 outfit part transfers ownership to a ragdoll.
 
-
 **Parameters:**
-
 
 * part (Entity) – The outfit part being transferred.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnPAC3PartTransfered is triggered
@@ -10480,39 +8414,30 @@ hook.Add("OnPAC3PartTransfered", "TrackTransfers", function(p)
 end)
 ```
 
-
 ---
-
 
 ### DrawPlayerRagdoll
 
-
 **Description:**
-
 
 Allows custom rendering of a player's ragdoll created by PAC3.
 
-
 **Parameters:**
-
 
 * entity (Entity) – Ragdoll entity to draw.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when DrawPlayerRagdoll is triggered
@@ -10521,39 +8446,30 @@ hook.Add("DrawPlayerRagdoll", "TintRagdoll", function(ent)
 end)
 ```
 
-
 ---
-
 
 ### setupPACDataFromItems
 
-
 **Description:**
-
 
 Initializes PAC3 outfits from equipped items after modules load.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when setupPACDataFromItems is triggered
@@ -10562,39 +8478,30 @@ hook.Add("setupPACDataFromItems", "InitPAC", function()
 end)
 ```
 
-
 ---
-
 
 ### TryViewModel
 
-
 **Description:**
-
 
 Allows PAC3 to swap the view model entity for event checks.
 
-
 **Parameters:**
-
 
 * entity (Entity) – The view model entity.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * Entity – Replacement entity.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when TryViewModel is triggered
@@ -10603,33 +8510,25 @@ hook.Add("TryViewModel", "UsePlayerViewModel", function(ent)
 end)
 ```
 
-
 ---
-
 
 ### WeaponCycleSound
 
-
 **Description:**
-
 
 Lets modules provide a custom sound when cycling weapons in the selector.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * string|nil – Sound path.
 
@@ -10638,7 +8537,6 @@ Lets modules provide a custom sound when cycling weapons in the selector.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when WeaponCycleSound is triggered
@@ -10647,33 +8545,25 @@ hook.Add("WeaponCycleSound", "SilentCycle", function()
 end)
 ```
 
-
 ---
-
 
 ### WeaponSelectSound
 
-
 **Description:**
-
 
 Similar to WeaponCycleSound but used when confirming a weapon choice.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * string|nil – Sound path.
 
@@ -10683,7 +8573,6 @@ Similar to WeaponCycleSound but used when confirming a weapon choice.
 
 **Example Usage:**
 
-
 ```lua
 -- Prints a message when WeaponSelectSound is triggered
 hook.Add("WeaponSelectSound", "CustomSelectSound", function()
@@ -10691,39 +8580,30 @@ hook.Add("WeaponSelectSound", "CustomSelectSound", function()
 end)
 ```
 
-
 ---
-
 
 ### ShouldDrawWepSelect
 
-
 **Description:**
-
 
 Determines if the weapon selection UI should be visible.
 
-
 **Parameters:**
-
 
 * client (Player) – Player whose UI is drawing.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldDrawWepSelect is triggered
@@ -10732,39 +8612,30 @@ hook.Add("ShouldDrawWepSelect", "HideInVehicles", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerChooseWeapon
 
-
 **Description:**
-
 
 Checks whether the active weapon can be selected via the weapon wheel.
 
-
 **Parameters:**
-
 
 * weapon (Weapon) – Weapon to name.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean|nil – false to block selection.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerChooseWeapon is triggered
@@ -10775,21 +8646,15 @@ hook.Add("CanPlayerChooseWeapon", "BlockPhysgun", function(wep)
 end)
 ```
 
-
 ---
-
 
 ### OverrideSpawnTime
 
-
 **Description:**
-
 
 Allows modules to modify the respawn delay after death.
 
-
 **Parameters:**
-
 
 * client (Player) – Respawning player.
 
@@ -10799,18 +8664,15 @@ Allows modules to modify the respawn delay after death.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * number|nil – New respawn time.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OverrideSpawnTime is triggered
@@ -10821,39 +8683,30 @@ hook.Add("OverrideSpawnTime", "ShortRespawns", function(ply, time)
 end)
 ```
 
-
 ---
-
 
 ### ShouldRespawnScreenAppear
 
-
 **Description:**
-
 
 Lets modules suppress the respawn HUD from showing.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean|nil – false to hide.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when ShouldRespawnScreenAppear is triggered
@@ -10862,39 +8715,30 @@ hook.Add("ShouldRespawnScreenAppear", "NoRespawnHUD", function()
 end)
 ```
 
-
 ---
-
 
 ### VoiceToggled
 
-
 **Description:**
-
 
 Fired when voice chat is enabled or disabled via config.
 
-
 **Parameters:**
-
 
 * enabled (boolean) – Current voice chat state.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when VoiceToggled is triggered
@@ -10903,39 +8747,30 @@ hook.Add("VoiceToggled", "AnnounceVoice", function(state)
 end)
 ```
 
-
 ---
-
 
 ### DermaSkinChanged
 
-
 **Description:**
-
 
 Fired when the Derma UI skin configuration value changes. Allows modules to react to the UI skin being switched.
 
-
 **Parameters:**
-
 
 * skin (string) – Name of the new Derma skin.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reload custom panels when the skin changes
@@ -10944,39 +8779,30 @@ hook.Add("DermaSkinChanged", "UpdatePanels", function(skin)
 end)
 ```
 
-
 ---
-
 
 ### RefreshFonts
 
-
 **Description:**
-
 
 Requests recreation of all registered UI fonts.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when RefreshFonts is triggered
@@ -10985,21 +8811,15 @@ hook.Add("RefreshFonts", "ReloadFonts", function()
 end)
 ```
 
-
 ---
-
 
 ### AdjustCreationData
 
-
 **Description:**
-
 
 Allows modification of character creation data before the character is saved.
 
-
 **Parameters:**
-
 
 * client (Player) – Player creating the character.
 
@@ -11015,18 +8835,15 @@ Allows modification of character creation data before the character is saved.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when AdjustCreationData is triggered
@@ -11037,21 +8854,15 @@ hook.Add("AdjustCreationData", "EnforceName", function(ply, data, newData)
 end)
 ```
 
-
 ---
-
 
 ### CanCharBeTransfered
 
-
 **Description:**
-
 
 Determines if a character may switch factions.
 
-
 **Parameters:**
-
 
 * character (table) – Character being transferred.
 
@@ -11064,18 +8875,15 @@ Determines if a character may switch factions.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to block.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanCharBeTransfered is triggered
@@ -11086,21 +8894,15 @@ hook.Add("CanCharBeTransfered", "BlockRestrictedFactions", function(char, factio
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerUseChar
 
-
 **Description:**
-
 
 Called when a player attempts to load one of their characters.
 
-
 **Parameters:**
-
 
 * client (Player) – Player loading the character.
 
@@ -11110,18 +8912,15 @@ Called when a player attempts to load one of their characters.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to deny.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerUseChar is triggered
@@ -11132,21 +8931,15 @@ hook.Add("CanPlayerUseChar", "CheckBans", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerSwitchChar
 
-
 **Description:**
-
 
 Checks if a player can switch from their current character to another.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting the switch.
 
@@ -11159,18 +8952,15 @@ Checks if a player can switch from their current character to another.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to block the switch.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerSwitchChar is triggered
@@ -11181,21 +8971,15 @@ hook.Add("CanPlayerSwitchChar", "NoSwitchInCombat", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerLock
 
-
 **Description:**
-
 
 Determines whether the player may lock the given door or vehicle.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to lock.
 
@@ -11205,18 +8989,15 @@ Determines whether the player may lock the given door or vehicle.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to disallow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerLock is triggered
@@ -11227,21 +9008,15 @@ hook.Add("CanPlayerLock", "AdminsAlwaysLock", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerUnlock
 
-
 **Description:**
-
 
 Determines whether the player may unlock the given door or vehicle.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to unlock.
 
@@ -11251,18 +9026,15 @@ Determines whether the player may unlock the given door or vehicle.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to disallow.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerUnlock is triggered
@@ -11273,21 +9045,15 @@ hook.Add("CanPlayerUnlock", "AdminsAlwaysUnlock", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### GetMaxStartingAttributePoints
 
-
 **Description:**
-
 
 Lets you change how many attribute points a new character receives. Retrieves the maximum attribute points available at character creation.
 
-
 **Parameters:**
-
 
 * client (Player) – Viewing player.
 
@@ -11297,18 +9063,15 @@ Lets you change how many attribute points a new character receives. Retrieves th
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * number – Maximum starting points
 
 
 **Example Usage:**
-
 
 ```lua
 -- Gives every new character 60 starting points.
@@ -11317,21 +9080,15 @@ hook.Add("GetMaxStartingAttributePoints", "DoublePoints", function(client)
 end)
 ```
 
-
 ---
-
 
 ### GetAttributeStartingMax
 
-
 **Description:**
-
 
 Sets a limit for a specific attribute at character creation. Returns the starting maximum for a specific attribute.
 
-
 **Parameters:**
-
 
 * client (Player) – Viewing player.
 
@@ -11341,18 +9098,15 @@ Sets a limit for a specific attribute at character creation. Returns the startin
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * number – Maximum starting value
 
 
 **Example Usage:**
-
 
 ```lua
 -- Limits the Strength attribute to a maximum of 20.
@@ -11363,21 +9117,15 @@ hook.Add("GetAttributeStartingMax", "CapStrength", function(client, attribute)
 end)
 ```
 
-
 ---
-
 
 ### GetAttributeMax
 
-
 **Description:**
-
 
 Returns the maximum value allowed for an attribute.
 
-
 **Parameters:**
-
 
 * client (Player) – Player being queried.
 
@@ -11387,18 +9135,15 @@ Returns the maximum value allowed for an attribute.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Maximum attribute value
 
 
 **Example Usage:**
-
 
 ```lua
 -- Increase stamina cap for admins.
@@ -11409,21 +9154,15 @@ hook.Add("GetAttributeMax", "AdminStamina", function(client, attrib)
 end)
 ```
 
-
 ---
-
 
 ### OnCharAttribBoosted
 
-
 **Description:**
-
 
 Fired when an attribute boost is added or removed.
 
-
 **Parameters:**
-
 
 * client (Player) – Player owning the character.
 
@@ -11442,18 +9181,15 @@ Fired when an attribute boost is added or removed.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notify the player when they gain a temporary bonus.
@@ -11464,21 +9200,15 @@ hook.Add("OnCharAttribBoosted", "BoostNotice", function(client, char, key, id, a
 end)
 ```
 
-
 ---
-
 
 ### OnCharAttribUpdated
 
-
 **Description:**
-
 
 Fired when a character attribute value is changed.
 
-
 **Parameters:**
-
 
 * client (Player) – Player owning the character.
 
@@ -11494,18 +9224,15 @@ Fired when a character attribute value is changed.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the changed attribute on the local player's HUD.
@@ -11516,21 +9243,15 @@ hook.Add("OnCharAttribUpdated", "PrintAttribChange", function(client, char, key,
 end)
 ```
 
-
 ---
-
 
 ### CanPlayerModifyConfig
 
-
 **Description:**
-
 
 Called when a player attempts to change a configuration value.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting the change.
 
@@ -11540,18 +9261,15 @@ Called when a player attempts to change a configuration value.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean|nil – false to deny modification.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CanPlayerModifyConfig is triggered
@@ -11560,21 +9278,15 @@ hook.Add("CanPlayerModifyConfig", "RestrictConfig", function(ply, k)
 end)
 ```
 
-
 ---
-
 
 ### CharDeleted
 
-
 **Description:**
-
 
 Fired after a character is permanently removed.
 
-
 **Parameters:**
-
 
 * client (Player) – Player who owned the character.
 
@@ -11584,18 +9296,15 @@ Fired after a character is permanently removed.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CharDeleted is triggered
@@ -11604,21 +9313,15 @@ hook.Add("CharDeleted", "LogDeletion", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### CheckFactionLimitReached
 
-
 **Description:**
-
 
 Allows custom logic for determining if a faction has reached its player limit.
 
-
 **Parameters:**
-
 
 * faction (table) – Faction being checked.
 
@@ -11631,18 +9334,15 @@ Allows custom logic for determining if a faction has reached its player limit.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when CheckFactionLimitReached is triggered
@@ -11653,21 +9353,15 @@ hook.Add("CheckFactionLimitReached", "IgnoreAdmins", function(faction, char, ply
 end)
 ```
 
-
 ---
-
 
 ### F1OnAddSection
 
-
 **Description:**
-
 
 Triggered after AddSection inserts a new information section.
 
-
 **Parameters:**
-
 
 * sectionName (string) – Name of the inserted section.
 
@@ -11683,18 +9377,15 @@ Triggered after AddSection inserts a new information section.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when F1OnAddSection is triggered
@@ -11703,39 +9394,30 @@ hook.Add("F1OnAddSection", "PrintSection", function(name)
 end)
 ```
 
-
 ---
-
 
 ### GetWeaponName
 
-
 **Description:**
-
 
 Allows overriding of the displayed weapon name in the selector.
 
-
 **Parameters:**
-
 
 * weapon (Weapon) – Weapon to name.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * string|nil – Replacement name.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when GetWeaponName is triggered
@@ -11744,21 +9426,15 @@ hook.Add("GetWeaponName", "UppercaseName", function(wep)
 end)
 ```
 
-
 ---
-
 
 ### OnCharGetup
 
-
 **Description:**
-
 
 Called when a ragdolled character finishes getting up.
 
-
 **Parameters:**
-
 
 * client (Player) – Player getting up.
 
@@ -11768,18 +9444,15 @@ Called when a ragdolled character finishes getting up.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnCharGetup is triggered
@@ -11788,39 +9461,30 @@ hook.Add("OnCharGetup", "NotifyGetup", function(ply)
 end)
 ```
 
-
 ---
-
 
 ### OnLocalizationLoaded
 
-
 **Description:**
-
 
 Fired once language files finish loading.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnLocalizationLoaded is triggered
@@ -11829,21 +9493,15 @@ hook.Add("OnLocalizationLoaded", "PrintLang", function()
 end)
 ```
 
-
 ---
-
 
 ### OnPlayerObserve
 
-
 **Description:**
-
 
 Called when a player's observe mode is toggled.
 
-
 **Parameters:**
-
 
 * client (Player) – Player toggling observe mode.
 
@@ -11853,18 +9511,15 @@ Called when a player's observe mode is toggled.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when OnPlayerObserve is triggered
@@ -11873,21 +9528,15 @@ hook.Add("OnPlayerObserve", "AnnounceObserve", function(ply, s)
 end)
 ```
 
-
 ---
-
 
 ### PlayerLoadedChar
 
-
 **Description:**
-
 
 Runs after a character has been loaded and set up for a player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player who loaded the character.
 
@@ -11900,18 +9549,15 @@ Runs after a character has been loaded and set up for a player.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PlayerLoadedChar is triggered
@@ -11920,21 +9566,15 @@ hook.Add("PlayerLoadedChar", "WelcomeBack", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### PrePlayerLoadedChar
 
-
 **Description:**
-
 
 Fired right before a player switches to a new character.
 
-
 **Parameters:**
-
 
 * client (Player) – Player switching characters.
 
@@ -11947,18 +9587,15 @@ Fired right before a player switches to a new character.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PrePlayerLoadedChar is triggered
@@ -11967,21 +9604,15 @@ hook.Add("PrePlayerLoadedChar", "SaveStuff", function(ply, new, old)
 end)
 ```
 
-
 ---
-
 
 ### PostPlayerLoadedChar
 
-
 **Description:**
-
 
 Called after PlayerLoadedChar to allow post-load operations.
 
-
 **Parameters:**
-
 
 * client (Player) – Player that finished loading.
 
@@ -11994,18 +9625,15 @@ Called after PlayerLoadedChar to allow post-load operations.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PostPlayerLoadedChar is triggered
@@ -12014,21 +9642,15 @@ hook.Add("PostPlayerLoadedChar", "GiveItems", function(ply, char)
 end)
 ```
 
-
 ---
-
 
 ### PlayerSay
 
-
 **Description:**
-
 
 Custom hook executed when a player sends a chat message server-side.
 
-
 **Parameters:**
-
 
 * client (Player) – Speaking player.
 
@@ -12038,18 +9660,15 @@ Custom hook executed when a player sends a chat message server-side.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PlayerSay is triggered
@@ -12058,21 +9677,15 @@ hook.Add("PlayerSay", "LogChat", function(ply, msg)
 end)
 ```
 
-
 ---
-
 
 ### PopulateAdminStick
 
-
 **Description:**
-
 
 Called after the admin stick menu is created so additional commands can be added.
 
-
 **Parameters:**
-
 
 * menu (DermaPanel) – Context menu panel.
 
@@ -12082,18 +9695,15 @@ Called after the admin stick menu is created so additional commands can be added
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when PopulateAdminStick is triggered
@@ -12104,21 +9714,15 @@ hook.Add("PopulateAdminStick", "AddCustomOption", function(menu, ent)
 end)
 ```
 
-
 ---
-
 
 ### TicketSystemClaim
 
-
 **Description:**
-
 
 Fired when a staff member claims a help ticket.
 
-
 **Parameters:**
-
 
 * admin (Player) – Staff member claiming the ticket.
 
@@ -12128,18 +9732,15 @@ Fired when a staff member claims a help ticket.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when TicketSystemClaim is triggered
@@ -12148,21 +9749,15 @@ hook.Add("TicketSystemClaim", "NotifyClaim", function(staff, ply)
 end)
 ```
 
-
 ---
-
 
 ### liaOptionReceived
 
-
 **Description:**
-
 
 Triggered when a shared option value is changed.
 
-
 **Parameters:**
-
 
 * client (Player|nil) – Player that changed the option or nil if server.
 
@@ -12175,18 +9770,15 @@ Triggered when a shared option value is changed.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prints a message when liaOptionReceived is triggered

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,8 +1,6 @@
 # Home
 
-
 ---
-
 
 <p align="center">
 
@@ -10,35 +8,24 @@
 
 </p>
 
-
 Lilia is an advanced roleplay framework for Garry's Mod. Inspired by Lillia from League of Legends, it lets you create immersive servers with stability, rich features, and open-source flexibility. Because Lilia is only a framework, you must install a roleplay schema and launch your server using that schema's gamemode (for example, `+gamemode scprp`).
-
 
 ## Server Owners
 
-
 If you're looking to get your Lilia server up and running as soon as possible, check out the [Installation Tutorial](./installation.md) guide in the manual.
-
 
 ## Community
 
-
 Questions? Want to show off your work? Maybe drop a new module release? Come join our community [Discord server](https://discord.gg/esCRH5ckbQ).
-
 
 ## Contributing
 
-
 Lilia is still early in its lifespan, and there are still a few things missing here and there. Contributions to the documentation—from function references to simple typo fixes—are welcomed!
-
 
 If you'd like to contribute code, you can visit the [GitHub repository](https://github.com/LiliaFramework/Lilia/) and make a pull request.
 
-
 ## Learning
 
-
 Getting started with developing using the Lilia framework requires an intermediate level of Garry's Mod Lua knowledge. You'll want to learn the basics before you start making a schema. The [Garry's Mod Wiki](https://wiki.facepunch.com/gmod/) is a good place to start.
-
 
 ---

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -69,7 +69,6 @@ If you haven't already, set up your Garry's Mod server and ensure it is running 
 
     Find the `Lilia.zip` file you downloaded.
 
-
 2. **Extract the Contents:**
 
 
@@ -94,12 +93,10 @@ If you haven't already, set up your Garry's Mod server and ensure it is running 
 
     Use an FTP or SFTP client (e.g., [FileZilla](https://filezilla-project.org/) or [WinSCP](https://winscp.net/eng/index.php)) to connect to your Garry's Mod server.
 
-
 2. **Navigate to the Gamemodes Directory:**
 
 
     Go to `garrysmod/gamemodes` within your server's file structure.
-
 
 3. **Upload the Lilia Folder:**
 

--- a/docs/docs/libraries/lia.attributes.md
+++ b/docs/docs/libraries/lia.attributes.md
@@ -1,25 +1,18 @@
 # Attributes Library
 
-
 This page documents the functions for working with character attributes.
 
-
 ---
-
 
 ## Overview
 
-
 The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper methods for modifying them. It also exposes hooks for registering new attributes and controlling how they progress.
 
-
 ---
-
 
 ### lia.attribs.loadFromDir(directory)
 
 **Description:**
-
 
 Loads attribute definitions from the given folder. Files prefixed
 
@@ -31,41 +24,33 @@ lia.attribs.list using the filename, without prefix or extension,
 
 as the key.
 
-
 **Parameters:**
-
 
 * directory (string) – Path to the folder containing attribute Lua files.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.attribs.loadFromDir
     lia.attribs.loadFromDir("schema/attributes")
 ```
 
-
 ---
-
 
 ### lia.attribs.setup(client)
 
 **Description:**
-
 
 Initializes attribute data for a client's character. Each attribute in
 
@@ -73,30 +58,24 @@ lia.attribs.list is read from the character and, if the attribute has
 
 an OnSetup callback, it is executed with the current value.
 
-
 **Parameters:**
-
 
 * client (Player) – The player whose character attributes should be set up.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.attribs.setup
     lia.attribs.setup(client)
 ```
-

--- a/docs/docs/libraries/lia.bars.md
+++ b/docs/docs/libraries/lia.bars.md
@@ -1,49 +1,37 @@
 # Bars Library
 
-
 This page describes the API for status bars displayed on the HUD.
 
-
 ---
-
 
 ## Overview
 
-
 The bars library manages health, stamina, and other progress bars displayed on the player's HUD. It lets you register custom bar callbacks, draws them every frame, and provides helpers for temporary action bars.
 
-
 ---
-
 
 ### lia.bar.get(identifier)
 
 **Description:**
 
-
 Retrieves a bar object from the list by its unique identifier.
 
-
 **Parameters:**
-
 
 * identifier (string) – The unique identifier of the bar to retrieve.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table or nil – The bar table if found, or nil if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Retrieve the health bar and change its color at runtime
@@ -53,14 +41,11 @@ Retrieves a bar object from the list by its unique identifier.
     end
 ```
 
-
 ---
-
 
 ### lia.bar.add(getValue, color, priority, identifier)
 
 **Description:**
-
 
 Adds a new bar or replaces an existing one in the bar list.
 
@@ -68,9 +53,7 @@ If the identifier matches an existing bar, the old bar is removed first.
 
 Bars are drawn in order of ascending priority.
 
-
 **Parameters:**
-
 
 * getValue (function) – A callback that returns the current value of the bar.
 
@@ -86,18 +69,15 @@ Bars are drawn in order of ascending priority.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * number – The priority assigned to the added bar.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Calculates the player's current health as a fraction of their maximum health.
@@ -109,60 +89,47 @@ Bars are drawn in order of ascending priority.
     end, Color(200, 50, 40), 1, "health")
 ```
 
-
 ---
-
 
 ### lia.bar.remove(identifier)
 
 **Description:**
 
-
 Removes a bar from the list based on its unique identifier.
 
-
 **Parameters:**
-
 
 * identifier (string) – The unique identifier of the bar to remove.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.bar.remove
     lia.bar.remove("example")
 ```
 
-
 ---
-
 
 ### lia.bar.drawBar(x, y, w, h, pos, max, color)
 
 **Description:**
 
-
 Draws a single horizontal bar at the specified screen coordinates,
 
 filling it proportionally based on pos and max.
 
-
 **Parameters:**
-
 
 * x (number) – The x-coordinate of the bar's top-left corner.
 
@@ -187,40 +154,32 @@ filling it proportionally based on pos and max.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.bar.drawBar
     lia.bar.drawBar(10, 10, 200, 20, 0.5, 1, Color(255,0,0))
 ```
 
-
 ---
-
 
 ### lia.bar.drawAction(text, duration)
 
 **Description:**
 
-
 Displays a temporary action progress bar with accompanying text
 
 for the specified duration on the HUD.
 
-
 **Parameters:**
-
 
 * text (string) – The text to display above the progress bar.
 
@@ -230,61 +189,49 @@ for the specified duration on the HUD.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.bar.drawAction
     lia.bar.drawAction("Reloading", 2)
 ```
 
-
 ---
-
 
 ### lia.bar.drawAll()
 
 **Description:**
 
-
 Iterates through all registered bars, applies smoothing to their values,
 
 and draws them on the HUD according to their priority and visibility rules.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of hook.Add
     hook.Add("HUDPaintBackground", "liaBarDraw", lia.bar.drawAll)
 ```
-

--- a/docs/docs/libraries/lia.character.md
+++ b/docs/docs/libraries/lia.character.md
@@ -1,25 +1,18 @@
 # Character Library
 
-
 This page covers utilities for manipulating character data.
-
 
 ---
 
-
 ## Overview
-
 
 The character library handles creation and persistence of player characters. It manages character variables, interacts with the database, and offers helpers for retrieving characters by ID or SteamID. Because these functions directly modify stored data, use them carefully or you may corrupt character information.
 
-
 **Description:**
-
 
 Creates a new character instance with default variables and metatable.
 
 **Parameters:**
-
 
 * data (table) – Table of character variables.
 
@@ -35,39 +28,30 @@ Creates a new character instance with default variables and metatable.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * character (table) – New character object.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.new
     local char = lia.char.new({name = "John"}, 1, client)
 ```
 
-
 ---
-
-
 
 ### lia.char.hookVar(varName, hookName, func)
 
 **Description:**
 
-
 Registers a hook function for when a character variable changes.
 
-
 **Parameters:**
-
 
 * varName (string) – Variable name to hook.
 
@@ -80,38 +64,30 @@ Registers a hook function for when a character variable changes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.hookVar
     lia.char.hookVar("name", "PrintName", function(old, new) print(new) end)
 ```
 
-
 ---
-
 
 ### lia.char.registerVar(key, data)
 
 **Description:**
 
-
 Registers a character variable with metadata and generates accessor methods.
 
-
 **Parameters:**
-
 
 * key (string) – Variable key.
 
@@ -121,38 +97,30 @@ Registers a character variable with metadata and generates accessor methods.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.registerVar
     lia.char.registerVar("age", {field = "_age", default = 20})
 ```
 
-
 ---
-
 
 ### lia.char.getCharData(charID, key)
 
 **Description:**
 
-
 Retrieves character data JSON from the database as a Lua table.
 
-
 **Parameters:**
-
 
 * charID (number|string) – Character ID.
 
@@ -162,38 +130,30 @@ Retrieves character data JSON from the database as a Lua table.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * value (any) – Data value or full table if no key provided.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.getCharData
     local age = lia.char.getCharData(1, "age")
 ```
 
-
 ---
-
 
 ### lia.char.getCharDataRaw(charID, key)
 
 **Description:**
 
-
 Retrieves raw character database row or specific column.
 
-
 **Parameters:**
-
 
 * charID (number|string) – Character ID.
 
@@ -203,190 +163,150 @@ Retrieves raw character database row or specific column.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * row (table|any) – Full row table or column value.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.getCharDataRaw
     local row = lia.char.getCharDataRaw(1)
 ```
 
-
 ---
-
 
 ### lia.char.getOwnerByID(ID)
 
 **Description:**
 
-
 Finds the player entity that owns the character with the given ID.
 
-
 **Parameters:**
-
 
 * ID (number|string) – Character ID.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * Player – Player entity or nil if not found.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.getOwnerByID
     local ply = lia.char.getOwnerByID(1)
 ```
 
-
 ---
-
 
 ### lia.char.getBySteamID(steamID)
 
 **Description:**
 
-
 Retrieves a character object by SteamID or SteamID64.
 
-
 **Parameters:**
-
 
 * steamID (string) – SteamID or SteamID64.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * Character – Character object or nil.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.getBySteamID
     local char = lia.char.getBySteamID("STEAM_0:0:11101")
 ```
 
-
 ---
-
 
 ### lia.char.getAll()
 
 **Description:**
 
-
 Returns a table mapping all players to their loaded character objects.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – Map of Player to Character.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of pairs
     for ply, char in pairs(lia.char.getAll()) do print(ply, char:getName()) end
 ```
 
-
 ---
-
 
 ### lia.char.GetTeamColor(client)
 
 **Description:**
 
-
 Determines the team color for a client based on their character class or default team.
 
-
 **Parameters:**
-
 
 * client (Player) – Player entity.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * Color – Team or class color.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.GetTeamColor
     local color = lia.char.GetTeamColor(client)
 ```
 
-
 ---
-
 
 ### lia.char.create(data, callback)
 
 **Description:**
 
-
 Inserts a new character into the database and sets up default inventory.
 
-
 **Parameters:**
-
 
 * data (table) – Character creation data.
 
@@ -396,38 +316,30 @@ Inserts a new character into the database and sets up default inventory.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.create
     lia.char.create({name = "John"}, function(id) print("Created", id) end)
 ```
 
-
 ---
-
 
 ### lia.char.restore(client, callback, id)
 
 **Description:**
 
-
 Loads characters for a client from the database, optionally filtering by ID.
 
-
 **Parameters:**
-
 
 * client (Player) – Player entity.
 
@@ -440,76 +352,60 @@ Loads characters for a client from the database, optionally filtering by ID.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.char.restore
     lia.char.restore(client, print)
 ```
 
-
 ---
-
 
 ### lia.char.cleanUpForPlayer(client)
 
 **Description:**
 
-
 Cleans up loaded characters and inventories for a player on disconnect.
 
-
 **Parameters:**
-
 
 * client (Player) – Player entity.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.cleanUpForPlayer
     lia.char.cleanUpForPlayer(client)
 ```
 
-
 ---
-
 
 ### lia.char.delete(id, client)
 
 **Description:**
 
-
 Deletes a character by ID from the database, cleans up and notifies players.
 
-
 **Parameters:**
-
 
 * id (number) – Character ID to delete.
 
@@ -519,38 +415,30 @@ Deletes a character by ID from the database, cleans up and notifies players.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.delete
     lia.char.delete(1, client)
 ```
 
-
 ---
-
 
 ### lia.char.setCharData(charID, key, val)
 
 **Description:**
 
-
 Updates a character's JSON data field in the database and loaded object.
 
-
 **Parameters:**
-
 
 * charID (number|string) – Character ID.
 
@@ -563,38 +451,30 @@ Updates a character's JSON data field in the database and loaded object.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – True on success, false on failure.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.setCharData
     lia.char.setCharData(1, "age", 25)
 ```
 
-
 ---
-
 
 ### lia.char.setCharName(charID, name)
 
 **Description:**
 
-
 Updates the character's name in the database and loaded object.
 
-
 **Parameters:**
-
 
 * charID (number|string) – Character ID.
 
@@ -604,38 +484,30 @@ Updates the character's name in the database and loaded object.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – True on success, false on failure.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.setCharName
     lia.char.setCharName(1, "NewName")
 ```
 
-
 ---
-
 
 ### lia.char.setCharModel(charID, model, bg)
 
 **Description:**
 
-
 Updates the character's model and bodygroups in the database and in-game.
 
-
 **Parameters:**
-
 
 * charID (number|string) – Character ID.
 
@@ -648,21 +520,17 @@ Updates the character's model and bodygroups in the database and in-game.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – True on success, false on failure.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.char.setCharModel
     lia.char.setCharModel(1, "models/player.mdl", {})
 ```
-

--- a/docs/docs/libraries/lia.chatbox.md
+++ b/docs/docs/libraries/lia.chatbox.md
@@ -1,64 +1,48 @@
 # Chatbox Library
 
-
 This page outlines chatbox related functions and helpers.
 
-
 ---
-
 
 ## Overview
 
 The chatbox library defines chat commands and renders messages. It lets you register chat classes that determine how text such as IC, action, and OOC messages appear and handles radius-based or global visibility.
 
-
-
 **Description:**
-
 
 Returns a formatted timestamp if chat timestamps are enabled.
 
 **Parameters:**
-
 
 * ooc (boolean) – True for out-of-character messages.
 
 
 **Returns:**
 
-
 * string – Formatted time string or an empty string.
 
 
 **Realm:**
-
 
 * Shared
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.chat.timestamp
     local ts = lia.chat.timestamp(false)
 ```
 
-
 ---
-
-
 
 ### lia.chat.register(chatType, data)
 
 **Description:**
 
-
 Registers a new chat class and sets up command aliases.
 
-
 **Parameters:**
-
 
 * chatType (string) – Identifier for the chat class.
 
@@ -68,18 +52,15 @@ Registers a new chat class and sets up command aliases.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- Register a simple "/me" chat command that prints actions in purple
@@ -91,20 +72,15 @@ Registers a new chat class and sets up command aliases.
     })
 ```
 
-
 ---
-
 
 ### lia.chat.parse(client, message, noSend)
 
 **Description:**
 
-
 Parses chat text for the proper chat type and optionally sends it.
 
-
 **Parameters:**
-
 
 * client (Player) – Player sending the message.
 
@@ -117,18 +93,15 @@ Parses chat text for the proper chat type and optionally sends it.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * chatType (string), text (string), anonymous (boolean)
 
 
 **Example Usage:**
-
 
 ```lua
     -- Parse chat messages and log "/me" actions to the console
@@ -140,20 +113,15 @@ Parses chat text for the proper chat type and optionally sends it.
     end)
 ```
 
-
 ---
-
 
 ### lia.chat.send(speaker, chatType, text, anonymous, receivers)
 
 **Description:**
 
-
 Broadcasts a chat message to all eligible receivers.
 
-
 **Parameters:**
-
 
 * speaker (Player) – The message sender.
 
@@ -172,21 +140,17 @@ Broadcasts a chat message to all eligible receivers.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.chat.send
     lia.chat.send(client, "ic", "Hello")
 ```
-

--- a/docs/docs/libraries/lia.classes.md
+++ b/docs/docs/libraries/lia.classes.md
@@ -1,66 +1,50 @@
 # Classes Library
 
-
 This page details the class system functions.
-
 
 ---
 
-
 ## Overview
 
-
 The classes library loads Lua definitions that describe player classes. Classes act like temporary jobs within a faction. The library stores available classes, registers default attributes, and provides lookup functions by name or index.
-
 
 ### lia.class.loadFromDir(directory)
 
 **Description:**
 
-
 Loads all class definitions from the given directory and stores them in lia.class.list.
 
-
 **Parameters:**
-
 
 * directory (string) – Folder path containing class Lua files.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.loadFromDir
     lia.class.loadFromDir("schema/classes")
 ```
 
-
 ---
-
 
 ### lia.class.canBe(client, class)
 
 **Description:**
 
-
 Determines if the given client may become the specified class.
 
-
 **Parameters:**
-
 
 * client (Player) – Player attempting to join.
 
@@ -70,208 +54,165 @@ Determines if the given client may become the specified class.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * boolean – False with a message if denied; default status when allowed.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.canBe
     local allowed = lia.class.canBe(client, classID)
 ```
 
-
 ---
-
 
 ### lia.class.get(identifier)
 
 **Description:**
 
-
 Retrieves the class table associated with the given identifier.
 
-
 **Parameters:**
-
 
 * identifier (string|number) – Unique identifier for the class.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table|nil – Class table if found.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.get
     local classData = lia.class.get(1)
 ```
 
-
 ---
-
 
 ### lia.class.getPlayers(class)
 
 **Description:**
 
-
 Returns a table of players whose characters belong to the given class.
 
-
 **Parameters:**
-
 
 * class (string|number) – Class identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – List of player objects.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.getPlayers
     local players = lia.class.getPlayers(classID)
 ```
 
-
 ---
-
 
 ### lia.class.getPlayerCount(class)
 
 **Description:**
 
-
 Counts how many players belong to the given class.
 
-
 **Parameters:**
-
 
 * class (string|number) – Class identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * number – Player count.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.getPlayerCount
     local count = lia.class.getPlayerCount(classID)
 ```
 
-
 ---
-
 
 ### lia.class.retrieveClass(class)
 
 **Description:**
 
-
 Searches the class list for a class whose ID or name matches the given text.
 
-
 **Parameters:**
-
 
 * class (string) – Search text.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string|nil – Matching class identifier or nil.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.class.retrieveClass
     local id = lia.class.retrieveClass("police")
 ```
 
-
 ---
-
 
 ### lia.class.hasWhitelist(class)
 
 **Description:**
 
-
 Returns whether the specified class requires a whitelist.
 
-
 **Parameters:**
-
 
 * class (string|number) – Class identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the class is whitelisted.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.class.hasWhitelist
@@ -279,4 +220,3 @@ Returns whether the specified class requires a whitelist.
         print("Whitelist required")
     end
 ```
-

--- a/docs/docs/libraries/lia.color.md
+++ b/docs/docs/libraries/lia.color.md
@@ -1,31 +1,22 @@
 # Color Library
 
-
 This page lists helper functions for working with colors.
 
-
 ---
-
 
 ## Overview
 
-
 The color library centralizes color utilities used throughout the UI. You can register reusable colors, adjust their channels to create variants, and fetch the main palette from the configuration.
 
-
 ---
-
 
 ### lia.color.register(name, color)
 
 **Description:**
 
-
 Registers a named color for later lookup.
 
-
 **Parameters:**
-
 
 * name (string) – Key used to reference the color.
 
@@ -35,38 +26,30 @@ Registers a named color for later lookup.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.color.register
     lia.color.register("myRed", Color(255,0,0))
 ```
 
-
 ---
-
 
 ### lia.color.Adjust(color, rOffset, gOffset, bOffset, aOffset)
 
 **Description:**
 
-
 Creates a new color by applying offsets to each channel.
 
-
 **Parameters:**
-
 
 * color (Color) – Base color.
 
@@ -85,59 +68,47 @@ Creates a new color by applying offsets to each channel.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * Color – Adjusted color.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.color.Adjust
     local lighter = lia.color.Adjust(Color(50,50,50), 10,10,10)
 ```
 
-
 ---
-
 
 ### lia.color.ReturnMainAdjustedColors()
 
 **Description:**
 
-
 Returns a table of commonly used UI colors derived from the base config color.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – Mapping of UI color keys to Color objects.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.color.ReturnMainAdjustedColors
     local uiColors = lia.color.ReturnMainAdjustedColors()
 ```
-

--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -1,28 +1,20 @@
 # Commands Library
 
-
 This page documents command registration and execution.
-
 
 ---
 
-
 ## Overview
 
-
 The commands library registers console and chat commands. It parses arguments, checks permissions, and routes the handlers for execution. Commands can be run via slash chat or the console and may be restricted to specific usergroups through a CAMI-compliant admin mod.
-
 
 ### lia.command.add(command, data)
 
 **Description:**
 
-
 Registers a new command with its associated data.
 
-
 **Parameters:**
-
 
 * command (string) – Command name.
 
@@ -32,34 +24,27 @@ Registers a new command with its associated data.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- TODO
 ```
-
 
 ### lia.command.hasAccess(client, command, data)
 
 **Description:**
 
-
 Determines if a player may run the specified command.
 
-
 **Parameters:**
-
 
 * client (Player) – Command caller.
 
@@ -72,12 +57,10 @@ Determines if a player may run the specified command.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * boolean – Whether access is granted.
 
@@ -87,42 +70,34 @@ Determines if a player may run the specified command.
 
 **Example Usage:**
 
-
 ```lua
     -- TODO
 ```
-
 
 ### lia.command.extractArgs
 
 **Description:**
 
-
 Splits the provided text into arguments, respecting quotes.
 
 Quoted sections are treated as single arguments.
 
-
 **Parameters:**
-
 
 * text (string) – The raw input text to parse.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – A list of arguments extracted from the text.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.command.extractArgs
@@ -130,34 +105,27 @@ Quoted sections are treated as single arguments.
     -- args = {"quoted arg", "anotherArg"}
 ```
 
-
 ---
-
 
 ### lia.command.parseSyntaxFields
 
 **Description:**
 
-
 Parses a command syntax string into an ordered list of field tables.
 
 Each field contains a name and a type derived from the syntax.
 
-
 **Parameters:**
-
 
 * syntax (string) – The syntax string, e.g. "[string Name] [number Time]".
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – List of fields in call order.
 
@@ -167,28 +135,22 @@ Each field contains a name and a type derived from the syntax.
 
 **Example Usage:**
 
-
 ```lua
     -- Extract field data from a syntax string
     local fields, valid = lia.command.parseSyntaxFields("[string Name] [number Time]")
 ```
 
-
 ---
-
 
 ### lia.command.run
 
 **Description:**
 
-
 Executes a command by its name, passing the provided arguments.
 
 If the command returns a string, it notifies the client (if valid).
 
-
 **Parameters:**
-
 
 * client (Player) – The player or console running the command.
 
@@ -201,18 +163,15 @@ If the command returns a string, it notifies the client (if valid).
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- Execute the "boost" command when a player types !boost in chat
@@ -225,22 +184,17 @@ If the command returns a string, it notifies the client (if valid).
     end)
 ```
 
-
 ---
-
 
 ### lia.command.parse
 
 **Description:**
 
-
 Attempts to parse the input text as a command, optionally using realCommand
 
 and arguments if provided. If parsed successfully, the command is executed.
 
-
 **Parameters:**
-
 
 * client (Player) – The player or console issuing the command.
 
@@ -256,40 +210,32 @@ and arguments if provided. If parsed successfully, the command is executed.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – True if the text was parsed as a valid command, false otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.command.parse
     lia.command.parse(player, "/mycommand arg1 arg2")
 ```
 
-
 ---
-
 
 ### lia.command.send
 
 **Description:**
 
-
 Sends a command (and optional arguments) from the client to the server using the
 
 Garry's Mod net library. The server will then execute the command.
 
-
 **Parameters:**
-
 
 * command (string) – The name of the command to send.
 
@@ -299,32 +245,26 @@ Garry's Mod net library. The server will then execute the command.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.command.send
     lia.command.send("mycommand", "arg1", "arg2")
 ```
 
-
 ---
-
 
 ### lia.command.openArgumentPrompt
 
 **Description:**
-
 
 Opens a window asking the player to fill in arguments for the given command. If only
 
@@ -334,9 +274,7 @@ requested. Passing existing arguments causes the prompt to request only the miss
 
 ones.
 
-
 **Parameters:**
-
 
 * cmd (string) – The command name.
 
@@ -351,20 +289,16 @@ missing fields from the server.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- TODO
 ```
-

--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -1,31 +1,22 @@
 # Config Library
 
-
 This page explains how to add and access configuration settings.
 
-
 ---
-
 
 ## Overview
 
-
 The config library stores server configuration values with descriptions and default settings. It also provides callbacks when values change so modules can react to new options.
 
-
 ---
-
 
 ### lia.config.add(key, name, value, callback, data)
 
 **Description:**
 
-
 Registers a new config option with the given key, display name, default value, and optional callback/data.
 
-
 **Parameters:**
-
 
 * key (string) — The unique key identifying the config.
 
@@ -44,18 +35,15 @@ Registers a new config option with the given key, display name, default value, a
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- Register a config option with a callback that prints when it changes
@@ -70,20 +58,15 @@ Registers a new config option with the given key, display name, default value, a
     )
 ```
 
-
 ---
-
 
 ### lia.config.setDefault(key, value)
 
 **Description:**
 
-
 Overrides the default value of an existing config.
 
-
 **Parameters:**
-
 
 * key (string) — The key identifying the config.
 
@@ -93,38 +76,30 @@ Overrides the default value of an existing config.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.setDefault
     lia.config.setDefault("maxPlayers", 32)
 ```
 
-
 ---
-
 
 ### lia.config.forceSet(key, value, noSave)
 
 **Description:**
 
-
 Forces a config value without triggering networking or callback if 'noSave' is true, then optionally saves.
 
-
 **Parameters:**
-
 
 * key (string) — The key identifying the config.
 
@@ -137,38 +112,30 @@ Forces a config value without triggering networking or callback if 'noSave' is t
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.forceSet
     lia.config.forceSet("someSetting", true, true)
 ```
 
-
 ---
-
 
 ### lia.config.set(key, value)
 
 **Description:**
 
-
 Sets a config value, runs callback, and handles networking (if on server). Also saves the config.
 
-
 **Parameters:**
-
 
 * key (string) — The key identifying the config.
 
@@ -178,38 +145,30 @@ Sets a config value, runs callback, and handles networking (if on server). Also 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.set
     lia.config.set("maxPlayers", 24)
 ```
 
-
 ---
-
 
 ### lia.config.get(key, default)
 
 **Description:**
 
-
 Retrieves the current value of a config, or returns a default if neither value nor default is set.
 
-
 **Parameters:**
-
 
 * key (string) — The key identifying the config.
 
@@ -219,46 +178,37 @@ Retrieves the current value of a config, or returns a default if neither value n
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * (any) The config's value or the provided default.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.get
     local players = lia.config.get("maxPlayers", 64)
 ```
 
-
 ---
-
 
 ### lia.config.load()
 
 **Description:**
 
-
 Loads the config data from storage (server-side) and updates the stored config values.
 
 Triggers "InitializedConfig" hook once done.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
-
 
 * Shared
 
@@ -267,132 +217,104 @@ Triggers "InitializedConfig" hook once done.
 
     true
 
-
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.config.load
     lia.config.load()
 ```
 
-
 ---
-
 
 ### lia.config.getChangedValues()
 
 **Description:**
 
-
 Returns a table of all config entries where the current value differs from the default.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * (table) Key-value pairs of changed config entries.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.getChangedValues
     local changed = lia.config.getChangedValues()
 ```
 
-
 ---
-
 
 ### lia.config.send(client)
 
 **Description:**
 
-
 Sends current changed config values to a specified client.
 
-
 **Parameters:**
-
 
 * client (player) — The player to receive the config data.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.config.send
     lia.config.send(client)
 ```
 
-
 ---
-
 
 ### lia.config.save()
 
 **Description:**
 
-
 Saves all changed config values to persistent storage.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.config.save
     lia.config.save()
 ```
-

--- a/docs/docs/libraries/lia.currency.md
+++ b/docs/docs/libraries/lia.currency.md
@@ -1,25 +1,18 @@
 # Currency Library
 
-
 This page covers money and currency related helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The currency library formats money amounts and converts between numeric and display representations. It stores the currency symbol and helps with cost calculations.
 
-
 ---
-
 
 ### lia.currency.get
 
 **Description:**
-
 
 Formats a numeric amount into a currency string using the defined symbol,
 
@@ -27,49 +20,39 @@ singular, and plural names. If the amount is exactly 1, it returns the singular
 
 form; otherwise, it returns the plural form.
 
-
 **Parameters:**
-
 
 * amount (number) – The amount to format.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – The formatted currency string.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.currency.get
     lia.currency.get(10)  -- e.g., "$10 dollars"
 ```
 
-
 ---
-
 
 ### lia.currency.spawn
 
 **Description:**
 
-
 Spawns a currency entity at the specified position with a given amount and optional angle.
 
 Validates the position and ensures the amount is a non-negative number.
 
-
 **Parameters:**
-
 
 * pos (Vector) – The spawn position for the currency entity.
 
@@ -82,21 +65,17 @@ Validates the position and ensures the amount is a non-negative number.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * Entity – The spawned currency entity if successful; nil otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.currency.spawn
     lia.currency.spawn(Vector(0, 0, 0), 100)
 ```
-

--- a/docs/docs/libraries/lia.darkrp.md
+++ b/docs/docs/libraries/lia.darkrp.md
@@ -1,33 +1,24 @@
 # DarkRP Compatibility
 
-
 This page describes helpers for integrating with DarkRP.
 
-
 ---
-
 
 ## Overview
 
-
 The darkrp library bridges functionality with the DarkRP gamemode. It offers helper checks and wrappers to maintain compatibility when running Lilia alongside DarkRP.
 
-
 ---
-
 
 ### lia.darkrp.isEmpty(position, entitiesToIgnore)
 
 **Description:**
 
-
 Checks whether the specified position is free from players, NPCs,
 
 and props.
 
-
 **Parameters:**
-
 
 * position (Vector) – World position to test.
 
@@ -37,18 +28,15 @@ and props.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – True if the position is clear, false otherwise.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.isEmpty
@@ -57,20 +45,15 @@ and props.
     end
 ```
 
-
 ---
-
 
 ### lia.darkrp.findEmptyPos(startPos, entitiesToIgnore, maxDistance, searchStep, checkArea)
 
 **Description:**
 
-
 Finds a nearby position that is unobstructed by players or props.
 
-
 **Parameters:**
-
 
 * startPos (Vector) – The initial position to search from.
 
@@ -89,40 +72,32 @@ Finds a nearby position that is unobstructed by players or props.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * Vector – A position considered safe for spawning.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.findEmptyPos
     local pos = lia.darkrp.findEmptyPos(Vector(0,0,0), nil, 128, 16, Vector(0,0,32))
 ```
 
-
 ---
-
 
 ### lia.darkrp.notify(client, _, _, message)
 
 **Description:**
 
-
 Forwards a notification message to the given client using
 
 lia's notify system.
 
-
 **Parameters:**
-
 
 * client (Player) – The player to receive the message.
 
@@ -132,40 +107,32 @@ lia's notify system.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.notify
     lia.darkrp.notify(player.GetAll()[1], nil, nil, "Hello!")
 ```
 
-
 ---
-
 
 ### lia.darkrp.textWrap(text, fontName, maxLineWidth)
 
 **Description:**
 
-
 Wraps a text string so that it fits within the specified width
 
 when drawn with the given font.
 
-
 **Parameters:**
-
 
 * text (string) – The text to wrap.
 
@@ -178,78 +145,62 @@ when drawn with the given font.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * string – The wrapped text with newline characters inserted.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.textWrap
     local wrapped = lia.darkrp.textWrap("Some very long text", "DermaDefault", 150)
 ```
 
-
 ---
-
 
 ### lia.darkrp.formatMoney(amount)
 
 **Description:**
 
-
 Converts a numeric amount to a formatted currency string.
 
-
 **Parameters:**
-
 
 * amount (number) – The value of money to format.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – The formatted currency value.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of print
     print(lia.darkrp.formatMoney(2500))
 ```
 
-
 ---
-
 
 ### lia.darkrp.createEntity(name, data)
 
 **Description:**
 
-
 Registers a new DarkRP entity as an item so that it can be spawned
 
 through lia's item system.
 
-
 **Parameters:**
-
 
 * name (string) – Display name of the entity.
 
@@ -262,59 +213,47 @@ through lia's item system.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.createEntity
     lia.darkrp.createEntity("Fuel", {model = "models/props_c17/oildrum001.mdl", price = 50})
 ```
 
-
 ---
-
 
 ### lia.darkrp.createCategory()
 
 **Description:**
 
-
 Placeholder for DarkRP category creation. Currently unused.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.darkrp.createCategory
     lia.darkrp.createCategory()
 ```
-

--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -1,25 +1,18 @@
 # Data Library
 
-
 This page describes persistent data storage helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The data library persists key/value pairs either on disk or through the database backend. It supplies convenience methods for saving, retrieving, and deleting stored data.
 
-
 ---
-
 
 ### lia.data.set(key, value, global, ignoreMap)
 
 **Description:**
-
 
 Saves the provided value under the specified key to persistent storage.
 
@@ -27,9 +20,7 @@ The data is written to a file whose path is constructed based on the folder, map
 
 Also caches the value in lia.data.stored.
 
-
 **Parameters:**
-
 
 * key (string) – The key under which the data is stored.
 
@@ -45,18 +36,15 @@ Also caches the value in lia.data.stored.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – The path where the data was saved.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Save the admin's position as the global spawn point with a command
@@ -67,22 +55,17 @@ Also caches the value in lia.data.stored.
     end)
 ```
 
-
 ---
-
 
 ### lia.data.delete(key, global, ignoreMap)
 
 **Description:**
 
-
 Deletes the stored data file corresponding to the specified key.
 
 Also removes the value from the cached storage.
 
-
 **Parameters:**
-
 
 * key (string) – The key corresponding to the data to be deleted.
 
@@ -95,32 +78,26 @@ Also removes the value from the cached storage.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * boolean – True if the file was deleted, false otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.data.delete
     lia.data.delete("spawn_pos")
 ```
 
-
 ---
-
 
 ### lia.data.get(key, default, global, ignoreMap, refresh)
 
 **Description:**
-
 
 Retrieves the stored data for the specified key.
 
@@ -128,9 +105,7 @@ If refresh is not set and data exists in cache, returns the cached data.
 
 Otherwise, reads from the file, decodes, and caches the value.
 
-
 **Parameters:**
-
 
 * key (string) – The key corresponding to the data.
 
@@ -149,18 +124,15 @@ Otherwise, reads from the file, decodes, and caches the value.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any – The stored value, or the default if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Teleport players to the saved spawn point when they spawn
@@ -171,4 +143,3 @@ Otherwise, reads from the file, decodes, and caches the value.
         end
     end)
 ```
-

--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -1,25 +1,18 @@
 # Database Library
 
-
 This page documents functions for connecting to the database.
 
-
 ---
-
 
 ## Overview
 
-
 The database library sets up the SQL connection used by the framework. It defines helpers for creating tables, performing queries, and waiting for asynchronous operations to finish.
 
-
 ---
-
 
 ### lia.db.connect(callback, reconnect)
 
 **Description:**
-
 
 Establishes a connection to the configured database module. If the database
 
@@ -27,9 +20,7 @@ is not already connected or if reconnect is true, it will initiate a new connect
 
 or re-establish one.
 
-
 **Parameters:**
-
 
 * callback (function) – The function to call when the database connection is established.
 
@@ -39,18 +30,15 @@ or re-establish one.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.connect
@@ -59,40 +47,32 @@ or re-establish one.
     end)
 ```
 
-
 ---
-
 
 ### lia.db.wipeTables(callback)
 
 **Description:**
 
-
 Wipes all Lilia data tables from the database, dropping the specified
 
 tables. This action is irreversible and will remove all stored data.
 
-
 **Parameters:**
-
 
 * callback (function) – The function to call when the wipe operation is completed.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.wipeTables
@@ -101,80 +81,64 @@ tables. This action is irreversible and will remove all stored data.
     end)
 ```
 
-
 ---
-
 
 ### lia.db.loadTables()
 
 **Description:**
 
-
 Creates the required database tables if they do not already exist for
 
 storing Lilia data. This ensures the schema is properly set up.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.loadTables
     lia.db.loadTables()
 ```
 
-
 ---
-
 
 ### lia.db.waitForTablesToLoad()
 
 **Description:**
 
-
 Returns a deferred object that resolves once the database tables are fully loaded.
 
 This allows asynchronous code to wait for table creation before proceeding.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * deferred – Resolves when the tables are loaded.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.waitForTablesToLoad
@@ -183,14 +147,11 @@ This allows asynchronous code to wait for table creation before proceeding.
     end)
 ```
 
-
 ---
-
 
 ### lia.db.convertDataType(value, noEscape)
 
 **Description:**
-
 
 Converts a Lua value into a string suitable for database insertion,
 
@@ -198,9 +159,7 @@ handling strings, tables, and NULL values. Escaping is optionally applied
 
 unless noEscape is set.
 
-
 **Parameters:**
-
 
 * value (any) – The value to be converted.
 
@@ -210,40 +169,32 @@ unless noEscape is set.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – The converted data type as a string.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.db.convertDataType
     local str = lia.db.convertDataType({name = "Lilia"})
 ```
 
-
 ---
-
 
 ### lia.db.insertTable(value, callback, dbTable)
 
 **Description:**
 
-
 Inserts a new row into the specified database table with the given key-value pairs.
 
 The callback is invoked after the insert query is complete.
 
-
 **Parameters:**
-
 
 * value (table) – Key-value pairs representing the columns and values to insert.
 
@@ -256,18 +207,15 @@ The callback is invoked after the insert query is complete.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.insertTable
@@ -276,22 +224,17 @@ The callback is invoked after the insert query is complete.
     end, "characters")
 ```
 
-
 ---
-
 
 ### lia.db.updateTable(value, callback, dbTable, condition)
 
 **Description:**
 
-
 Updates one or more rows in the specified database table according to the
 
 provided condition. The callback is invoked once the update query finishes.
 
-
 **Parameters:**
-
 
 * value (table) – Key-value pairs representing columns to update and their new values.
 
@@ -307,18 +250,15 @@ provided condition. The callback is invoked once the update query finishes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.updateTable
@@ -327,14 +267,11 @@ provided condition. The callback is invoked once the update query finishes.
     end, "characters", "id = 1")
 ```
 
-
 ---
-
 
 ### lia.db.select(fields, dbTable, condition, limit)
 
 **Description:**
-
 
 Retrieves rows from the specified database table, optionally filtered by
 
@@ -342,9 +279,7 @@ a condition and limited to a specified number of results. Returns a deferred
 
 object that resolves with the query results.
 
-
 **Parameters:**
-
 
 * fields (table|string) – The columns to select, either as a table or a comma-separated string.
 
@@ -360,18 +295,15 @@ object that resolves with the query results.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * deferred – Resolves with query results and last insert ID.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.select
@@ -380,14 +312,11 @@ object that resolves with the query results.
     end)
 ```
 
-
 ---
-
 
 ### lia.db.upsert(value, dbTable)
 
 **Description:**
-
 
 Inserts or updates a row in the specified database table. If a row with
 
@@ -395,9 +324,7 @@ the same unique key exists, it updates it; otherwise, it inserts a new row.
 
 Returns a deferred object that resolves when the operation completes.
 
-
 **Parameters:**
-
 
 * value (table) – Key-value pairs representing the columns and values.
 
@@ -407,40 +334,32 @@ Returns a deferred object that resolves when the operation completes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * deferred – Resolves to a table of results and last insert ID.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.db.upsert
     lia.db.upsert({id = 1, name = "John"}, "characters")
 ```
 
-
 ---
-
 
 ### lia.db.delete(dbTable, condition)
 
 **Description:**
 
-
 Deletes rows from the specified database table that match the provided condition.
 
 If no condition is specified, all rows are deleted. Returns a deferred object.
 
-
 **Parameters:**
-
 
 * dbTable (string) – The name of the table (without the 'lia_' prefix).
 
@@ -450,18 +369,15 @@ If no condition is specified, all rows are deleted. Returns a deferred object.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * deferred – Resolves to the results of the deletion.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.delete
@@ -470,43 +386,34 @@ If no condition is specified, all rows are deleted. Returns a deferred object.
     end)
 ```
 
-
 ---
-
 
 ### lia.db.GetCharacterTable(callback)
 
 **Description:**
 
-
 Fetches a list of column names from the ``lia_characters`` table.
 
 This is useful for debugging or database maintenance tasks.
 
-
 **Parameters:**
-
 
 * callback (function) – Function executed with the table of column names.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.db.GetCharacterTable
     lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)
 ```
-

--- a/docs/docs/libraries/lia.factions.md
+++ b/docs/docs/libraries/lia.factions.md
@@ -1,25 +1,18 @@
 # Factions Library
 
-
 This page covers the faction system helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The factions library loads faction definitions and stores them for later lookup. It provides functions to find factions by index or name and to iterate all faction data.
 
-
 ---
-
 
 ### lia.faction.loadFromDir
 
 **Description:**
-
 
 Loads all Lua faction files (*.lua) from the specified directory,
 
@@ -27,237 +20,187 @@ includes them as shared files, and registers the factions.
 
 Each faction file should define a FACTION table with properties such as name, desc, color, etc.
 
-
 **Parameters:**
-
 
 * directory (string) – The path to the directory containing faction files.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.loadFromDir
     lia.faction.loadFromDir("path/to/factions")
 ```
 
-
 ---
-
 
 ### lia.faction.get
 
 **Description:**
 
-
 Retrieves a faction by its index or unique identifier.
 
-
 **Parameters:**
-
 
 * identifier (number or string) – The faction's index or unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table|nil – The faction table if found; nil otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.get
     local faction = lia.faction.get("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.getIndex
 
 **Description:**
 
-
 Retrieves the index of a faction by its unique identifier.
 
-
 **Parameters:**
-
 
 * uniqueID (string) – The unique identifier of the faction.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * number|nil – The faction index if found; nil otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getIndex
     local index = lia.faction.getIndex("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.getClasses
 
 **Description:**
 
-
 Retrieves a list of classes associated with the specified faction.
 
-
 **Parameters:**
-
 
 * faction (string) – The faction unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – A table containing class tables that belong to the faction.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getClasses
     local classes = lia.faction.getClasses("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.getPlayers
 
 **Description:**
 
-
 Retrieves all player entities whose characters belong to the specified faction.
 
-
 **Parameters:**
-
 
 * faction (string) – The faction unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – A table of player entities in the faction.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getPlayers
     local players = lia.faction.getPlayers("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.getPlayerCount
 
 **Description:**
 
-
 Counts the number of players whose characters belong to the specified faction.
 
-
 **Parameters:**
-
 
 * faction (string) – The faction unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * number – The number of players in the faction.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getPlayerCount
     local count = lia.faction.getPlayerCount("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.isFactionCategory
 
 **Description:**
 
-
 Checks if the specified faction is a member of a given category.
 
-
 **Parameters:**
-
 
 * faction (string) – The faction unique identifier.
 
@@ -267,32 +210,26 @@ Checks if the specified faction is a member of a given category.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * boolean – True if the faction is in the category; false otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.isFactionCategory
     local isMember = lia.faction.isFactionCategory("citizen", {"citizen", "veteran"})
 ```
 
-
 ---
-
 
 ### lia.faction.jobGenerate
 
 **Description:**
-
 
 Generates a new faction (job) based on provided parameters.
 
@@ -300,9 +237,7 @@ Creates a faction table with index, name, description, color, models, and regist
 
 Pre-caches the faction models.
 
-
 **Parameters:**
-
 
 * index (number) – The team index for the faction.
 
@@ -321,118 +256,94 @@ Pre-caches the faction models.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – The newly generated faction table.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.jobGenerate
     local faction = lia.faction.jobGenerate(2, "Police", Color(0, 0, 255), false, {"models/player/police.mdl"})
 ```
 
-
 ---
-
 
 ### lia.faction.formatModelData
 
 **Description:**
 
-
 Processes and formats model data for all registered factions.
 
 Iterates through each faction's model data and applies formatting to ensure proper grouping.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.formatModelData
     lia.faction.formatModelData()
 ```
 
-
 ---
-
 
 ### lia.faction.getCategories
 
 **Description:**
 
-
 Retrieves a list of model categories for a given faction.
 
 Categories are determined by keys in the faction's models table that are strings.
 
-
 **Parameters:**
-
 
 * teamName (string) – The unique identifier of the faction.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – A list of category names.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getCategories
     local categories = lia.faction.getCategories("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.getModelsFromCategory
 
 **Description:**
 
-
 Retrieves models from a specified category for a given faction.
 
-
 **Parameters:**
-
 
 * teamName (string) – The unique identifier of the faction.
 
@@ -442,101 +353,81 @@ Retrieves models from a specified category for a given faction.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – A table of models in the specified category.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getModelsFromCategory
     local models = lia.faction.getModelsFromCategory("citizen", "special")
 ```
 
-
 ---
-
 
 ### lia.faction.getDefaultClass
 
 **Description:**
 
-
 Retrieves the default class for a specified faction.
 
 Searches through the class list for the first class that is marked as default for the faction.
 
-
 **Parameters:**
-
 
 * id (string) – The unique identifier of the faction.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table|nil – The default class table if found; nil otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.getDefaultClass
     local defaultClass = lia.faction.getDefaultClass("citizen")
 ```
 
-
 ---
-
 
 ### lia.faction.hasWhitelist
 
 **Description:**
 
-
 Determines if the local player has whitelist access for a given faction.
 
 Checks the local whitelist data against the faction's uniqueID.
 
-
 **Parameters:**
-
 
 * faction (string) – The unique identifier of the faction.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * boolean – True if the player is whitelisted; false otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.faction.hasWhitelist
     local whitelisted = lia.faction.hasWhitelist("citizen")
 ```
-

--- a/docs/docs/libraries/lia.flags.md
+++ b/docs/docs/libraries/lia.flags.md
@@ -1,32 +1,24 @@
 # Flags Library
 
-
 This page explains permission flag management.
-
 
 ---
 
-
 ## Overview
-
 
 The flags library assigns text-based permission flags to players. It offers tools for checking whether a player possesses a flag and for saving or loading flag data. Flags grant characters extra abilities but are often best replaced with in-character checks when possible.
 
 ---
 
-
 ### lia.flag.add
 
 **Description:**
-
 
 Registers a new flag by adding it to the flag list.
 
 Each flag has a description and an optional callback that is executed when the flag is applied to a player.
 
-
 **Parameters:**
-
 
 * flag (string) – The unique flag identifier.
 
@@ -39,61 +31,49 @@ Each flag has a description and an optional callback that is executed when the f
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.flag.add
     lia.flag.add("C", "Spawn vehicles.")
 ```
 
-
 ---
-
 
 ### lia.flag.onSpawn
 
 **Description:**
 
-
 Called when a player spawns. This function checks the player's character flags and triggers
 
 the associated callbacks for each flag that the character possesses.
 
-
 **Parameters:**
-
 
 * client (Player) – The player who spawned.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.flag.onSpawn
     lia.flag.onSpawn(player)
 ```
-

--- a/docs/docs/libraries/lia.fonts.md
+++ b/docs/docs/libraries/lia.fonts.md
@@ -1,31 +1,22 @@
 # Fonts Library
 
-
 This page lists utilities for creating fonts.
 
-
 ---
-
 
 ## Overview
 
-
 The fonts library wraps surface.CreateFont for commonly used fonts. It reduces duplication by registering fonts once and allowing them to be recalled by name.
 
-
 ---
-
 
 ### lia.font.register(fontName, fontData)
 
 **Description:**
 
-
 Creates and stores a font using surface.CreateFont for later refresh.
 
-
 **Parameters:**
-
 
 * fontName (string) – Font identifier.
 
@@ -35,56 +26,45 @@ Creates and stores a font using surface.CreateFont for later refresh.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.font.register
     lia.font.register("MyFont", {font = "Arial", size = 16})
 ```
 
-
 ---
-
 
 ### lia.font.getAvailableFonts()
 
 **Description:**
 
-
 Returns a sorted list of font names that have been registered.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table – Array of font name strings.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.font.getAvailableFonts
@@ -92,41 +72,32 @@ Returns a sorted list of font names that have been registered.
     PrintTable(fonts)
 ```
 
-
 ---
-
 
 ### lia.font.refresh()
 
 **Description:**
 
-
 Recreates all stored fonts. Called when font related config values change.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.font.refresh
     lia.font.refresh()
 ```
-

--- a/docs/docs/libraries/lia.inventory.md
+++ b/docs/docs/libraries/lia.inventory.md
@@ -1,31 +1,22 @@
 # Inventory Library
 
-
 This page documents inventory handling functions.
 
-
 ---
-
 
 ## Overview
 
-
 The inventory library manages item containers and grid inventories. It supports registering new inventory types and handles item transfers between them.
 
-
 ---
-
 
 ### lia.inventory.newType(typeID, invTypeStruct)
 
 **Description:**
 
-
 Registers a new inventory type.
 
-
 **Parameters:**
-
 
 * typeID (string) — unique identifier
 
@@ -35,325 +26,257 @@ Registers a new inventory type.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.newType
     lia.inventory.newType("bag", {className = "liaBag"})
 ```
 
-
 ---
-
 
 ### lia.inventory.new(typeID)
 
 **Description:**
 
-
 Instantiates a new inventory instance.
 
-
 **Parameters:**
-
 
 * typeID (string)
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.new
     local inv = lia.inventory.new("bag")
 ```
 
-
 ---
-
 
 ### lia.inventory.loadByID(id, noCache)
 
 **Description:**
 
-
 Loads an inventory by ID (cached or via custom loader).
 
-
 **Parameters:**
-
 
 * id (number), noCache? (boolean)
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * deferred
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.loadByID
     lia.inventory.loadByID(1):next(function(inv) print(inv) end)
 ```
 
-
 ---
-
 
 ### lia.inventory.loadFromDefaultStorage(id, noCache)
 
 **Description:**
 
-
 Default database loader.
 
-
 **Parameters:**
-
 
 * id (number), noCache? (boolean)
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * deferred
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.loadFromDefaultStorage
     lia.inventory.loadFromDefaultStorage(1)
 ```
 
-
 ---
-
 
 ### lia.inventory.instance(typeID, initialData)
 
 **Description:**
 
-
 Creates & persists a new inventory instance.
 
-
 **Parameters:**
-
 
 * typeID (string), initialData? (table)
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * deferred
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.instance
     lia.inventory.instance("bag", {charID = 1})
 ```
 
-
 ---
-
 
 ### lia.inventory.loadAllFromCharID(charID)
 
 **Description:**
 
-
 Loads all inventories for a character.
 
-
 **Parameters:**
-
 
 * charID (number)
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * deferred
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.loadAllFromCharID
     lia.inventory.loadAllFromCharID(client:getChar():getID())
 ```
 
-
 ---
-
 
 ### lia.inventory.deleteByID(id)
 
 **Description:**
 
-
 Deletes an inventory and its data.
 
-
 **Parameters:**
-
 
 * id (number)
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.deleteByID
     lia.inventory.deleteByID(1)
 ```
 
-
 ---
-
 
 ### lia.inventory.cleanUpForCharacter(character)
 
 **Description:**
 
-
 Destroys all inventories for a character.
 
-
 **Parameters:**
-
 
 * character
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.cleanUpForCharacter
     lia.inventory.cleanUpForCharacter(client:getChar())
 ```
 
-
 ---
-
 
 ### lia.inventory.show(inventory, parent)
 
 **Description:**
 
-
 Displays inventory UI client‑side.
 
-
 **Parameters:**
-
 
 * inventory, parent
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * Panel
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.inventory.show
     local panel = lia.inventory.show(inv)
 ```
-

--- a/docs/docs/libraries/lia.item.md
+++ b/docs/docs/libraries/lia.item.md
@@ -1,83 +1,64 @@
 # Item Library
 
-
 This page covers item definition helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The item library contains utilities for retrieving item definitions and creating new items. It also provides shared item methods used throughout the framework.
 
-
 ---
-
 
 ### lia.item.get
 
 **Description:**
 
-
 Retrieves an item definition by its identifier, checking both lia.item.base and lia.item.list.
 
-
 **Parameters:**
-
 
 * identifier (string) – The unique identifier of the item.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * The item table if found, otherwise nil.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.get
     local itemDef = lia.item.get("testItem")
 ```
 
-
 ---
-
 
 ### lia.item.getItemByID
 
 **Description:**
 
-
 Retrieves an item instance by its numeric item ID. Also determines whether it's in an inventory
 
 or in the world.
 
-
 **Parameters:**
-
 
 * itemID (number) – The numeric item ID.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * A table containing 'item' (the item object) and 'location' (the string location) if found,
 
@@ -87,7 +68,6 @@ or in the world.
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.getItemByID
     local result = lia.item.getItemByID(42)
@@ -96,38 +76,30 @@ or in the world.
     end
 ```
 
-
 ---
-
 
 ### lia.item.getInstancedItemByID
 
 **Description:**
 
-
 Retrieves the item instance table itself by its numeric ID without additional location info.
 
-
 **Parameters:**
-
 
 * itemID (number) – The numeric item ID.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * The item instance table if found, otherwise nil and an error message.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.getInstancedItemByID
@@ -137,38 +109,30 @@ Retrieves the item instance table itself by its numeric ID without additional lo
     end
 ```
 
-
 ---
-
 
 ### lia.item.getItemDataByID
 
 **Description:**
 
-
 Retrieves the 'data' table of an item instance by its numeric item ID.
 
-
 **Parameters:**
-
 
 * itemID (number) – The numeric item ID.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * The data table if found, otherwise nil and an error message.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.getItemDataByID
@@ -178,22 +142,17 @@ Retrieves the 'data' table of an item instance by its numeric item ID.
     end
 ```
 
-
 ---
-
 
 ### lia.item.load
 
 **Description:**
 
-
 Processes the item file path to generate a uniqueID, and calls lia.item.register
 
 to register the item. Used for loading items from directory structures.
 
-
 **Parameters:**
-
 
 * path (string) – The path to the Lua file for the item.
 
@@ -206,56 +165,45 @@ to register the item. Used for loading items from directory structures.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.load
     lia.item.load("items/base/sh_item_base.lua", nil, true)
 ```
 
-
 ---
-
 
 ### lia.item.isItem
 
 **Description:**
 
-
 Checks if the given object is recognized as an item (via isItem flag).
 
-
 **Parameters:**
-
 
 * object (any) – The object to check.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * true if the object is an item, false otherwise.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.isItem
@@ -265,38 +213,30 @@ Checks if the given object is recognized as an item (via isItem flag).
     end
 ```
 
-
 ---
-
 
 ### lia.item.getInv
 
 **Description:**
 
-
 Retrieves an inventory table by its ID from lia.item.inventories.
 
-
 **Parameters:**
-
 
 * id (number) – The ID of the inventory to retrieve.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * The inventory table if found, otherwise nil.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.getInv
@@ -306,22 +246,17 @@ Retrieves an inventory table by its ID from lia.item.inventories.
     end
 ```
 
-
 ---
-
 
 ### lia.item.register
 
 **Description:**
 
-
 Registers a new item or base item with a unique ID. This sets up the meta table
 
 and merges data from the specified base. Optionally includes the file if provided.
 
-
 **Parameters:**
-
 
 * uniqueID (string) – The unique identifier for the item.
 
@@ -340,80 +275,64 @@ and merges data from the specified base. Optionally includes the file if provide
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * The registered item table.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.register
     lia.item.register("special_item", "base_item", false, "path/to/item.lua")
 ```
 
-
 ---
-
 
 ### lia.item.loadFromDir
 
 **Description:**
 
-
 Loads item Lua files from a specified directory. Base items are loaded first,
 
 then any folders (with base_ prefix usage), and finally any loose Lua files.
 
-
 **Parameters:**
-
 
 * directory (string) – The path to the directory containing item files.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.loadFromDir
     lia.item.loadFromDir("lilia/gamemode/items")
 ```
 
-
 ---
-
 
 ### lia.item.new
 
 **Description:**
 
-
 Creates an item instance (not in the database) from a registered item definition.
 
 The new item is stored in lia.item.instances using the provided item ID.
 
-
 **Parameters:**
-
 
 * uniqueID (string) – The unique identifier of the item definition.
 
@@ -423,18 +342,15 @@ The new item is stored in lia.item.instances using the provided item ID.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * The newly created item instance.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.new
@@ -442,22 +358,17 @@ The new item is stored in lia.item.instances using the provided item ID.
     print(newItem.id) -- 101
 ```
 
-
 ---
-
 
 ### lia.item.registerInv
 
 **Description:**
 
-
 Registers an inventory type with a given width and height. The inventory type
 
 becomes accessible for creation or usage in the system.
 
-
 **Parameters:**
-
 
 * invType (string) – The inventory type name (identifier).
 
@@ -470,40 +381,32 @@ becomes accessible for creation or usage in the system.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.registerInv
     lia.item.registerInv("smallInv", 4, 4)
 ```
 
-
 ---
-
 
 ### lia.item.newInv
 
 **Description:**
 
-
 Asynchronously creates a new inventory (with a specific invType) and associates it
 
 with the given character owner. Once created, it syncs the inventory to the owner if online.
 
-
 **Parameters:**
-
 
 * owner (number) – The character ID who owns this inventory.
 
@@ -516,18 +419,15 @@ with the given character owner. Once created, it syncs the inventory to the owne
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None (asynchronous, uses a deferred internally).
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.newInv
@@ -536,22 +436,17 @@ with the given character owner. Once created, it syncs the inventory to the owne
     end)
 ```
 
-
 ---
-
 
 ### lia.item.createInv
 
 **Description:**
 
-
 Creates a new GridInv instance with a specified width, height, and ID,
 
 then caches it in lia.inventory.instances.
 
-
 **Parameters:**
-
 
 * w (number) – The width of the inventory.
 
@@ -564,18 +459,15 @@ then caches it in lia.inventory.instances.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * The newly created GridInv instance.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.createInv
@@ -583,22 +475,17 @@ then caches it in lia.inventory.instances.
     print("Created inventory with ID:", inv.id)
 ```
 
-
 ---
-
 
 ### lia.item.setItemDataByID
 
 **Description:**
 
-
 Sets a specific key-value in the data table of an item instance by its numeric ID.
 
 Optionally notifies receivers about the change.
 
-
 **Parameters:**
-
 
 * itemID (number) – The numeric item ID.
 
@@ -620,18 +507,15 @@ Optionally notifies receivers about the change.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * true if successful, false and error message if item not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.setItemDataByID
@@ -641,22 +525,17 @@ Optionally notifies receivers about the change.
     end
 ```
 
-
 ---
-
 
 ### lia.item.instance
 
 **Description:**
 
-
 Asynchronously creates a new item in the database, optionally assigned to an inventory.
 
 Once the item is created, a new item object is constructed and returned via a deferred.
 
-
 **Parameters:**
-
 
 * index (number) – The inventory ID to place the item into (or 0/NULL if none).
 
@@ -678,18 +557,15 @@ Once the item is created, a new item object is constructed and returned via a de
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * A deferred object that resolves to the new item.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.instance
@@ -698,78 +574,62 @@ Once the item is created, a new item object is constructed and returned via a de
     end)
 ```
 
-
 ---
-
 
 ### lia.item.deleteByID
 
 **Description:**
 
-
 Deletes an item from the system (database and memory) by its numeric ID.
 
-
 **Parameters:**
-
 
 * id (number) – The numeric item ID to delete.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.item.deleteByID
     lia.item.deleteByID(42)
 ```
 
-
 ---
-
 
 ### lia.item.loadItemByID
 
 **Description:**
 
-
 Loads items from the database by a given ID or set of IDs, creating the corresponding
 
 item instances in memory. This is commonly used during inventory or character loading.
 
-
 **Parameters:**
-
 
 * itemIndex (number or table) – Either a single numeric item ID or a table of numeric item IDs.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None (asynchronous query).
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.loadItemByID
@@ -778,22 +638,17 @@ item instances in memory. This is commonly used during inventory or character lo
     lia.item.loadItemByID({10, 11, 12})
 ```
 
-
 ---
-
 
 ### lia.item.spawn
 
 **Description:**
 
-
 Creates a new item instance (not in an inventory) and spawns a corresponding
 
 entity in the world at the specified position/angles.
 
-
 **Parameters:**
-
 
 * uniqueID (string) – The unique ID of the item definition.
 
@@ -812,18 +667,15 @@ entity in the world at the specified position/angles.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * A deferred object if callback is not given, otherwise none.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Spawn an item and use a callback to access the spawned entity
@@ -832,22 +684,17 @@ entity in the world at the specified position/angles.
     end)
 ```
 
-
 ---
-
 
 ### lia.item.restoreInv
 
 **Description:**
 
-
 Restores an existing inventory by loading it through lia.inventory.loadByID,
 
 then sets its width/height data, optionally providing a callback once loaded.
 
-
 **Parameters:**
-
 
 * invID (number) – The inventory ID to restore.
 
@@ -863,18 +710,15 @@ then sets its width/height data, optionally providing a callback once loaded.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None (asynchronous call).
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.item.restoreInv
@@ -882,4 +726,3 @@ then sets its width/height data, optionally providing a callback once loaded.
         print("Restored inventory with ID 101.")
     end)
 ```
-

--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -1,25 +1,18 @@
 # Keybind Library
 
-
 This page describes functions to register custom keybinds.
 
-
 ---
-
 
 ## Overview
 
-
 The keybind library stores user-defined keyboard bindings. It reads and writes keybind files and dispatches callbacks when the associated keys are pressed.
 
-
 ---
-
 
 ### lia.keybind.add(k, d, cb, rcb)
 
 **Description:**
-
 
 Registers a new keybind for a given action.
 
@@ -29,9 +22,7 @@ and stores the keybind settings including the default key, press callback, and r
 
 Also maps the key code back to the action identifier for reverse lookup.
 
-
 **Parameters:**
-
 
 * k (string or number) – The key identifier, either as a string (to be converted) or as a key code.
 
@@ -47,32 +38,26 @@ Also maps the key code back to the action identifier for reverse lookup.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.keybind.add
     lia.keybind.add("space", "jump", function() print("Jump pressed!") end, function() print("Jump released!") end)
 ```
 
-
 ---
-
 
 ### lia.keybind.get(a, df)
 
 **Description:**
-
 
 Retrieves the current key code for a specified keybind action.
 
@@ -80,9 +65,7 @@ If the keybind has a set value, that value is returned; otherwise, it falls back
 
 or an optionally provided fallback value.
 
-
 **Parameters:**
-
 
 * a (string) – The unique identifier for the keybind action.
 
@@ -92,32 +75,26 @@ or an optionally provided fallback value.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * number – The key code associated with the keybind action, or the default/fallback value if not set.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.keybind.get
     local jumpKey = lia.keybind.get("jump", KEY_SPACE)
 ```
 
-
 ---
-
 
 ### lia.keybind.save()
 
 **Description:**
-
 
 Saves the current keybind settings to a file.
 
@@ -125,15 +102,12 @@ The function creates a directory specific to the active gamemode, constructs a f
 
 and writes the keybind mapping (action identifiers to key codes) in JSON format.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
-
 
 * Client
 
@@ -142,29 +116,23 @@ and writes the keybind mapping (action identifiers to key codes) in JSON format.
 
     true
 
-
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.keybind.save
     lia.keybind.save()
 ```
 
-
 ---
-
 
 ### lia.keybind.load()
 
 **Description:**
-
 
 Loads keybind settings from a file.
 
@@ -176,15 +144,12 @@ It also sets up a reverse mapping from key codes to keybind action identifiers.
 
 Finally, it triggers the "InitializedKeybinds" hook.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
-
 
 * Client
 
@@ -193,18 +158,14 @@ Finally, it triggers the "InitializedKeybinds" hook.
 
     true
 
-
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.keybind.load
     lia.keybind.load()
 ```
-

--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -1,24 +1,18 @@
 # Languages Library
 
-
 This page explains how translations and phrases are loaded.
-
 
 ---
 
-
 ## Overview
-
 
 The languages library loads localization files from directories. It resolves phrase keys to translated text and allows runtime language switching. Language files live in `languages/langname.lua` within schemas or modules and contain tables of localized phrases.
 
 ---
 
-
 ### lia.lang.loadFromDir(directory)
 
 **Description:**
-
 
 Loads all Lua language files (*.lua) from the specified directory,
 
@@ -28,15 +22,12 @@ into the stored language data. If a language name (NAME) is provided in the file
 
 it is registered in lia.lang.names.
 
-
 **Parameters:**
-
 
 * directory (string) – The path to the directory containing language files.
 
 
 **Realm:**
-
 
 * Shared
 
@@ -45,29 +36,23 @@ it is registered in lia.lang.names.
 
     true
 
-
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.lang.loadFromDir
     lia.lang.loadFromDir("languages")
 ```
 
-
 ---
-
 
 ### lia.lang.AddTable(name, tbl)
 
 **Description:**
-
 
 Adds or merges a table of language key-value pairs into the stored language table
 
@@ -75,9 +60,7 @@ for a specified language. If the language already exists in the storage, the new
 
 will be merged with the existing ones.
 
-
 **Parameters:**
-
 
 * name (string) – The name of the language to update.
 
@@ -87,21 +70,17 @@ will be merged with the existing ones.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.lang.AddTable
     lia.lang.AddTable("english", {greeting = "Hello"})
 ```
-

--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -1,37 +1,27 @@
 # Logger Library
 
-
 This page documents logging utilities.
 
-
 ---
-
 
 ## Overview
 
-
 The logger library writes structured log entries to files and the console. It tracks important gameplay events for later auditing or debugging.
 
-
 ---
-
 
 ### lia.log.loadTables()
 
 **Description:**
 
-
 Creates the logs directory for the current active gamemode under "lilia/logs".
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
-
 
 * Server
 
@@ -40,37 +30,29 @@ Creates the logs directory for the current active gamemode under "lilia/logs".
 
     true
 
-
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.log.loadTables
     lia.log.loadTables()
 ```
 
-
 ---
-
 
 ### lia.log.addType(logType, func, category)
 
 **Description:**
 
-
 Registers a new log type by associating a log generating function and a category with the log type identifier.
 
 The registered function will be used later to generate log messages for that type.
 
-
 **Parameters:**
-
 
 * logType (string) – The unique identifier for the log type.
 
@@ -83,18 +65,15 @@ The registered function will be used later to generate log messages for that typ
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.log.addType
@@ -103,22 +82,17 @@ The registered function will be used later to generate log messages for that typ
     end, "actions")
 ```
 
-
 ---
-
 
 ### lia.log.getString(client, logType, ...)
 
 **Description:**
 
-
 Retrieves the log string and its associated category for a given client and log type.
 
 It calls the registered log function with the provided parameters.
 
-
 **Parameters:**
-
 
 * client (Player) – The client for which the log is generated.
 
@@ -131,7 +105,6 @@ It calls the registered log function with the provided parameters.
 
 **Realm:**
 
-
 * Server
 
 
@@ -139,37 +112,29 @@ It calls the registered log function with the provided parameters.
 
     true
 
-
 **Returns:**
-
 
 * string, string – The generated log string and its category if successful; otherwise, nil.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.log.getString
     local str, category = lia.log.getString(client, "mytype", "info")
 ```
 
-
 ---
-
 
 ### lia.log.add(client, logType, ...)
 
 **Description:**
 
-
 Generates a log string using the registered log type function, triggers the "OnServerLog" hook,
 
 and appends the log string to a log file corresponding to its category in the logs directory.
 
-
 **Parameters:**
-
 
 * client (Player) – The client associated with the log event.
 
@@ -182,21 +147,17 @@ and appends the log string to a log file corresponding to its category in the lo
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.log.add
     lia.log.add(client, "mytype", "info")
 ```
-

--- a/docs/docs/libraries/lia.markup.md
+++ b/docs/docs/libraries/lia.markup.md
@@ -1,25 +1,18 @@
 # Markup Library
 
-
 This page covers markup parsing helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The markup library parses a subset of HTML-like tags for drawing rich text in chat panels. It handles basic color, size, and font formatting.
 
-
 ---
-
 
 ### lia.markup.parse(text, maxwidth)
 
 **Description:**
-
 
 Parses the provided markup text and returns a markup object representing
 
@@ -27,9 +20,7 @@ the formatted content. When maxwidth is provided, the text will
 
 automatically wrap at that width.
 
-
 **Parameters:**
-
 
 * text (string) – String containing markup to be parsed.
 
@@ -39,21 +30,17 @@ automatically wrap at that width.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * MarkupObject – The parsed markup object with size information.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.markup.parse
     local object = lia.markup.parse("<color=255,0,0>Hello</color>", 200)
 ```
-

--- a/docs/docs/libraries/lia.md
+++ b/docs/docs/libraries/lia.md
@@ -1,31 +1,22 @@
 # Lia Core Library
 
-
 This page documents general utilities used throughout Lilia.
 
-
 ---
-
 
 ## Overview
 
-
 The lia core library exposes shared helper functions used across multiple modules. It primarily handles file inclusion logic and other small utilities.
 
-
 ---
-
 
 ### lia.include(fileName, state)
 
 **Description:**
 
-
 Includes a Lua file based on its realm. It determines the realm from the file name or provided state, and handles server/client inclusion logic.
 
-
 **Parameters:**
-
 
 * fileName (string) – The path to the Lua file.
 
@@ -35,38 +26,30 @@ Includes a Lua file based on its realm. It determines the realm from the file na
 
 **Realm:**
 
-
 * Depends on the file realm.
 
 
 **Returns:**
-
 
 * The result of the include, if applicable.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.include
     lia.include("lilia/gamemode/core/libraries/util.lua", "shared")
 ```
 
-
 ---
-
 
 ### lia.includeDir(directory, fromLua, recursive, realm)
 
 **Description:**
 
-
 Includes all Lua files in a specified directory. If recursive is true, it traverses subdirectories. It determines the base directory based on the active schema or gamemode.
 
-
 **Parameters:**
-
 
 * directory (string) – The directory path to include.
 
@@ -82,38 +65,30 @@ Includes all Lua files in a specified directory. If recursive is true, it traver
 
 **Realm:**
 
-
 * Depends on file inclusion.
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.includeDir
     lia.includeDir("lilia/gamemode/core/libraries/shared/thirdparty", true, true)
 ```
 
-
 ---
-
 
 ### lia.includeGroupedDir(dir, raw, recursive, forceRealm)
 
 **Description:**
 
-
 Recursively includes all Lua files in a specified directory, preserving alphabetical order within each folder. Determines each file’s realm by override or filename prefix, then calls lia.include on each file.
 
-
 **Parameters:**
-
 
 * dir        (string) – Directory path to load files from (relative if raw is false).
 
@@ -129,76 +104,60 @@ Recursively includes all Lua files in a specified directory, preserving alphabet
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.includeGroupedDir
     lia.includeGroupedDir("core/modules", false, true, "shared")
 ```
 
-
 ---
-
 
 ### lia.error(msg)
 
 **Description:**
 
-
 Prints a colored error message prefixed with "[Lilia]" to the console.
 
-
 **Parameters:**
-
 
 * msg (string) – Error text to display.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.error
     lia.error("Invalid configuration detected")
 ```
 
-
 ---
-
 
 ### lia.deprecated(methodName, callback)
 
 **Description:**
 
-
 Notifies that a method is deprecated and optionally runs a callback.
 
-
 **Parameters:**
-
 
 * methodName (string) – Name of the deprecated method.
 
@@ -208,114 +167,90 @@ Notifies that a method is deprecated and optionally runs a callback.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.deprecated
     lia.deprecated("OldFunction", function() print("Called fallback") end)
 ```
 
-
 ---
-
 
 ### lia.updater(msg)
 
 **Description:**
 
-
 Prints an updater message in cyan to the console with the Lilia prefix.
 
-
 **Parameters:**
-
 
 * msg (string) – Update text to display.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.updater
     lia.updater("Loading additional content...")
 ```
 
-
 ---
-
 
 ### lia.information(msg)
 
 **Description:**
 
-
 Prints an informational message with the Lilia prefix.
 
-
 **Parameters:**
-
 
 * msg (string) – Text to print to the console.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.information
     lia.information("Server started successfully")
 ```
 
-
 ---
-
 
 ### lia.bootstrap(section, msg)
 
 **Description:**
 
-
 Logs a bootstrap message with a colored section tag for clarity.
 
-
 **Parameters:**
-
 
 * section (string) – Category or stage of bootstrap.
 
@@ -325,59 +260,47 @@ Logs a bootstrap message with a colored section tag for clarity.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.bootstrap
     lia.bootstrap("Database", "Connection established")
 ```
 
-
 ---
-
 
 ### lia.includeEntities(path)
 
 **Description:**
 
-
 Includes entity files from the specified directory. It checks for standard entity files ("init.lua", "shared.lua", "cl_init.lua"), handles inclusion and registration of entities, weapons, tools, and effects, and supports recursive inclusion within entity folders.
 
-
 **Parameters:**
-
 
 * path (string) – The directory path containing entity files.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.includeEntities
     lia.includeEntities("lilia/entities")
 ```
-

--- a/docs/docs/libraries/lia.menu.md
+++ b/docs/docs/libraries/lia.menu.md
@@ -1,22 +1,16 @@
 # Menu Library
 
-
 This page describes small menu creation helpers.
-
 
 ---
 
-
 ## Overview
 
-
 The menu library offers convenience functions for building simple context menus. It supports nested options whose callbacks execute when selected and automatically positions the menu on screen.
-
 
 ### lia.menu.add(opts, pos, onRemove)
 
 **Description:**
-
 
 Creates a new world or entity menu using the entries provided in 'opts'.
 
@@ -26,9 +20,7 @@ selected. The menu may be positioned at a world Vector or anchored to
 
 an entity.
 
-
 **Parameters:**
-
 
 * opts (table) – Table of label/callback pairs.
 
@@ -41,92 +33,74 @@ an entity.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * number – Identifier for the created menu entry.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.menu.add
     lia.menu.add({["Hello"] = function() print("Hi") end})
 ```
 
-
 ---
-
 
 ### lia.menu.drawAll()
 
 **Description:**
 
-
 Draws all active menus on the player's screen. Typically called from
 
 HUDPaint.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of hook.Add
     hook.Add("HUDPaint", "DrawMenus", lia.menu.drawAll)
 ```
 
-
 ---
-
 
 ### lia.menu.getActiveMenu()
 
 **Description:**
 
-
 Returns the ID and callback of the menu item currently being hovered
 
 or selected by the player.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * id (number|nil) – Index of the active menu.
 
@@ -136,26 +110,20 @@ or selected by the player.
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.menu.getActiveMenu
     local id, callback = lia.menu.getActiveMenu()
 ```
 
-
 ---
-
 
 ### lia.menu.onButtonPressed(id, callback)
 
 **Description:**
 
-
 Removes the specified menu and runs its callback if provided.
 
-
 **Parameters:**
-
 
 * id (number) – Identifier returned by lia.menu.add.
 
@@ -165,21 +133,17 @@ Removes the specified menu and runs its callback if provided.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * boolean – True if a callback was executed.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.menu.onButtonPressed
     lia.menu.onButtonPressed(id)
 ```
-

--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -1,25 +1,18 @@
 # Modularity Library
 
-
 This page explains the module loading system.
 
-
 ---
-
 
 ## Overview
 
-
 The modularity library loads modules contained in the 'modules' folder. It resolves dependencies and initializes serverside and clientside components.
 
-
 ---
-
 
 ### lia.module.load
 
 **Description:**
-
 
 Loads a module from a specified path. If the module is a single file, it includes it directly;
 
@@ -27,9 +20,7 @@ if it is a directory, it loads the core file (or its extended version), applies 
 
 It also registers the module in the module list if applicable.
 
-
 **Parameters:**
-
 
 * uniqueID – The unique identifier of the module.
 
@@ -45,72 +36,58 @@ It also registers the module in the module list if applicable.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.module.load
     lia.module.load("example", "lilia/modules/example", false)
 ```
 
-
 ---
-
 
 ### lia.module.initialize
 
 **Description:**
 
-
 Initializes the module system by loading the schema and various module directories,
 
 then running the appropriate hooks after modules have been loaded.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.module.initialize
     lia.module.initialize()
 ```
 
-
 ---
-
 
 ### lia.module.loadFromDir
 
 **Description:**
-
 
 Loads modules from a specified directory. It iterates over all subfolders and .lua files in the directory.
 
@@ -118,9 +95,7 @@ Each subfolder is treated as a multi-file module, and each .lua file as a single
 
 Non-Lua files are ignored.
 
-
 **Parameters:**
-
 
 * directory – The directory path from which to load modules.
 
@@ -130,59 +105,47 @@ Non-Lua files are ignored.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.module.loadFromDir
     lia.module.loadFromDir("lilia/modules/core", "module")
 ```
 
-
 ---
-
 
 ### lia.module.get
 
 **Description:**
 
-
 Retrieves a module table by its identifier.
 
-
 **Parameters:**
-
 
 * identifier – The unique identifier of the module to retrieve.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * The module table if found, or nil if the module is not registered.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.module.get
     local mod = lia.module.get("schema")
 ```
-

--- a/docs/docs/libraries/lia.networking.md
+++ b/docs/docs/libraries/lia.networking.md
@@ -1,33 +1,24 @@
 # Networking Library
 
-
 This page documents network variable and message helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The networking library synchronizes data between the server and clients. It provides wrappers around net messages and networked variables.
 
-
 ---
-
 
 ### setNetVar(key, value, receiver)
 
 **Description:**
 
-
 Stores a global networked variable and broadcasts it to clients. When a
 
 receiver is specified the update is only sent to those players.
 
-
 **Parameters:**
-
 
 * key (string) – Name of the variable.
 
@@ -40,18 +31,15 @@ receiver is specified the update is only sent to those players.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- Start a new round and only inform the winner
@@ -62,20 +50,15 @@ receiver is specified the update is only sent to those players.
     hook.Run("RoundStarted", round)
 ```
 
-
 ---
-
 
 ### getNetVar(key, default)
 
 **Description:**
 
-
 Retrieves a global networked variable previously set by setNetVar.
 
-
 **Parameters:**
-
 
 * key (string) – Variable name.
 
@@ -85,18 +68,15 @@ Retrieves a global networked variable previously set by setNetVar.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any – Stored value or default.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Inform a joining player of the current round and last winner
@@ -108,4 +88,3 @@ Retrieves a global networked variable previously set by setNetVar.
         end
     end)
 ```
-

--- a/docs/docs/libraries/lia.notice.md
+++ b/docs/docs/libraries/lia.notice.md
@@ -1,31 +1,22 @@
 # Notice Library
 
-
 This page describes how popup notices are displayed.
 
-
 ---
-
 
 ## Overview
 
-
 The notice library displays temporary popup notifications at the top of the player's screen. Notices can be queued or targeted to specific players.
 
-
 ---
-
 
 ### lia.notices.notify(message, recipient)
 
 **Description:**
 
-
 Sends a notification message to a specific player or all players.
 
-
 **Parameters:**
-
 
 * message (string) – Message text to send.
 
@@ -35,38 +26,30 @@ Sends a notification message to a specific player or all players.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.notices.notify
     lia.notices.notify("Server restarting", nil)
 ```
 
-
 ---
-
 
 ### lia.notices.notifyLocalized(key, recipient, ...)
 
 **Description:**
 
-
 Sends a localized notification to a player or all players.
 
-
 **Parameters:**
-
 
 * key (string) – Localization key.
 
@@ -79,76 +62,60 @@ Sends a localized notification to a player or all players.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
     lia.notices.notifyLocalized("welcome", client)
 ```
 
-
 ---
-
 
 ### lia.notices.notify(message)
 
 **Description:**
 
-
 Creates a visual notification panel on the client's screen.
 
-
 **Parameters:**
-
 
 * message (string) – Message text to display.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.notices.notify
     lia.notices.notify("Item picked up")
 ```
 
-
 ---
-
 
 ### lia.notices.notifyLocalized(key, ...)
 
 **Description:**
 
-
 Displays a localized notification on the client's screen.
 
-
 **Parameters:**
-
 
 * key (string) – Localization key.
 
@@ -158,21 +125,17 @@ Displays a localized notification on the client's screen.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
     lia.notices.notifyLocalized("item_picked_up")
 ```
-

--- a/docs/docs/libraries/lia.option.md
+++ b/docs/docs/libraries/lia.option.md
@@ -1,30 +1,22 @@
 # Option Library
 
-
 This page details the client/server option system.
-
 
 ---
 
-
 ## Overview
-
 
 The option library stores user and server options with default values. It offers getters and setters that automatically network changes between client and server. Define options clientside with `lia.option.add` to make them available for networking and configuration.
 
 ---
 
-
 ### lia.option.add(key, name, desc, default, callback, data)
 
 **Description:**
 
-
 Adds a configuration option to the lia.option system.
 
-
 **Parameters:**
-
 
 * key (string) — The unique key for the option.
 
@@ -46,38 +38,30 @@ Adds a configuration option to the lia.option system.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.option.add
     lia.option.add("showHints", "Show Hints", "Display hints", true)
 ```
 
-
 ---
-
 
 ### lia.option.set(key, value)
 
 **Description:**
 
-
 Sets the value of a specified option, saves locally, and optionally networks to the server.
 
-
 **Parameters:**
-
 
 * key (string) — The unique key identifying the option.
 
@@ -87,38 +71,30 @@ Sets the value of a specified option, saves locally, and optionally networks to 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.option.set
     lia.option.set("showHints", false)
 ```
 
-
 ---
-
 
 ### lia.option.get(key, default)
 
 **Description:**
 
-
 Retrieves the value of a specified option, or returns a default if it doesn't exist.
 
-
 **Parameters:**
-
 
 * key (string) — The unique key identifying the option.
 
@@ -128,97 +104,77 @@ Retrieves the value of a specified option, or returns a default if it doesn't ex
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * (any) The current value of the option or the provided default.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.option.get
     local show = lia.option.get("showHints", true)
 ```
 
-
 ---
-
 
 ### lia.option.save()
 
 **Description:**
 
-
 Saves all current option values to a file, named based on the server IP, within the active gamemode folder.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.option.save
     lia.option.save()
 ```
 
-
 ---
-
 
 ### lia.option.load()
 
 **Description:**
 
-
 Loads saved option values from disk based on server IP and applies them to lia.option.stored.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.option.load
     lia.option.load()
 ```
-

--- a/docs/docs/libraries/lia.time.md
+++ b/docs/docs/libraries/lia.time.md
@@ -1,48 +1,37 @@
 # Time Library
 
-
 This page lists time and date utilities.
-
 
 ---
 
-
 ## Overview
-
 
 The time library handles date formatting and relative time conversions. It offers helper functions to compute durations such as "time since" or "time until" and uses a third-party date module to avoid the 1970 epoch limitation.
 
 ---
 
-
 ### lia.time.TimeSince
 
 **Description:**
 
-
 Returns a human-readable string indicating how long ago a given time occurred (e.g., "5 minutes ago").
 
-
 **Parameters:**
-
 
 * strTime (string or number) — The time in string or timestamp form.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * (string) The time since the given date/time in a readable format.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Greet players with the time since they last joined using persistence data
@@ -62,40 +51,32 @@ Returns a human-readable string indicating how long ago a given time occurred (e
     end)
 ```
 
-
 ---
-
 
 ### lia.time.toNumber
 
 **Description:**
 
-
 Converts a string timestamp (YYYY-MM-DD HH:MM:SS) to a table with numeric fields:
 
 year, month, day, hour, min, sec. Defaults to current time if not provided.
 
-
 **Parameters:**
-
 
 * str (string) — The time string to convert (optional).
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * (table) A table with numeric year, month, day, hour, min, sec.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Schedule an event at a custom date and time using the parsed table
@@ -108,14 +89,11 @@ year, month, day, hour, min, sec. Defaults to current time if not provided.
     end
 ```
 
-
 ---
-
 
 ### lia.time.GetDate
 
 **Description:**
-
 
 Returns the full current date and time formatted based on the
 
@@ -125,27 +103,22 @@ Returns the full current date and time formatted based on the
 
 • If disabled: "Weekday, DD Month YYYY, HH:MM:SS"
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * (string) Formatted date and time string.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Announce the current server date and time to all players every hour
@@ -157,14 +130,11 @@ Returns the full current date and time formatted based on the
     end)
 ```
 
-
 ---
-
 
 ### lia.time.GetHour
 
 **Description:**
-
 
 Returns the current hour formatted based on the
 
@@ -174,21 +144,17 @@ Returns the current hour formatted based on the
 
 • If disabled: H (0–23, 24-hour)
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * (string|number) Current hour string with suffix when AmericanTimeStamps
 
@@ -197,7 +163,6 @@ Returns the current hour formatted based on the
 
 
 **Example Usage:**
-
 
 ```lua
     -- Toggle an NPC's shop based on the in-game hour
@@ -208,4 +173,3 @@ Returns the current hour formatted based on the
     npc:SetNWBool("ShopOpen", false)
     end
 ```
-

--- a/docs/docs/libraries/lia.util.md
+++ b/docs/docs/libraries/lia.util.md
@@ -1,31 +1,22 @@
 # Utility Library
 
-
 This page documents miscellaneous helper functions.
 
-
 ---
-
 
 ## Overview
 
-
 The util library contains small miscellaneous helper functions used across modules. These include player searches, entity queries, and geometric calculations.
 
-
 ---
-
 
 ### lia.util.FindPlayersInBox
 
 **Description:**
 
-
 Finds and returns players located inside a world-space bounding box. Useful for quickly gathering clients within rectangular areas like rooms or zones.
 
-
 **Parameters:**
-
 
 * mins (Vector) – The minimum corner of the box.
 
@@ -35,18 +26,15 @@ Finds and returns players located inside a world-space bounding box. Useful for 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – A table of matching player entities.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Kick everyone hiding inside a restricted building
@@ -56,20 +44,15 @@ Finds and returns players located inside a world-space bounding box. Useful for 
     end
 ```
 
-
 ---
-
 
 ### lia.util.FindPlayersInSphere
 
 **Description:**
 
-
 Finds and returns a table of players within a given spherical radius from an origin.
 
-
 **Parameters:**
-
 
 * origin (Vector) — The center of the sphere.
 
@@ -79,18 +62,15 @@ Finds and returns a table of players within a given spherical radius from an ori
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of valid player entities.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.FindPlayersInSphere
@@ -100,20 +80,15 @@ Finds and returns a table of players within a given spherical radius from an ori
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayer
 
 **Description:**
 
-
 Attempts to find a player by identifier. The identifier can be STEAMID, SteamID64, "^" (self), "@" (looking at target), or partial name.
 
-
 **Parameters:**
-
 
 * client (Player) — The player requesting the find (used for notifications).
 
@@ -123,7 +98,6 @@ Attempts to find a player by identifier. The identifier can be STEAMID, SteamID6
 
 **Realm:**
 
-
 * Shared
 
 
@@ -131,15 +105,12 @@ Attempts to find a player by identifier. The identifier can be STEAMID, SteamID6
 
     lia.util.findPlayer
 
-
 **Returns:**
-
 
 * Player|nil — The found player, or nil if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Teleport an admin next to the found player by partial name
@@ -149,38 +120,30 @@ Attempts to find a player by identifier. The identifier can be STEAMID, SteamID6
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayerItems
 
 **Description:**
 
-
 Finds all item entities in the world created by the specified player.
 
-
 **Parameters:**
-
 
 * client (Player) — The player whose items to find.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of valid item entities.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findPlayerItems
@@ -190,20 +153,15 @@ Finds all item entities in the world created by the specified player.
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayerItemsByClass
 
 **Description:**
 
-
 Finds all item entities in the world created by the specified player with a specific class ID.
 
-
 **Parameters:**
-
 
 * client (Player) — The player whose items to find.
 
@@ -213,18 +171,15 @@ Finds all item entities in the world created by the specified player with a spec
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of valid item entities matching the class.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findPlayerItemsByClass
@@ -234,20 +189,15 @@ Finds all item entities in the world created by the specified player with a spec
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayerEntities
 
 **Description:**
 
-
 Finds all entities in the world created by or associated with the specified player. An optional class filter can be applied.
 
-
 **Parameters:**
-
 
 * client (Player) — The player whose entities to find.
 
@@ -257,18 +207,15 @@ Finds all entities in the world created by or associated with the specified play
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of valid entities.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findPlayerEntities
@@ -278,20 +225,15 @@ Finds all entities in the world created by or associated with the specified play
     end
 ```
 
-
 ---
-
 
 ### lia.util.stringMatches
 
 **Description:**
 
-
 Checks if string a matches string b (case-insensitive, partial matches).
 
-
 **Parameters:**
-
 
 * a (string) — The first string to check.
 
@@ -301,18 +243,15 @@ Checks if string a matches string b (case-insensitive, partial matches).
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean — True if they match, false otherwise.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.stringMatches
@@ -321,38 +260,30 @@ Checks if string a matches string b (case-insensitive, partial matches).
     end
 ```
 
-
 ---
-
 
 ### lia.util.getAdmins
 
 **Description:**
 
-
 Returns all players considered staff or admins, as determined by client:isStaff().
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of player entities who are staff.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Notify all online staff members about an upcoming restart
@@ -362,38 +293,30 @@ Returns all players considered staff or admins, as determined by client:isStaff(
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayerBySteamID64
 
 **Description:**
 
-
 Finds a player currently on the server by their SteamID64.
 
-
 **Parameters:**
-
 
 * SteamID64 (string) — The SteamID64 to search for.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|nil — The found player or nil if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID64
@@ -403,38 +326,30 @@ Finds a player currently on the server by their SteamID64.
     end
 ```
 
-
 ---
-
 
 ### lia.util.findPlayerBySteamID
 
 **Description:**
 
-
 Finds a player currently on the server by their SteamID.
 
-
 **Parameters:**
-
 
 * SteamID (string) — The SteamID to search for (e.g. "STEAM_0:1:23456789").
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|nil — The found player or nil if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findPlayerBySteamID
@@ -444,20 +359,15 @@ Finds a player currently on the server by their SteamID.
     end
 ```
 
-
 ---
-
 
 ### lia.util.canFit
 
 **Description:**
 
-
 Checks if a hull (defined by mins and maxs) can fit at the given position without intersecting obstacles.
 
-
 **Parameters:**
-
 
 * pos (Vector) — The position to test.
 
@@ -473,18 +383,15 @@ Checks if a hull (defined by mins and maxs) can fit at the given position withou
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean — True if it can fit, false otherwise.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.canFit
@@ -494,20 +401,15 @@ Checks if a hull (defined by mins and maxs) can fit at the given position withou
     end
 ```
 
-
 ---
-
 
 ### lia.util.playerInRadius
 
 **Description:**
 
-
 Finds and returns a table of players within a given radius from a position.
 
-
 **Parameters:**
-
 
 * pos (Vector) — The center position.
 
@@ -517,18 +419,15 @@ Finds and returns a table of players within a given radius from a position.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table — A table of player entities within the radius.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.playerInRadius
@@ -538,20 +437,15 @@ Finds and returns a table of players within a given radius from a position.
     end
 ```
 
-
 ---
-
 
 ### lia.util.formatStringNamed
 
 **Description:**
 
-
 Formats a string with named or indexed placeholders. If a table is passed, uses named keys. Otherwise uses ordered arguments.
 
-
 **Parameters:**
-
 
 * format (string) — The format string with placeholders like "{key}".
 
@@ -561,18 +455,15 @@ Formats a string with named or indexed placeholders. If a table is passed, uses 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string — The formatted string.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.formatStringNamed
@@ -580,20 +471,15 @@ Formats a string with named or indexed placeholders. If a table is passed, uses 
     print(result) -- "Hello, Bob!"
 ```
 
-
 ---
-
 
 ### lia.util.getMaterial
 
 **Description:**
 
-
 Retrieves a cached Material for the specified path and parameters, to avoid repeated creation.
 
-
 **Parameters:**
-
 
 * materialPath (string) — The file path to the material.
 
@@ -603,18 +489,15 @@ Retrieves a cached Material for the specified path and parameters, to avoid repe
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Material — The requested material.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.getMaterial
@@ -623,20 +506,15 @@ Retrieves a cached Material for the specified path and parameters, to avoid repe
     surface.DrawTexturedRect(0, 0, 100, 100)
 ```
 
-
 ---
-
 
 ### lia.util.findFaction
 
 **Description:**
 
-
 Finds a faction by name or uniqueID. If an exact identifier is found in lia.faction.teams, returns that. Otherwise checks for partial match.
 
-
 **Parameters:**
-
 
 * client (Player) — The player requesting the search (used for notifications).
 
@@ -646,18 +524,15 @@ Finds a faction by name or uniqueID. If an exact identifier is found in lia.fact
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table|nil — The found faction table, or nil if not found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findFaction
@@ -667,20 +542,15 @@ Finds a faction by name or uniqueID. If an exact identifier is found in lia.fact
     end
 ```
 
-
 ---
-
 
 ### lia.util.CreateTableUI
 
 **Description:**
 
-
 Sends a net message to the client to create a table UI with given data.
 
-
 **Parameters:**
-
 
 * client (Player) — The player to whom the UI will be sent.
 
@@ -702,38 +572,30 @@ Sends a net message to the client to create a table UI with given data.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.CreateTableUI
     lia.util.CreateTableUI(somePlayer, "My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, someData, someOptions, charID)
 ```
 
-
 ---
-
 
 ### lia.util.findEmptySpace
 
 **Description:**
 
-
 Finds potential empty space positions around an entity using a grid-based approach.
 
-
 **Parameters:**
-
 
 * entity (Entity) — The entity around which to search.
 
@@ -755,18 +617,15 @@ Finds potential empty space positions around an entity using a grid-based approa
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table — A sorted table of valid positions found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.findEmptySpace
@@ -776,20 +635,15 @@ Finds potential empty space positions around an entity using a grid-based approa
     end
 ```
 
-
 ---
-
 
 ### lia.util.ShadowText
 
 **Description:**
 
-
 Draws text with a shadow offset.
 
-
 **Parameters:**
-
 
 * text (string) — The text to draw.
 
@@ -820,38 +674,30 @@ Draws text with a shadow offset.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.ShadowText
     lia.util.ShadowText("Hello!", "DermaDefault", 100, 100, color_white, color_black, 2, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
 ```
 
-
 ---
-
 
 ### lia.util.DrawTextOutlined
 
 **Description:**
 
-
 Draws text with an outlined border.
 
-
 **Parameters:**
-
 
 * text (string) — The text to draw.
 
@@ -879,38 +725,30 @@ Draws text with an outlined border.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.DrawTextOutlined
     lia.util.DrawTextOutlined("Outlined Text", "DermaLarge", 100, 200, color_white, TEXT_ALIGN_CENTER, 2, color_black)
 ```
 
-
 ---
-
 
 ### lia.util.DrawTip
 
 **Description:**
 
-
 Draws a tooltip-like shape with text in the center.
 
-
 **Parameters:**
-
 
 * x (number) — The x position.
 
@@ -938,38 +776,30 @@ Draws a tooltip-like shape with text in the center.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.DrawTip
     lia.util.DrawTip(100, 100, 200, 60, "This is a tip!", "DermaDefault", color_white, color_black)
 ```
 
-
 ---
-
 
 ### lia.util.drawText
 
 **Description:**
 
-
 Draws text with a subtle shadow effect.
 
-
 **Parameters:**
-
 
 * text (string) — The text to draw.
 
@@ -997,38 +827,30 @@ Draws text with a subtle shadow effect.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.drawText
     lia.util.drawText("Hello World", 200, 300, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, "liaGenericFont", 100)
 ```
 
-
 ---
-
 
 ### lia.util.drawTexture
 
 **Description:**
 
-
 Draws a textured rectangle with the specified material.
 
-
 **Parameters:**
-
 
 * material (string) — The material path.
 
@@ -1050,38 +872,30 @@ Draws a textured rectangle with the specified material.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.drawTexture
     lia.util.drawTexture("path/to/material", color_white, 50, 50, 64, 64)
 ```
 
-
 ---
-
 
 ### lia.util.skinFunc
 
 **Description:**
 
-
 Calls a skin function by name, passing the panel and any extra arguments.
 
-
 **Parameters:**
-
 
 * name (string) — The name of the skin function.
 
@@ -1094,38 +908,30 @@ Calls a skin function by name, passing the panel and any extra arguments.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * any — The result of the skin function call, if any.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.skinFunc
     lia.util.skinFunc("PaintButton", someButton, 10, 20)
 ```
 
-
 ---
-
 
 ### lia.util.wrapText
 
 **Description:**
 
-
 Wraps text to a maximum width, returning a table of lines and the maximum line width found.
 
-
 **Parameters:**
-
 
 * text (string) — The text to wrap.
 
@@ -1138,18 +944,15 @@ Wraps text to a maximum width, returning a table of lines and the maximum line w
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * table, number — A table of wrapped lines and the maximum line width found.
 
 
 **Example Usage:**
-
 
 ```lua
     -- This snippet demonstrates a common usage of lia.util.wrapText
@@ -1160,20 +963,15 @@ Wraps text to a maximum width, returning a table of lines and the maximum line w
     print("Max width: " .. maxW)
 ```
 
-
 ---
-
 
 ### lia.util.drawBlur
 
 **Description:**
 
-
 Draws a blur effect over the specified panel.
 
-
 **Parameters:**
-
 
 * panel (Panel) — The panel to blur.
 
@@ -1186,38 +984,30 @@ Draws a blur effect over the specified panel.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.drawBlur
     lia.util.drawBlur(somePanel, 5, 1)
 ```
 
-
 ---
-
 
 ### lia.util.drawBlurAt
 
 **Description:**
 
-
 Draws a blur effect at a specified rectangle on the screen.
 
-
 **Parameters:**
-
 
 * x (number) — The x position.
 
@@ -1239,38 +1029,30 @@ Draws a blur effect at a specified rectangle on the screen.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.drawBlurAt
     lia.util.drawBlurAt(100, 100, 200, 150, 5, 1)
 ```
 
-
 ---
-
 
 ### lia.util.CreateTableUI
 
 **Description:**
 
-
 Creates and displays a table UI with given columns and data on the client side.
 
-
 **Parameters:**
-
 
 * title (string) — The title of the table.
 
@@ -1289,21 +1071,17 @@ Creates and displays a table UI with given columns and data on the client side.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.util.CreateTableUI
     lia.util.CreateTableUI("My Table", {{name="ID", field="id"}, {name="Name", field="name"}}, myData, myOptions, 1)
 ```
-

--- a/docs/docs/libraries/lia.webimage.md
+++ b/docs/docs/libraries/lia.webimage.md
@@ -1,25 +1,18 @@
 # WebImage Library
 
-
 This page explains how web images are downloaded and cached.
 
-
 ---
-
 
 ## Overview
 
-
 The webimage library downloads remote images and caches them as materials. It avoids repeated downloads and allows you to reference web images by name.
 
-
 ---
-
 
 ### lia.webimage.register(name, url, callback, flags)
 
 **Description:**
-
 
 Downloads an image from the specified URL and caches it within the
 
@@ -27,9 +20,7 @@ data folder. Once available, the provided callback receives the
 
 resulting Material.
 
-
 **Parameters:**
-
 
 * name (string) – Unique file name including extension.
 
@@ -45,32 +36,26 @@ resulting Material.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.webimage.register
     lia.webimage.register("logo.png", "https://example.com/logo.png")
 ```
 
-
 ---
-
 
 ### lia.webimage.get(name, flags)
 
 **Description:**
-
 
 The library extends Garry's Mod's `Material()` and `DImage:SetImage()`
 
@@ -80,9 +65,7 @@ automatically downloaded via `lia.webimage.register` and cached before
 
 the material is returned or applied.
 
-
 **Parameters:**
-
 
 * name (string) – File name used during registration.
 
@@ -92,18 +75,15 @@ the material is returned or applied.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * Material|nil – The image material or nil if missing.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Load a material directly from the web
@@ -112,4 +92,3 @@ the material is returned or applied.
     -- Apply a remote image to a button
     button:SetImage("https://example.com/icon.png")
 ```
-

--- a/docs/docs/libraries/lia.workshop.md
+++ b/docs/docs/libraries/lia.workshop.md
@@ -1,90 +1,69 @@
 # Workshop Library
 
-
 This page documents Workshop addon helpers.
 
-
 ---
-
 
 ## Overview
 
-
 The workshop library tracks required Workshop addon IDs and mounts them on clients. It helps ensure that players have the assets needed for the gamemode.
 
-
 ---
-
 
 ### lia.workshop.gather()
 
 **Description:**
 
-
 Collects workshop IDs from installed addons and registered modules.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * ids (table) – Table of workshop IDs to download.
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.workshop.gather
     local ids = lia.workshop.gather()
 ```
 
-
 ---
-
 
 ### lia.workshop.send(ply)
 
 **Description:**
 
-
 Sends the collected workshop IDs to a connecting player.
 
-
 **Parameters:**
-
 
 * ply (Player) – Player to send the download list to.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
     -- This snippet demonstrates a common usage of lia.workshop.send
     lia.workshop.send(ply)
 ```
-

--- a/docs/docs/meta/character.md
+++ b/docs/docs/meta/character.md
@@ -1,47 +1,35 @@
 # Character Meta
 
-
 Character objects returned by `player:getChar()` persist inventory, stats, and money. This reference outlines helper functions for managing those records.
-
 
 ---
 
-
 ## Overview
-
 
 The character meta library contains information about a player's current game state. It provides shortcuts for fetching stored values, verifying permissions, and linking a character back to its player. Characters are separate from players and hold names, models, money, and other data that persists across sessions.
 
-
 ### tostring()
-
 
 **Description:**
 
-
 Returns a printable identifier for this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Format "character[id]".
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print a readable identifier when saving debug logs
@@ -50,36 +38,28 @@ print("Active char: " .. char:tostring())
 
 ---
 
-
 ### eq(other)
-
 
 **Description:**
 
-
 Compares two characters by ID for equality.
 
-
 **Parameters:**
-
 
 * other (Character) – Character to compare.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if both share the same ID.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if the player is controlling the door owner
@@ -90,36 +70,28 @@ end
 
 ---
 
-
 ### getID()
-
 
 **Description:**
 
-
 Returns the unique database ID for this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Character identifier.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Store the character ID for later reference
@@ -129,36 +101,28 @@ session.lastCharID = id
 
 ---
 
-
 ### getPlayer()
-
 
 **Description:**
 
-
 Returns the player entity currently controlling this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|None – Owning player or None.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notify the controlling player that the character loaded
@@ -170,36 +134,28 @@ end
 
 ---
 
-
 ### getDisplayedName(client)
-
 
 **Description:**
 
-
 Returns the character's name as it should be shown to the given player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player requesting the name.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Localized or recognized character name.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Announce the character's name to a viewer
@@ -208,36 +164,28 @@ client:ChatPrint("You see " .. char:getDisplayedName(client))
 
 ---
 
-
 ### hasMoney(amount)
-
 
 **Description:**
 
-
 Checks if the character has at least the given amount of money.
 
-
 **Parameters:**
-
 
 * amount (number) – Amount to check for.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the character's funds are sufficient.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Verify the character can pay for an item before buying
@@ -248,36 +196,28 @@ end
 
 ---
 
-
 ### getFlags()
-
 
 **Description:**
 
-
 Retrieves the string of permission flags for this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Concatenated flag characters.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Look for the admin flag on this character
@@ -288,36 +228,28 @@ end
 
 ---
 
-
 ### hasFlags(flags)
-
 
 **Description:**
 
-
 Checks if the character possesses any of the specified flags.
 
-
 **Parameters:**
-
 
 * flags (string) – String of flag characters to check.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if at least one flag is present.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allow special command if any required flag is present
@@ -328,36 +260,28 @@ end
 
 ---
 
-
 ### getItemWeapon(requireEquip)
-
 
 **Description:**
 
-
 Checks the player's active weapon against items in the inventory.
 
-
 **Parameters:**
-
 
 * requireEquip (boolean) – Only match equipped items if true.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the active weapon corresponds to an item.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Determine if the equipped weapon is linked to an item
@@ -367,36 +291,28 @@ if match then print("Using weapon item") end
 
 ---
 
-
 ### getMaxStamina()
-
 
 **Description:**
 
-
 Returns the maximum stamina value for this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Maximum stamina points.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Calculate the proportion of stamina remaining
@@ -405,36 +321,28 @@ local pct = char:getStamina() / char:getMaxStamina()
 
 ---
 
-
 ### getStamina()
-
 
 **Description:**
 
-
 Retrieves the character's current stamina value.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Current stamina.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Display current stamina in the HUD
@@ -444,36 +352,28 @@ drawStaminaBar(stamina)
 
 ---
 
-
 ### hasClassWhitelist(class)
-
 
 **Description:**
 
-
 Checks if the character has whitelisted the given class.
 
-
 **Parameters:**
-
 
 * class (number) – Class index.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the class is whitelisted.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Decide if the player may choose the medic class
@@ -484,36 +384,28 @@ end
 
 ---
 
-
 ### isFaction(faction)
-
 
 **Description:**
 
-
 Returns true if the character's faction matches.
 
-
 **Parameters:**
-
 
 * faction (number) – Faction index.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the faction matches.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Restrict access to citizens only
@@ -524,36 +416,28 @@ end
 
 ---
 
-
 ### isClass(class)
-
 
 **Description:**
 
-
 Returns true if the character's class equals the specified class.
 
-
 **Parameters:**
-
 
 * class (number) – Class index.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the classes match.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Provide a bonus if the character is currently an engineer
@@ -564,18 +448,13 @@ end
 
 ---
 
-
 ### getAttrib(key, default)
-
 
 **Description:**
 
-
 Retrieves the value of an attribute including boosts.
 
-
 **Parameters:**
-
 
 * key (string) – Attribute identifier.
 
@@ -585,18 +464,15 @@ Retrieves the value of an attribute including boosts.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Final attribute value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Calculate damage using the strength attribute
@@ -606,36 +482,28 @@ dmg = baseDamage + strength * 0.5
 
 ---
 
-
 ### getBoost(attribID)
-
 
 **Description:**
 
-
 Returns the boost table for the given attribute.
 
-
 **Parameters:**
-
 
 * attribID (string) – Attribute identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table|None – Table of boosts or None.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Inspect active boosts on agility
@@ -644,36 +512,28 @@ PrintTable(char:getBoost("agi"))
 
 ---
 
-
 ### getBoosts()
-
 
 **Description:**
 
-
 Retrieves all attribute boosts for this character.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Mapping of attribute IDs to boost tables.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print all attribute boosts for debugging
@@ -684,36 +544,28 @@ end
 
 ---
 
-
 ### doesRecognize(id)
-
 
 **Description:**
 
-
 Determines if this character recognizes another character.
 
-
 **Parameters:**
-
 
 * id (number|Character) – Character ID or object to check.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if recognized.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reveal names in chat only if recognized
@@ -724,36 +576,28 @@ end
 
 ---
 
-
 ### doesFakeRecognize(id)
-
 
 **Description:**
 
-
 Checks if the character has a fake recognition entry for another.
 
-
 **Parameters:**
-
 
 * id (number|Character) – Character identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if fake recognized.
 
 
 **Example Usage:**
-
 
 ```lua
 -- See if recognition was forced by a disguise item
@@ -762,21 +606,15 @@ if char:doesFakeRecognize(targetChar) then
 end
 ```
 
-
 ---
-
 
 ### recognize(character, name)
 
-
 **Description:**
-
 
 Adds another character to this one's recognition list. If a name is supplied the character will be recognized by that alias.
 
-
 **Parameters:**
-
 
 * character (number|Character) – Character to recognize or its ID.
 
@@ -786,234 +624,180 @@ Adds another character to this one's recognition list. If a name is supplied the
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – Always true once processed.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Remember the rival using a codename
 char:recognize(rivalChar, "Mysterious Stranger")
 ```
 
-
 ---
-
 
 ### WhitelistAllClasses()
 
-
 **Description:**
-
 
 Grants class whitelist access for every class defined by the schema.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allow this character to choose any class
 char:WhitelistAllClasses()
 ```
 
-
 ---
-
 
 ### WhitelistAllFactions()
 
-
 **Description:**
-
 
 Marks the character as whitelisted for every faction.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grant access to all factions for testing
 char:WhitelistAllFactions()
 ```
 
-
 ---
-
 
 ### WhitelistEverything()
 
-
 **Description:**
-
 
 Convenience wrapper that whitelists the character for all factions and classes.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unlock every faction and class
 char:WhitelistEverything()
 ```
 
-
 ---
-
 
 ### classWhitelist(class)
 
-
 **Description:**
-
 
 Adds the specified class to this character's whitelist.
 
-
 **Parameters:**
-
 
 * class (number) – Class index to whitelist.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Permit switching to the engineer class
 char:classWhitelist(CLASS_ENGINEER)
 ```
 
-
 ---
-
 
 ### classUnWhitelist(class)
 
-
 **Description:**
-
 
 Removes the specified class from the character's whitelist.
 
-
 **Parameters:**
-
 
 * class (number) – Class index to remove.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Revoke access to the medic class
 char:classUnWhitelist(CLASS_MEDIC)
 ```
 
-
 ---
-
 
 ### joinClass(class, isForced)
 
-
 **Description:**
-
 
 Attempts to set the character's current class. When `isForced` is true the normal eligibility checks are skipped.
 
-
 **Parameters:**
-
 
 * class (number) – Class index to join.
 
@@ -1023,78 +807,60 @@ Attempts to set the character's current class. When `isForced` is true the norma
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – True on success, false otherwise.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Force the character into the soldier class
 char:joinClass(CLASS_SOLDIER, true)
 ```
 
-
 ---
-
 
 ### kickClass()
 
-
 **Description:**
-
 
 Removes the character from their current class, reverting to the default for their faction.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Reset the character's class after leaving the group
 char:kickClass()
 ```
 
-
 ---
-
 
 ### updateAttrib(key, value)
 
-
 **Description:**
-
 
 Increases an attribute by the specified value, clamped to the maximum allowed.
 
-
 **Parameters:**
-
 
 * key (string) – Attribute identifier.
 
@@ -1104,39 +870,30 @@ Increases an attribute by the specified value, clamped to the maximum allowed.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Award experience toward agility
 char:updateAttrib("agi", 5)
 ```
 
-
 ---
-
 
 ### setAttrib(key, value)
 
-
 **Description:**
-
 
 Directly sets an attribute to the given value.
 
-
 **Parameters:**
-
 
 * key (string) – Attribute identifier.
 
@@ -1146,39 +903,30 @@ Directly sets an attribute to the given value.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Reset strength after an event
 char:setAttrib("str", 10)
 ```
 
-
 ---
-
 
 ### addBoost(boostID, attribID, boostAmount)
 
-
 **Description:**
-
 
 Applies a temporary boost to one of the character's attributes.
 
-
 **Parameters:**
-
 
 * boostID (string) – Unique identifier for the boost.
 
@@ -1191,39 +939,30 @@ Applies a temporary boost to one of the character's attributes.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Grant a strength bonus while an item is equipped
 char:addBoost("powerGloves", "str", 2)
 ```
 
-
 ---
-
 
 ### removeBoost(boostID, attribID)
 
-
 **Description:**
-
 
 Removes a previously applied attribute boost.
 
-
 **Parameters:**
-
 
 * boostID (string) – Identifier used when the boost was added.
 
@@ -1233,369 +972,285 @@ Removes a previously applied attribute boost.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Clear the item bonus when unequipped
 char:removeBoost("powerGloves", "str")
 ```
 
-
 ---
-
 
 ### setFlags(flags)
 
-
 **Description:**
-
 
 Replaces the character's flag string with the provided value.
 
-
 **Parameters:**
-
 
 * flags (string) – New flag characters to assign.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reset all flags before assigning new ones
 char:setFlags("")
 ```
 
-
 ---
-
 
 ### giveFlags(flags)
 
-
 **Description:**
-
 
 Adds the specified flag characters to the character.
 
-
 **Parameters:**
-
 
 * flags (string) – Flags to grant.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grant temporary admin powers
 char:giveFlags("A")
 ```
 
-
 ---
-
 
 ### takeFlags(flags)
 
-
 **Description:**
-
 
 Removes the given flag characters from the character.
 
-
 **Parameters:**
-
 
 * flags (string) – Flags to revoke.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Strip special permissions when demoted
 char:takeFlags("A")
 ```
 
-
 ---
-
 
 ### save(callback)
 
-
 **Description:**
-
 
 Persists the character's current data to the database.
 
-
 **Parameters:**
-
 
 * callback (function|nil) – Optional function run after saving completes.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Save and then notify when finished
 char:save(function() print("character saved") end)
 ```
 
-
 ---
-
 
 ### sync(receiver)
 
-
 **Description:**
-
 
 Sends the character's networkable variables to the specified player. When no receiver is given the data is sent to all players.
 
-
 **Parameters:**
-
 
 * receiver (Player|nil) – Player to receive the data or nil for broadcast.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Refresh other players with our updated info
 char:sync()
 ```
 
-
 ---
-
 
 ### setup(noNetworking)
 
-
 **Description:**
-
 
 Initializes the owning player entity using this character's stored data.
 
-
 **Parameters:**
-
 
 * noNetworking (boolean) – Skip networking inventories and vars when true.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Apply character appearance without sending data to others
 char:setup(true)
 ```
 
-
 ---
-
 
 ### kick()
 
-
 **Description:**
-
 
 Forcibly disconnects the player from their character and respawns them.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Eject the player from their character
 char:kick()
 ```
 
-
 ---
-
 
 ### ban(time)
 
-
 **Description:**
-
 
 Bans the character for the specified duration and immediately kicks them.
 
-
 **Parameters:**
-
 
 * time (number|nil) – Ban length in seconds or nil for permanent.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Ban the character for one hour
 char:ban(3600)
 ```
 
-
 ---
-
 
 ### isBanned()
 
-
 **Description:**
-
 
 Checks whether this character is currently banned.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the character has an active ban.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent actions while the character is banned
@@ -1604,423 +1259,324 @@ if char:isBanned() then
 end
 ```
 
-
 ---
-
 
 ### delete()
 
-
 **Description:**
-
 
 Removes the character from the database entirely.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Permanently remove this character
 char:delete()
 ```
 
-
 ---
-
 
 ### destroy()
 
-
 **Description:**
-
 
 Clears the character from the server's loaded list without saving.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Drop the reference after deletion
 char:destroy()
 ```
 
-
 ---
-
 
 ### giveMoney(amount)
 
-
 **Description:**
-
 
 Credits the character with the given amount of money.
 
-
 **Parameters:**
-
 
 * amount (number) – Amount to add to the wallet.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – False if the owner is missing, otherwise true.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Pay the character for completing a job
 char:giveMoney(250)
 ```
 
-
 ---
-
 
 ### takeMoney(amount)
 
-
 **Description:**
-
 
 Subtracts the specified amount of money from the character.
 
-
 **Parameters:**
-
 
 * amount (number) – Amount to remove.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean – Always true when the deduction occurs.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Deduct a fine from the character
 char:takeMoney(50)
 ```
 
-
 ---
-
 
 ### getName(default)
 
-
 **Description:**
-
 
 Returns the character's stored name or a default value.
 
-
 **Parameters:**
-
 
 * default (any) – Value to return if the name is unset.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – Character name or the provided default.
 
 
 **Example Usage:**
 
-
 ```lua
 print("Character name:", char:getName("Unknown"))
 ```
 
-
 ---
-
 
 ### setName(value)
 
-
 **Description:**
-
 
 Updates the character's name and replicates the change to players.
 
-
 **Parameters:**
-
 
 * value (string) – New name for the character.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setName("Alyx Vance")
 ```
 
-
 ---
-
 
 ### getDesc(default)
 
-
 **Description:**
-
 
 Fetches the character's description text or returns the given default.
 
-
 **Parameters:**
-
 
 * default (any) – Value to return if no description exists.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – Description or fallback value.
 
 
 **Example Usage:**
 
-
 ```lua
 local about = char:getDesc("No bio")
 ```
 
-
 ---
-
 
 ### setDesc(value)
 
-
 **Description:**
-
 
 Assigns a new description for the character.
 
-
 **Parameters:**
-
 
 * value (string) – Description text.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setDesc("Hardened wasteland survivor")
 ```
 
-
 ---
-
 
 ### getModel(default)
 
-
 **Description:**
-
 
 Retrieves the model path assigned to the character.
 
-
 **Parameters:**
-
 
 * default (any) – Value returned when no model is stored.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * string – Model path or the fallback value.
 
 
 **Example Usage:**
 
-
 ```lua
 local mdl = char:getModel("models/error.mdl")
 ```
 
-
 ---
-
 
 ### setModel(value)
 
-
 **Description:**
-
 
 Sets the character's player model and broadcasts the update.
 
-
 **Parameters:**
-
 
 * value (string) – Model file path.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setModel("models/alyx.mdl")
 ```
 
-
 ---
-
 
 ### getClass(default)
 
-
 **Description:**
-
 
 Returns the class index currently assigned or the supplied default.
 
-
 **Parameters:**
-
 
 * default (any) – Value used when the class is unset.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Class index.
 
 
 **Example Usage:**
-
 
 ```lua
 if char:getClass() == CLASS_ENGINEER then
@@ -2028,211 +1584,160 @@ if char:getClass() == CLASS_ENGINEER then
 end
 ```
 
-
 ---
-
 
 ### setClass(value)
 
-
 **Description:**
-
 
 Stores a new class index for the character.
 
-
 **Parameters:**
-
 
 * value (number) – Class identifier.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setClass(CLASS_ENGINEER)
 ```
 
-
 ---
-
 
 ### getFaction(default)
 
-
 **Description:**
-
 
 Gets the faction index of the character or a fallback value.
 
-
 **Parameters:**
-
 
 * default (any) – Value to return when unset.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * number – Faction index.
 
 
 **Example Usage:**
 
-
 ```lua
 print("Faction:", char:getFaction())
 ```
 
-
 ---
-
 
 ### setFaction(value)
 
-
 **Description:**
-
 
 Sets the character's faction team.
 
-
 **Parameters:**
-
 
 * value (number) – Faction identifier.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setFaction(FACTION_CITIZEN)
 ```
 
-
 ---
-
 
 ### getMoney(default)
 
-
 **Description:**
-
 
 Retrieves the amount of currency this character holds.
 
-
 **Parameters:**
-
 
 * default (any) – Value to return when no money value is stored.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * number – Amount of money or default value.
 
 
 **Example Usage:**
 
-
 ```lua
 local cash = char:getMoney(0)
 ```
 
-
 ---
-
 
 ### setMoney(value)
 
-
 **Description:**
-
 
 Overwrites the character's stored money total.
 
-
 **Parameters:**
-
 
 * value (number) – Amount of currency.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setMoney(1000)
 ```
 
-
 ---
-
 
 ### getData(key, default)
 
-
 **Description:**
-
 
 Returns arbitrary data previously stored on the character.
 
-
 **Parameters:**
-
 
 * key (string) – Data key.
 
@@ -2242,38 +1747,29 @@ Returns arbitrary data previously stored on the character.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * any – Stored value or default.
 
 
 **Example Usage:**
 
-
 ```lua
 local rank = char:getData("rank", "rookie")
 ```
 
-
 ---
-
 
 ### setData(key, value, noReplication, receiver)
 
-
 **Description:**
-
 
 Writes a data entry on the character and optionally syncs it.
 
-
 **Parameters:**
-
 
 * key (string) – Data key to modify.
 
@@ -2289,38 +1785,29 @@ Writes a data entry on the character and optionally syncs it.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setData("rank", "veteran")
 ```
 
-
 ---
-
 
 ### getVar(key, default)
 
-
 **Description:**
-
 
 Fetches a temporary variable from the character.
 
-
 **Parameters:**
-
 
 * key (string) – Variable key.
 
@@ -2330,38 +1817,29 @@ Fetches a temporary variable from the character.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * any – Variable value or default.
 
 
 **Example Usage:**
 
-
 ```lua
 local mood = char:getVar("mood", "neutral")
 ```
 
-
 ---
-
 
 ### setVar(key, value, noReplication, receiver)
 
-
 **Description:**
-
 
 Stores a temporary variable on the character.
 
-
 **Parameters:**
-
 
 * key (string) – Variable name.
 
@@ -2377,246 +1855,189 @@ Stores a temporary variable on the character.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setVar("mood", "happy")
 ```
 
-
 ---
-
 
 ### getInv(index)
 
-
 **Description:**
-
 
 Retrieves the character's inventory instance.
 
-
 **Parameters:**
-
 
 * index (number) – Optional inventory slot index.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – Inventory object or list of inventories.
 
 
 **Example Usage:**
 
-
 ```lua
 local inv = char:getInv()
 ```
 
-
 ---
-
 
 ### setInv(value)
 
-
 **Description:**
-
 
 Directly sets the character's inventory table.
 
-
 **Parameters:**
-
 
 * value (table) – Inventory data.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setInv({})
 ```
 
-
 ---
-
 
 ### getAttribs(default)
 
-
 **Description:**
-
 
 Returns the table of raw attribute values for the character.
 
-
 **Parameters:**
-
 
 * default (any) – Fallback value when no attributes are stored.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – Attribute values table.
 
 
 **Example Usage:**
 
-
 ```lua
 local stats = char:getAttribs()
 ```
 
-
 ---
-
 
 ### setAttribs(value)
 
-
 **Description:**
-
 
 Overwrites the character's attribute table.
 
-
 **Parameters:**
-
 
 * value (table) – Table of attribute levels.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * None
 
 
 **Example Usage:**
 
-
 ```lua
 char:setAttribs({ strength = 10 })
 ```
 
-
 ---
-
 
 ### getRecognizedAs(default)
 
-
 **Description:**
-
 
 Gets the mapping of disguised names this character uses to recognize others.
 
-
 **Parameters:**
-
 
 * default (any) – Value to return when no data is stored.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
-
 
 * table – Table of ID to alias mappings.
 
 
 **Example Usage:**
 
-
 ```lua
 local aliases = char:getRecognizedAs()
 ```
 
-
 ---
-
 
 ### setRecognizedAs(value)
 
-
 **Description:**
-
 
 Updates the table of fake recognition names for this character.
 
-
 **Parameters:**
-
 
 * value (table) – Table of ID to alias mappings.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None
 
 
 **Example Usage:**
-
 
 ```lua
 char:setRecognizedAs({ [123] = "Masked Stranger" })

--- a/docs/docs/meta/entity.md
+++ b/docs/docs/meta/entity.md
@@ -1,51 +1,37 @@
 # Entity Meta
 
-
 Entities in Garry's Mod may represent props, items, and interactive objects. This reference describes utility functions added to entity metatables for easier classification and management.
 
-
 ---
-
 
 ## Overview
 
-
 The entity meta library extends Garry's Mod entities with helpers for detection, network-safe data, and item information. Using these functions ensures consistent behavior when handling game objects across Lilia.
-
-
 
 ---
 
-
 ### isProp()
-
 
 **Description:**
 
-
 Returns true if the entity is a physics prop.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the entity is a physics prop.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Apply physics damage only if this is a prop
@@ -56,36 +42,28 @@ end
 
 ---
 
-
 ### isItem()
-
 
 **Description:**
 
-
 Checks if the entity is an item entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the entity represents an item.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Attempt to pick up the entity as an item
@@ -96,36 +74,28 @@ end
 
 ---
 
-
 ### isMoney()
-
 
 **Description:**
 
-
 Checks if the entity is a money entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the entity represents money.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Collect money dropped on the ground
@@ -136,36 +106,28 @@ end
 
 ---
 
-
 ### isSimfphysCar()
-
 
 **Description:**
 
-
 Checks if the entity is a simfphys car.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if this is a simfphys vehicle.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Show a custom HUD when entering a simfphys vehicle
@@ -176,36 +138,28 @@ end
 
 ---
 
-
 ### isLiliaPersistent()
-
 
 **Description:**
 
-
 Determines if the entity is persistent in Lilia.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the entity should persist.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Save this entity across map resets if persistent
@@ -216,18 +170,13 @@ end
 
 ---
 
-
 ### checkDoorAccess(client, access)
-
 
 **Description:**
 
-
 Checks if a player has the given door access level.
 
-
 **Parameters:**
-
 
 * client (Player) – The player to check.
 
@@ -237,18 +186,15 @@ Checks if a player has the given door access level.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the player has access.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Block a player from opening the door without access
@@ -259,36 +205,28 @@ end
 
 ---
 
-
 ### keysOwn(client)
-
 
 **Description:**
 
-
 Assigns the entity to the specified player.
 
-
 **Parameters:**
-
 
 * client (Player) – Player to set as owner.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Assign ownership when a player buys the door
@@ -297,36 +235,28 @@ door:keysOwn(buyer)
 
 ---
 
-
 ### keysLock()
-
 
 **Description:**
 
-
 Locks the entity if it is a vehicle.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Lock the vehicle after the driver exits
@@ -335,36 +265,28 @@ car:keysLock()
 
 ---
 
-
 ### keysUnLock()
-
 
 **Description:**
 
-
 Unlocks the entity if it is a vehicle.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unlock the vehicle when the owner presses a key
@@ -373,36 +295,28 @@ car:keysUnLock()
 
 ---
 
-
 ### getDoorOwner()
-
 
 **Description:**
 
-
 Returns the player that owns this door if available.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|None – Door owner or None.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the name of the door owner when inspecting
@@ -414,36 +328,28 @@ end
 
 ---
 
-
 ### isLocked()
-
 
 **Description:**
 
-
 Returns the locked state stored in net variables.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the door is locked.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Display a lock icon if the door is networked as locked
@@ -454,36 +360,28 @@ end
 
 ---
 
-
 ### isDoorLocked()
-
 
 **Description:**
 
-
 Checks the internal door locked state.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the door is locked.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Play a sound when trying to open a locked door server-side
@@ -494,36 +392,28 @@ end
 
 ---
 
-
 ### getEntItemDropPos(offset)
-
 
 **Description:**
 
-
 Calculates a drop position in front of the entity's eyes.
 
-
 **Parameters:**
-
 
 * offset (number) – Distance from the player eye position.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Vector – Drop position and angle.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Spawn an item drop in front of the entity's eyes
@@ -533,18 +423,13 @@ lia.item.spawn("item_water", pos, ang)
 
 ---
 
-
 ### isNearEntity(radius, otherEntity)
-
 
 **Description:**
 
-
 Checks for another entity of the same class nearby.
 
-
 **Parameters:**
-
 
 * radius (number) – Sphere radius in units.
 
@@ -554,18 +439,15 @@ Checks for another entity of the same class nearby.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if another entity is within radius.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prevent building too close to another chest
@@ -576,36 +458,28 @@ end
 
 ---
 
-
 ### GetCreator()
-
 
 **Description:**
 
-
 Returns the entity creator player.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|None – Creator player if stored.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Credit the creator when the entity is removed
@@ -617,36 +491,28 @@ end
 
 ---
 
-
 ### SetCreator(client)
-
 
 **Description:**
 
-
 Stores the creator player on the entity.
 
-
 **Parameters:**
-
 
 * client (Player) – Creator of the entity.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
     -- Record the spawner for cleanup tracking
@@ -655,18 +521,13 @@ Stores the creator player on the entity.
 
 ---
 
-
 ### sendNetVar(key, receiver)
-
 
 **Description:**
 
-
 Sends a network variable to recipients.
 
-
 **Parameters:**
-
 
 * key (string) – Identifier of the variable.
 
@@ -676,7 +537,6 @@ Sends a network variable to recipients.
 
 **Realm:**
 
-
 * Server
 
 
@@ -684,15 +544,12 @@ Sends a network variable to recipients.
 
         Used by the networking system.
 
-
 **Returns:**
-
 
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Broadcast the "doorState" variable to every connected player
@@ -703,36 +560,28 @@ end
 
 ---
 
-
 ### clearNetVars(receiver)
-
 
 **Description:**
 
-
 Clears all network variables on this entity.
 
-
 **Parameters:**
-
 
 * receiver (Player|None) – Receiver to notify.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Force reinitialization by clearing all variables for this receiver
@@ -742,36 +591,28 @@ ent:sendNetVar("initialized", client)
 
 ---
 
-
 ### removeDoorAccessData()
-
 
 **Description:**
 
-
 Clears all stored door access information.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Wipe door permissions during cleanup
@@ -780,36 +621,28 @@ local result = ent:removeDoorAccessData()
 
 ---
 
-
 ### setLocked(state)
-
 
 **Description:**
 
-
 Stores the door locked state in network variables.
 
-
 **Parameters:**
-
 
 * state (boolean) – New locked state.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Toggle the door lock and play a latch sound for everyone
@@ -819,36 +652,28 @@ door:EmitSound("doors/door_latch3.wav")
 
 ---
 
-
 ### isDoor()
-
 
 **Description:**
 
-
 Returns true if the entity's class indicates a door.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – Whether the entity is a door.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if the entity behaves like a door
@@ -857,36 +682,28 @@ local result = ent:isDoor()
 
 ---
 
-
 ### getDoorPartner()
-
 
 **Description:**
 
-
 Returns the partner door linked with this entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Entity|None – The partnered door.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unlock both doors when opening a double-door setup
@@ -898,18 +715,13 @@ end
 
 ---
 
-
 ### setNetVar(key, value, receiver)
-
 
 **Description:**
 
-
 Updates a network variable and sends it to recipients.
 
-
 **Parameters:**
-
 
 * key (string) – Variable name.
 
@@ -922,18 +734,15 @@ Updates a network variable and sends it to recipients.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Store a variable and sync it to players
@@ -942,18 +751,13 @@ local result = ent:setNetVar(key, value, receiver)
 
 ---
 
-
 ### getNetVar(key, default)
-
 
 **Description:**
 
-
 Retrieves a stored network variable or a default value.
 
-
 **Parameters:**
-
 
 * key (string) – Variable name.
 
@@ -963,7 +767,6 @@ Retrieves a stored network variable or a default value.
 
 **Realm:**
 
-
 * Server
 
 
@@ -972,12 +775,10 @@ Retrieves a stored network variable or a default value.
 
 **Returns:**
 
-
 * any – Stored value or default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Retrieve the stored variable or fallback to the default
@@ -986,36 +787,28 @@ local result = ent:getNetVar(key, default)
 
 ---
 
-
 ### isDoor()
-
 
 **Description:**
 
-
 Client-side door check using class name.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * boolean – True if entity class contains "door".
 
 
 **Example Usage:**
-
 
 ```lua
 -- Determine if this entity's class name contains "door"
@@ -1024,36 +817,28 @@ local result = ent:isDoor()
 
 ---
 
-
 ### getDoorPartner()
-
 
 **Description:**
 
-
 Attempts to find the door partnered with this one.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * Entity|None – The partner door entity.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Highlight the partner door of the one being looked at
@@ -1065,18 +850,13 @@ end
 
 ---
 
-
 ### getNetVar(key, default)
-
 
 **Description:**
 
-
 Retrieves a network variable for this entity on the client.
 
-
 **Parameters:**
-
 
 * key (string) – Variable name.
 
@@ -1086,30 +866,24 @@ Retrieves a network variable for this entity on the client.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
-
 
 * any – Stored value or default.
 
 
 **Example Usage:**
 
-
 ```lua
 -- Access a synced variable on the client side
 local result = ent:getNetVar(key, default)
 ```
 
-
 ---
 
-
 ### getParts()
-
 
 ```lua
 function ENTITY:getParts()
@@ -1117,33 +891,26 @@ function ENTITY:getParts()
 end
 ```
 
-
 **Description:**
-
 
 Retrieves the table of PAC3 part identifiers applied to this entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – The currently applied part IDs.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print all equipped PAC3 parts for a player
@@ -1152,180 +919,140 @@ for id in pairs(client:getParts()) do
 end
 ```
 
-
 ---
 
-
 ### syncParts()
-
 
 ```lua
 function ENTITY:syncParts()
 end
 ```
 
-
 **Description:**
-
 
 Broadcasts the entity's PAC3 part list to synchronize with clients.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Resend parts when a player respawns
 client:syncParts()
 ```
 
-
 ---
 
-
 ### addPart(partID)
-
 
 ```lua
 function ENTITY:addPart(partID)
 end
 ```
 
-
 **Description:**
-
 
 Attaches a PAC3 part to this entity and networks the change.
 
-
 **Parameters:**
-
 
 * partID (string) – Identifier for the PAC3 outfit to add.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Give the player a custom hat part
 client:addPart("hat01")
 ```
 
-
 ---
 
-
 ### removePart(partID)
-
 
 ```lua
 function ENTITY:removePart(partID)
 end
 ```
 
-
 **Description:**
-
 
 Detaches a PAC3 part from this entity and updates clients.
 
-
 **Parameters:**
-
 
 * partID (string) – Identifier of the PAC3 outfit to remove.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove the previously equipped hat part
 client:removePart("hat01")
 ```
 
-
 ---
 
-
 ### resetParts()
-
 
 ```lua
 function ENTITY:resetParts()
 end
 ```
 
-
 **Description:**
-
 
 Clears all PAC3 parts from this entity and notifies clients.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove all PAC3 outfits from the player

--- a/docs/docs/meta/inventory.md
+++ b/docs/docs/meta/inventory.md
@@ -1,23 +1,16 @@
 # Inventory Meta
 
-
 Inventories hold items for characters or in-world containers. This document lists methods for managing and syncing these item stores.
 
-
 ---
-
 
 ## Overview
 
-
 Inventory meta functions handle transactions, capacity checks, retrieval by slot or ID, and persistent data storage. Inventories hold items in a grid layout and may belong to characters or world containers. The functions also manage network updates so clients remain in sync with server-side changes.
-
 
 ---
 
-
 ### getData(key, default)
-
 
 ```lua
 function Inventory:getData(key, default)
@@ -25,15 +18,11 @@ function Inventory:getData(key, default)
 end
 ```
 
-
 **Description:**
-
 
 Returns a stored data value for this inventory.
 
-
 **Parameters:**
-
 
 * key (string) – Data field key.
 
@@ -43,18 +32,15 @@ Returns a stored data value for this inventory.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any – Stored value or default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Read how many times the container was opened
@@ -63,9 +49,7 @@ local opens = inv:getData("openCount", 0)
 
 ---
 
-
 ### extend(className)
-
 
 ```lua
 function Inventory:extend(className)
@@ -73,33 +57,26 @@ function Inventory:extend(className)
 end
 ```
 
-
 **Description:**
-
 
 Creates a subclass of the inventory meta table with a new class name.
 
-
 **Parameters:**
-
 
 * className (string) – Name of the subclass meta table.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – The newly derived inventory table.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Define a subclass for weapon crates and register it
@@ -113,9 +90,7 @@ WeaponInv:register("weapon_inv")
 
 ---
 
-
 ### configure()
-
 
 ```lua
 function Inventory:configure()
@@ -123,33 +98,26 @@ function Inventory:configure()
 end
 ```
 
-
 **Description:**
-
 
 Stub for inventory configuration; meant to be overridden.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Called from a subclass to set up custom slots
@@ -161,9 +129,7 @@ end
 
 ---
 
-
 ### addDataProxy(key, onChange)
-
 
 ```lua
 function Inventory:addDataProxy(key, onChange)
@@ -171,15 +137,11 @@ function Inventory:addDataProxy(key, onChange)
 end
 ```
 
-
 **Description:**
-
 
 Adds a proxy function that is called when a data field changes.
 
-
 **Parameters:**
-
 
 * key (string) – Data field to watch.
 
@@ -189,18 +151,15 @@ Adds a proxy function that is called when a data field changes.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Track changes to the "locked" data field
@@ -212,9 +171,7 @@ end)
 
 ---
 
-
 ### getItemsByUniqueID(uniqueID, onlyMain)
-
 
 ```lua
 function Inventory:getItemsByUniqueID(uniqueID, onlyMain)
@@ -222,15 +179,11 @@ function Inventory:getItemsByUniqueID(uniqueID, onlyMain)
 end
 ```
 
-
 **Description:**
-
 
 Returns all items in the inventory matching the given unique ID.
 
-
 **Parameters:**
-
 
 * uniqueID (string) – Item unique identifier.
 
@@ -240,18 +193,15 @@ Returns all items in the inventory matching the given unique ID.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Table of matching item objects.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Use each ammo box found in the main list
@@ -262,9 +212,7 @@ end
 
 ---
 
-
 ### register(typeID)
-
 
 ```lua
 function Inventory:register(typeID)
@@ -272,33 +220,26 @@ function Inventory:register(typeID)
 end
 ```
 
-
 **Description:**
-
 
 Registers this inventory type with the lia.inventory system.
 
-
 **Parameters:**
-
 
 * typeID (string) – Unique identifier for this inventory type.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Register and then immediately create the inventory type
@@ -308,9 +249,7 @@ local chestInv = WeaponInv:new()
 
 ---
 
-
 ### new()
-
 
 ```lua
 function Inventory:new()
@@ -318,33 +257,26 @@ function Inventory:new()
 end
 ```
 
-
 **Description:**
-
 
 Creates a new inventory of this type.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – New inventory instance.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Create an inventory and attach it to a spawned chest entity
@@ -356,9 +288,7 @@ chest.inv = WeaponInv:new()
 
 ---
 
-
 ### tostring()
-
 
 ```lua
 function Inventory:tostring()
@@ -366,33 +296,26 @@ function Inventory:tostring()
 end
 ```
 
-
 **Description:**
-
 
 Returns a printable representation of this inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Formatted as "ClassName[id]".
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the identifier when debugging
@@ -401,9 +324,7 @@ print("Inventory: " .. inv:tostring())
 
 ---
 
-
 ### getType()
-
 
 ```lua
 function Inventory:getType()
@@ -411,33 +332,26 @@ function Inventory:getType()
 end
 ```
 
-
 **Description:**
-
 
 Retrieves the inventory type table from lia.inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Inventory type definition.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Read slot data from the type definition
@@ -446,9 +360,7 @@ local def = inv:getType()
 
 ---
 
-
 ### onDataChanged(key, oldValue, newValue)
-
 
 ```lua
 function Inventory:onDataChanged(key, oldValue, newValue)
@@ -456,17 +368,13 @@ function Inventory:onDataChanged(key, oldValue, newValue)
 end
 ```
 
-
 **Description:**
-
 
 Called when an inventory data field changes. Executes any
 
 registered proxy callbacks for that field.
 
-
 **Parameters:**
-
 
 * key (string) – Data field key.
 
@@ -479,18 +387,15 @@ registered proxy callbacks for that field.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- React when the stored credit amount changes
@@ -499,9 +404,7 @@ inv:onDataChanged("credits", 0, 100)
 
 ---
 
-
 ### getItems()
-
 
 ```lua
 function Inventory:getItems()
@@ -509,33 +412,26 @@ function Inventory:getItems()
 end
 ```
 
-
 **Description:**
-
 
 Returns all items stored in this inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Item instance table indexed by itemID.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Sum the weight of all items
@@ -548,9 +444,7 @@ print("Weight:", totalWeight)
 
 ---
 
-
 ### getItemsOfType(itemType)
-
 
 ```lua
 function Inventory:getItemsOfType(itemType)
@@ -558,33 +452,26 @@ function Inventory:getItemsOfType(itemType)
 end
 ```
 
-
 **Description:**
-
 
 Collects all items that match the given unique ID.
 
-
 **Parameters:**
-
 
 * itemType (string) – Item unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Array of matching items.
 
 
 **Example Usage:**
-
 
 ```lua
 -- List all medkits currently in the inventory
@@ -593,9 +480,7 @@ local kits = inv:getItemsOfType("medkit")
 
 ---
 
-
 ### getFirstItemOfType(itemType)
-
 
 ```lua
 function Inventory:getFirstItemOfType(itemType)
@@ -603,33 +488,26 @@ function Inventory:getFirstItemOfType(itemType)
 end
 ```
 
-
 **Description:**
-
 
 Retrieves the first item matching the given unique ID.
 
-
 **Parameters:**
-
 
 * itemType (string) – Item unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Item|None – The first matching item or None.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grab the first pistol found in the inventory
@@ -638,9 +516,7 @@ local pistol = inv:getFirstItemOfType("pistol")
 
 ---
 
-
 ### hasItem(itemType)
-
 
 ```lua
 function Inventory:hasItem(itemType)
@@ -648,33 +524,26 @@ function Inventory:hasItem(itemType)
 end
 ```
 
-
 **Description:**
-
 
 Determines whether the inventory contains an item type.
 
-
 **Parameters:**
-
 
 * itemType (string) – Item unique identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if an item is found.
 
 
 **Example Usage:**
-
 
 ```lua
 -- See if any health potion exists
@@ -685,9 +554,7 @@ end
 
 ---
 
-
 ### getItemCount(itemType)
-
 
 ```lua
 function Inventory:getItemCount(itemType)
@@ -695,33 +562,26 @@ function Inventory:getItemCount(itemType)
 end
 ```
 
-
 **Description:**
-
 
 Counts the total quantity of a specific item type.
 
-
 **Parameters:**
-
 
 * itemType (string|None) – Item unique ID to count. Counts all if nil.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Sum of quantities.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Count the total number of bullets
@@ -731,9 +591,7 @@ print("Ammo remaining:", ammoTotal)
 
 ---
 
-
 ### getID()
-
 
 ```lua
 function Inventory:getID()
@@ -741,33 +599,26 @@ function Inventory:getID()
 end
 ```
 
-
 **Description:**
-
 
 Returns the unique database ID of this inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Inventory identifier.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Store the inventory ID on its container entity
@@ -776,9 +627,7 @@ entity:setNetVar("invID", inv:getID())
 
 ---
 
-
 ### eq(other)
-
 
 ```lua
 function Inventory:eq(other)
@@ -786,33 +635,26 @@ function Inventory:eq(other)
 end
 ```
 
-
 **Description:**
-
 
 Compares two inventories by ID for equality.
 
-
 **Parameters:**
-
 
 * other (Inventory) – Other inventory to compare.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if both inventories share the same ID.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if two chests share the same inventory record
@@ -823,9 +665,7 @@ end
 
 ---
 
-
 ### addItem(item, noReplicate)
-
 
 ```lua
 function Inventory:addItem(item, noReplicate)
@@ -833,15 +673,11 @@ function Inventory:addItem(item, noReplicate)
 end
 ```
 
-
 **Description:**
-
 
 Inserts an item instance into this inventory and persists it.
 
-
 **Parameters:**
-
 
 * item (Item) – Item to add.
 
@@ -851,18 +687,15 @@ Inserts an item instance into this inventory and persists it.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Add a looted item to the inventory
@@ -873,9 +706,7 @@ end
 
 ---
 
-
 ### add(item)
-
 
 ```lua
 function Inventory:add(item)
@@ -883,33 +714,26 @@ function Inventory:add(item)
 end
 ```
 
-
 **Description:**
-
 
 Alias for `addItem` that inserts an item into the inventory.
 
-
 **Parameters:**
-
 
 * item (Item) – Item to add.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table – The inventory instance.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:add(item)
@@ -917,9 +741,7 @@ inv:add(item)
 
 ---
 
-
 ### syncItemAdded(item)
-
 
 ```lua
 function Inventory:syncItemAdded(item)
@@ -927,33 +749,26 @@ function Inventory:syncItemAdded(item)
 end
 ```
 
-
 **Description:**
-
 
 Replicates a newly added item to all clients that can access the inventory.
 
-
 **Parameters:**
-
 
 * item (Item) – Item instance that was added.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:syncItemAdded(item)
@@ -961,9 +776,7 @@ inv:syncItemAdded(item)
 
 ---
 
-
 ### initializeStorage(initialData)
-
 
 ```lua
 function Inventory:initializeStorage(initialData)
@@ -971,33 +784,26 @@ function Inventory:initializeStorage(initialData)
 end
 ```
 
-
 **Description:**
-
 
 Creates a persistent inventory record in the database using the supplied initial data.
 
-
 **Parameters:**
-
 
 * initialData (table) – Values to store when creating the inventory.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves with the new inventory ID.
 
 
 **Example Usage:**
-
 
 ```lua
 WeaponInv:initializeStorage({char = charID, locked = true}):next(function(id)
@@ -1007,42 +813,33 @@ end)
 
 ---
 
-
 ### restoreFromStorage()
-
 
 ```lua
 function Inventory:restoreFromStorage()
 end
 ```
 
-
 **Description:**
-
 
 Stub called when loading an inventory from custom storage systems.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:restoreFromStorage()
@@ -1050,9 +847,7 @@ inv:restoreFromStorage()
 
 ---
 
-
 ### removeItem(itemID, preserveItem)
-
 
 ```lua
 function Inventory:removeItem(itemID, preserveItem)
@@ -1060,15 +855,11 @@ function Inventory:removeItem(itemID, preserveItem)
 end
 ```
 
-
 **Description:**
-
 
 Removes an item by ID and optionally deletes it.
 
-
 **Parameters:**
-
 
 * itemID (number) – Unique item identifier.
 
@@ -1078,18 +869,15 @@ Removes an item by ID and optionally deletes it.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove an item but keep it saved for later
@@ -1101,9 +889,7 @@ end
 
 ---
 
-
 ### remove(itemID)
-
 
 ```lua
 function Inventory:remove(itemID)
@@ -1111,33 +897,26 @@ function Inventory:remove(itemID)
 end
 ```
 
-
 **Description:**
-
 
 Alias for `removeItem` that removes an item from the inventory.
 
-
 **Parameters:**
-
 
 * itemID (number) – Unique item identifier.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves once the item is removed.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:remove(itemID)
@@ -1145,9 +924,7 @@ inv:remove(itemID)
 
 ---
 
-
 ### setData(key, value)
-
 
 ```lua
 function Inventory:setData(key, value)
@@ -1155,15 +932,11 @@ function Inventory:setData(key, value)
 end
 ```
 
-
 **Description:**
-
 
 Sets a data field on the inventory and replicates the change to clients.
 
-
 **Parameters:**
-
 
 * key (string) – Data field name.
 
@@ -1173,18 +946,15 @@ Sets a data field on the inventory and replicates the change to clients.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table – The inventory instance.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:setData("locked", true)
@@ -1192,9 +962,7 @@ inv:setData("locked", true)
 
 ---
 
-
 ### canAccess(action, context)
-
 
 ```lua
 function Inventory:canAccess(action, context)
@@ -1202,15 +970,11 @@ function Inventory:canAccess(action, context)
 end
 ```
 
-
 **Description:**
-
 
 Evaluates access rules to determine whether an action is permitted.
 
-
 **Parameters:**
-
 
 * action (string) – Action identifier.
 
@@ -1220,12 +984,10 @@ Evaluates access rules to determine whether an action is permitted.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
-
 
 * boolean|nil – True, false, or nil if undecided.
 
@@ -1235,16 +997,13 @@ Evaluates access rules to determine whether an action is permitted.
 
 **Example Usage:**
 
-
 ```lua
 local allowed = inv:canAccess("take", {client = ply})
 ```
 
 ---
 
-
 ### addAccessRule(rule, priority)
-
 
 ```lua
 function Inventory:addAccessRule(rule, priority)
@@ -1252,15 +1011,11 @@ function Inventory:addAccessRule(rule, priority)
 end
 ```
 
-
 **Description:**
-
 
 Registers a function used by `canAccess` to grant or deny actions.
 
-
 **Parameters:**
-
 
 * rule (function) – Access rule function.
 
@@ -1270,18 +1025,15 @@ Registers a function used by `canAccess` to grant or deny actions.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table – The inventory instance.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:addAccessRule(function(inv, action, ctx)
@@ -1291,9 +1043,7 @@ end)
 
 ---
 
-
 ### removeAccessRule(rule)
-
 
 ```lua
 function Inventory:removeAccessRule(rule)
@@ -1301,33 +1051,26 @@ function Inventory:removeAccessRule(rule)
 end
 ```
 
-
 **Description:**
-
 
 Unregisters a previously added access rule.
 
-
 **Parameters:**
-
 
 * rule (function) – The rule to remove.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table – The inventory instance.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:removeAccessRule(myRule)
@@ -1335,9 +1078,7 @@ inv:removeAccessRule(myRule)
 
 ---
 
-
 ### getRecipients()
-
 
 ```lua
 function Inventory:getRecipients()
@@ -1345,33 +1086,26 @@ function Inventory:getRecipients()
 end
 ```
 
-
 **Description:**
-
 
 Returns a list of players that should receive network updates for this inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * table – Array of Player objects.
 
 
 **Example Usage:**
-
 
 ```lua
 local receivers = inv:getRecipients()
@@ -1379,42 +1113,33 @@ local receivers = inv:getRecipients()
 
 ---
 
-
 ### onInstanced()
-
 
 ```lua
 function Inventory:onInstanced()
 end
 ```
 
-
 **Description:**
-
 
 Called after a new inventory is created in the database.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function WeaponInv:onInstanced()
@@ -1424,42 +1149,33 @@ end
 
 ---
 
-
 ### onLoaded()
-
 
 ```lua
 function Inventory:onLoaded()
 end
 ```
 
-
 **Description:**
-
 
 Called after an inventory is loaded from the database.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function WeaponInv:onLoaded()
@@ -1469,9 +1185,7 @@ end
 
 ---
 
-
 ### loadItems()
-
 
 ```lua
 function Inventory:loadItems()
@@ -1479,33 +1193,26 @@ function Inventory:loadItems()
 end
 ```
 
-
 **Description:**
-
 
 Loads all items belonging to this inventory from storage.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves with a table of loaded items.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:loadItems():next(function(items)
@@ -1515,42 +1222,33 @@ end)
 
 ---
 
-
 ### onItemsLoaded(items)
-
 
 ```lua
 function Inventory:onItemsLoaded(items)
 end
 ```
 
-
 **Description:**
-
 
 Hook called after `loadItems` finishes loading all items.
 
-
 **Parameters:**
-
 
 * items (table) – Loaded items indexed by ID.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function WeaponInv:onItemsLoaded(items)
@@ -1560,9 +1258,7 @@ end
 
 ---
 
-
 ### instance(initialData)
-
 
 ```lua
 function Inventory:instance(initialData)
@@ -1570,33 +1266,26 @@ function Inventory:instance(initialData)
 end
 ```
 
-
 **Description:**
-
 
 Creates and stores a new inventory instance of this type.
 
-
 **Parameters:**
-
 
 * initialData (table|None) – Data to populate the inventory with.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves with the created inventory.
 
 
 **Example Usage:**
-
 
 ```lua
 WeaponInv:instance({char = charID}):next(function(inv) end)
@@ -1604,9 +1293,7 @@ WeaponInv:instance({char = charID}):next(function(inv) end)
 
 ---
 
-
 ### syncData(key, recipients)
-
 
 ```lua
 function Inventory:syncData(key, recipients)
@@ -1614,15 +1301,11 @@ function Inventory:syncData(key, recipients)
 end
 ```
 
-
 **Description:**
-
 
 Sends a single data field to clients.
 
-
 **Parameters:**
-
 
 * key (string) – Field to replicate.
 
@@ -1632,18 +1315,15 @@ Sends a single data field to clients.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Sync the locked state to nearby players
@@ -1652,9 +1332,7 @@ inv:syncData("locked", recipients)
 
 ---
 
-
 ### sync(recipients)
-
 
 ```lua
 function Inventory:sync(recipients)
@@ -1662,33 +1340,26 @@ function Inventory:sync(recipients)
 end
 ```
 
-
 **Description:**
-
 
 Sends the entire inventory and its items to players.
 
-
 **Parameters:**
-
 
 * recipients (table|None) – Player recipients.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Send all items to the owner after they join
@@ -1697,9 +1368,7 @@ inv:sync({owner})
 
 ---
 
-
 ### delete()
-
 
 ```lua
 function Inventory:delete()
@@ -1707,33 +1376,26 @@ function Inventory:delete()
 end
 ```
 
-
 **Description:**
-
 
 Removes this inventory record from the database.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Permanently delete a chest inventory on cleanup
@@ -1743,9 +1405,7 @@ print("Inventory removed from database")
 
 ---
 
-
 ### destroy()
-
 
 ```lua
 function Inventory:destroy()
@@ -1753,33 +1413,26 @@ function Inventory:destroy()
 end
 ```
 
-
 **Description:**
-
 
 Destroys all items and removes network references.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Clear all items when the container entity is removed
@@ -1787,9 +1440,7 @@ inv:destroy()
 print("Inventory destroyed")
 ```
 
-
 ### show(parent)
-
 
 ```lua
 function Inventory:show(parent)
@@ -1797,33 +1448,26 @@ function Inventory:show(parent)
 end
 ```
 
-
 **Description:**
-
 
 Opens the inventory user interface on the client.
 
-
 **Parameters:**
-
 
 * parent (Panel|None) – Optional parent panel.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * Panel – The created inventory UI panel.
 
 
 **Example Usage:**
-
 
 ```lua
 inv:show()

--- a/docs/docs/meta/item.md
+++ b/docs/docs/meta/item.md
@@ -1,47 +1,35 @@
 # Item Meta
 
-
 Item objects represent things found in inventories or spawned in the world. This guide describes methods for reading and manipulating item data.
-
 
 ---
 
-
 ## Overview
-
 
 Item meta functions cover stack counts, categories, weight calculations, and network variables. Items are objects that can exist in inventories or the world, and item instances clone the base properties defined by the item table. These helpers enable consistent interaction across trading, crafting, and interface components.
 
-
 ### getQuantity()
-
 
 **Description:**
 
-
 Retrieves how many of this item the stack represents.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Quantity contained in this item instance.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Give the player ammo equal to the stack quantity
@@ -50,36 +38,28 @@ player:GiveAmmo(item:getQuantity(), "pistol")
 
 ---
 
-
 ### eq(other)
-
 
 **Description:**
 
-
 Compares this item instance to another by ID.
 
-
 **Parameters:**
-
 
 * other (Item) – The other item to compare with.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if both items share the same ID.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if the held item matches the inventory slot
@@ -90,36 +70,28 @@ end
 
 ---
 
-
 ### tostring()
-
 
 **Description:**
 
-
 Returns a printable representation of this item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Identifier in the form "item[uniqueID][id]".
 
 
 **Example Usage:**
-
 
 ```lua
 -- Log the item identifier during saving
@@ -128,36 +100,28 @@ print("Saving " .. item:tostring())
 
 ---
 
-
 ### getID()
-
 
 **Description:**
 
-
 Retrieves the unique identifier of this item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Item database ID.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Use the ID when updating the database
@@ -166,36 +130,28 @@ lia.db.updateItem(item:getID(), {price = 50})
 
 ---
 
-
 ### getModel()
-
 
 **Description:**
 
-
 Returns the model path associated with this item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Model path.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Spawn the item's model as a world prop
@@ -206,36 +162,28 @@ prop:Spawn()
 
 ---
 
-
 ### getSkin()
-
 
 **Description:**
 
-
 Retrieves the skin index this item uses.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – Skin ID applied to the model.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Apply the correct skin when displaying the item
@@ -244,36 +192,28 @@ model:SetSkin(item:getSkin())
 
 ---
 
-
 ### getPrice()
-
 
 **Description:**
 
-
 Returns the calculated purchase price for the item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – The price value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Charge the player the item's price before giving it
@@ -284,18 +224,13 @@ end
 
 ---
 
-
 ### call(method, client, entity, ...)
-
 
 **Description:**
 
-
 Invokes an item method with the given player and entity context.
 
-
 **Parameters:**
-
 
 * method (string) – Method name to run.
 
@@ -311,18 +246,15 @@ Invokes an item method with the given player and entity context.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any – Results returned by the called function.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Trigger a custom "use" function when the player presses Use
@@ -331,36 +263,28 @@ item:call("use", client, entity)
 
 ---
 
-
 ### getOwner()
-
 
 **Description:**
 
-
 Attempts to find the player currently owning this item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player|None – The owner if available.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Notify whoever currently owns the item
@@ -372,18 +296,13 @@ end
 
 ---
 
-
 ### getData(key, default)
-
 
 **Description:**
 
-
 Retrieves a piece of persistent data stored on the item.
 
-
 **Parameters:**
-
 
 * key (string) – Data key to read.
 
@@ -393,18 +312,15 @@ Retrieves a piece of persistent data stored on the item.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * any – Stored value or default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Retrieve a custom paint color stored on the item
@@ -413,38 +329,30 @@ local color = item:getData("paintColor", Color(255,255,255))
 
 ---
 
-
 ### getAllData()
 
-
 **Description:**
-
 
 Returns a merged table of this item's stored data and any
 
 networked values on its entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Key/value table of all data fields.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print all stored data for debugging
@@ -453,18 +361,13 @@ PrintTable(item:getAllData())
 
 ---
 
-
 ### hook(name, func)
-
 
 **Description:**
 
-
 Registers a hook callback for this item instance.
 
-
 **Parameters:**
-
 
 * name (string) – Hook identifier.
 
@@ -474,18 +377,15 @@ Registers a hook callback for this item instance.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Run code when the item is used
@@ -494,18 +394,13 @@ item:hook("use", function(ply) ply:ChatPrint("Used!") end)
 
 ---
 
-
 ### postHook(name, func)
-
 
 **Description:**
 
-
 Registers a post-hook callback for this item.
 
-
 **Parameters:**
-
 
 * name (string) – Hook identifier.
 
@@ -515,18 +410,15 @@ Registers a post-hook callback for this item.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Give a pistol after the item is picked up
@@ -535,36 +427,28 @@ item:postHook("pickup", function(ply) ply:Give("weapon_pistol") end)
 
 ---
 
-
 ### onRegistered()
-
 
 **Description:**
 
-
 Called when the item table is first registered.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Initialize data when the item type loads
@@ -573,36 +457,28 @@ item:onRegistered()
 
 ---
 
-
 ### print(detail)
-
 
 **Description:**
 
-
 Prints a simple representation of the item to the console.
 
-
 **Parameters:**
-
 
 * detail (boolean) – Include position details when true.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Output item info while debugging spawn issues
@@ -611,36 +487,28 @@ item:print(true)
 
 ---
 
-
 ### printData()
-
 
 **Description:**
 
-
 Debug helper that prints all stored item data.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Dump all stored data to the console
@@ -649,18 +517,13 @@ item:printData()
 
 ---
 
-
 ### addQuantity(quantity, receivers, noCheckEntity)
-
 
 **Description:**
 
-
 Increases the stored quantity for this item instance.
 
-
 **Parameters:**
-
 
 * quantity (number) – Amount to add.
 
@@ -673,7 +536,6 @@ Increases the stored quantity for this item instance.
 
 **Realm:**
 
-
 * Server
 
 
@@ -685,7 +547,6 @@ Increases the stored quantity for this item instance.
 
 **Example Usage:**
 
-
 ```lua
 -- Combine stacks from a loot drop and notify the owner
 item:addQuantity(5, {player})
@@ -694,18 +555,13 @@ player:notifyLocalized("item_added", item.name, 5)
 
 ---
 
-
 ### setQuantity(quantity, receivers, noCheckEntity)
-
 
 **Description:**
 
-
 Sets the current stack quantity and replicates the change.
 
-
 **Parameters:**
-
 
 * quantity (number) – New amount to store.
 
@@ -718,7 +574,6 @@ Sets the current stack quantity and replicates the change.
 
 **Realm:**
 
-
 * Server
 
 
@@ -730,7 +585,6 @@ Sets the current stack quantity and replicates the change.
 
 **Example Usage:**
 
-
 ```lua
 -- Set quantity to 1 after splitting the stack
 item:setQuantity(1, nil, true)
@@ -738,36 +592,28 @@ item:setQuantity(1, nil, true)
 
 ---
 
-
 ### getName()
-
 
 **Description:**
 
-
 Returns the display name of this item. On the client this value is localized.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Item name.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Inform the player which item they found
@@ -776,36 +622,28 @@ client:ChatPrint("Picked up: " .. item:getName())
 
 ---
 
-
 ### getDesc()
-
 
 **Description:**
 
-
 Retrieves the description text for this item.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Item description.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Display a tooltip describing the item
@@ -814,36 +652,28 @@ tooltip:AddRowAfter("name", "desc"):SetText(item:getDesc())
 
 ---
 
-
 ### removeFromInventory(preserveItem)
-
 
 **Description:**
 
-
 Removes this item from its inventory without deleting it when `preserveItem` is true.
 
-
 **Parameters:**
-
 
 * preserveItem (boolean) – Keep the item saved in the database.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves when the item has been removed.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unequip and drop the item while keeping it saved
@@ -854,36 +684,28 @@ end)
 
 ---
 
-
 ### delete()
-
 
 **Description:**
 
-
 Deletes this item from the database after destroying it.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves when deletion completes.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Permanently remove the item from the database
@@ -894,36 +716,28 @@ end)
 
 ---
 
-
 ### remove()
-
 
 **Description:**
 
-
 Destroys the item's entity then removes and deletes it from its inventory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Deferred – Resolves when the item has been removed.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove the item from the world and database
@@ -934,36 +748,28 @@ end)
 
 ---
 
-
 ### destroy()
-
 
 **Description:**
 
-
 Broadcasts deletion of this item and removes it from memory.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Instantly delete the item across the network
@@ -972,36 +778,28 @@ item:destroy()
 
 ---
 
-
 ### onDisposed()
-
 
 **Description:**
 
-
 Callback executed after the item is destroyed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function ITEM:onDisposed()
@@ -1011,36 +809,28 @@ end
 
 ---
 
-
 ### getEntity()
-
 
 **Description:**
 
-
 Finds the entity spawned for this item, if any.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Entity|nil – The world entity representing the item.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Grab the world entity to modify it
@@ -1052,18 +842,13 @@ end
 
 ---
 
-
 ### spawn(position, angles)
-
 
 **Description:**
 
-
 Creates a world entity for this item at the specified position.
 
-
 **Parameters:**
-
 
 * position (Vector|Player) – Drop position or player dropping the item.
 
@@ -1073,18 +858,15 @@ Creates a world entity for this item at the specified position.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * Entity|nil – The created entity if successful.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Drop the item at the player's feet
@@ -1093,18 +875,13 @@ item:spawn(client:getItemDropPos(), Angle(0, 0, 0))
 
 ---
 
-
 ### transfer(newInventory, bBypass)
-
 
 **Description:**
 
-
 Moves the item to another inventory, optionally bypassing access checks.
 
-
 **Parameters:**
-
 
 * newInventory (Inventory) – Destination inventory.
 
@@ -1114,18 +891,15 @@ Moves the item to another inventory, optionally bypassing access checks.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – True if the transfer was initiated.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Move the item into another container
@@ -1136,36 +910,28 @@ end)
 
 ---
 
-
 ### onInstanced()
-
 
 **Description:**
 
-
 Called when a new instance of this item is created.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function ITEM:onInstanced()
@@ -1175,36 +941,28 @@ end
 
 ---
 
-
 ### onSync(recipient)
-
 
 **Description:**
 
-
 Runs after this item is networked to `recipient`.
 
-
 **Parameters:**
-
 
 * recipient (Player|None) – Who received the data.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function ITEM:onSync(ply)
@@ -1214,36 +972,28 @@ end
 
 ---
 
-
 ### onRemoved()
-
 
 **Description:**
 
-
 Executed after the item is permanently removed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function ITEM:onRemoved()
@@ -1253,36 +1003,28 @@ end
 
 ---
 
-
 ### onRestored()
-
 
 **Description:**
 
-
 Called when the item is restored from the database.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 function ITEM:onRestored()
@@ -1292,36 +1034,28 @@ end
 
 ---
 
-
 ### sync(recipient)
-
 
 **Description:**
 
-
 Sends this item's data to a player or broadcasts to all.
 
-
 **Parameters:**
-
 
 * recipient (Player|None) – Target player or nil for broadcast.
 
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Resend the item data to a specific player
@@ -1330,18 +1064,13 @@ item:sync(player)
 
 ---
 
-
 ### setData(key, value, receivers, noSave, noCheckEntity)
-
 
 **Description:**
 
-
 Sets a data field on the item and optionally networks and saves it.
 
-
 **Parameters:**
-
 
 * key (string) – Data key to modify.
 
@@ -1360,18 +1089,15 @@ Sets a data field on the item and optionally networks and saves it.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Mark the item as legendary and notify the owner
@@ -1380,18 +1106,13 @@ item:setData("rarity", "legendary", player)
 
 ---
 
-
 ### interact(action, client, entity, data)
-
 
 **Description:**
 
-
 Processes an interaction action performed by `client` on this item.
 
-
 **Parameters:**
-
 
 * action (string) – Identifier of the interaction.
 
@@ -1407,18 +1128,15 @@ Processes an interaction action performed by `client` on this item.
 
 **Realm:**
 
-
 * Server
 
 
 **Returns:**
 
-
 * boolean – True if the interaction succeeded.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Trigger the "use" interaction from code

--- a/docs/docs/meta/panel.md
+++ b/docs/docs/meta/panel.md
@@ -1,50 +1,37 @@
 # Panel Meta
 
-
 Lilia's interface relies on VGUI panels with extra functionality. This document describes convenience methods available to those panels.
 
-
 ---
-
 
 ## Overview
 
-
 Panel meta functions support scaled positioning, listen for inventory changes, and offer other utilities that make building responsive menus and HUD elements easier.
-
 
 ---
 
-
 ### liaListenForInventoryChanges(inventory)
-
 
 **Description:**
 
-
 Subscribes this panel to updates for a specific inventory.
 
-
 **Parameters:**
-
 
 * inventory (Inventory) – Inventory to watch for changes.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Example Usage:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 panel:liaListenForInventoryChanges(player:getChar():getInv())
@@ -52,36 +39,28 @@ panel:liaListenForInventoryChanges(player:getChar():getInv())
 
 ---
 
-
 ### liaDeleteInventoryHooks(id)
-
 
 **Description:**
 
-
 Removes inventory update hooks created by `liaListenForInventoryChanges`.
 
-
 **Parameters:**
-
 
 * id (number) – ID of the inventory to stop listening to.
 
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove all registered hooks for this panel
@@ -90,18 +69,13 @@ panel:liaDeleteInventoryHooks()
 
 ---
 
-
 ### SetScaledPos(x, y)
-
 
 **Description:**
 
-
 Positions the panel using screen scale units.
 
-
 **Parameters:**
-
 
 * x (number) – Horizontal position using `ScreenScale`.
 
@@ -111,18 +85,15 @@ Positions the panel using screen scale units.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Position the panel 10 units from the left and 20 units down
@@ -131,18 +102,13 @@ panel:SetScaledPos(10, 20)
 
 ---
 
-
 ### SetScaledSize(w, h)
-
 
 **Description:**
 
-
 Sizes the panel using screen scale units.
 
-
 **Parameters:**
-
 
 * w (number) – Width using `ScreenScale`.
 
@@ -152,18 +118,15 @@ Sizes the panel using screen scale units.
 
 **Realm:**
 
-
 * Client
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Set panel size to 64 by 32 scaled units

--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -1,49 +1,37 @@
 # Player Meta
 
-
 Lilia extends Garry's Mod players with characters, inventories, and permission checks. This reference details the meta functions enabling that integration.
-
 
 ---
 
-
 ## Overview
-
 
 Player meta functions provide quick access to the active character, networking helpers for messaging or data transfer, and utility checks such as admin status. Players are entity objects that hold at most one Character instance, so these helpers unify player-related logic across the framework.
 
 ---
 
-
 ### getChar()
-
 
 **Description:**
 
-
 Returns the currently loaded character object for this player.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Character|None – The player's active character.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Retrieve the character to modify inventory
@@ -52,36 +40,28 @@ local char = player:getChar()
 
 ---
 
-
 ### Name()
-
 
 **Description:**
 
-
 Returns either the character's roleplay name or the player's Steam name.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Display name.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Print the roleplay name in chat
@@ -90,36 +70,28 @@ chat.AddText(player:Name())
 
 ---
 
-
 ### hasPrivilege(privilegeName)
-
 
 **Description:**
 
-
 Wrapper for CAMI privilege checks.
 
-
 **Parameters:**
-
 
 * privilegeName (string) – Privilege identifier.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Result from CAMI.PlayerHasAccess.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Deny access if the player lacks a privilege
@@ -130,36 +102,28 @@ end
 
 ---
 
-
 ### getCurrentVehicle()
-
 
 **Description:**
 
-
 Safely returns the vehicle the player is currently using.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Entity|None – Vehicle entity or None.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Attach a camera to the vehicle the player is in
@@ -171,36 +135,28 @@ end
 
 ---
 
-
 ### hasValidVehicle()
-
 
 **Description:**
 
-
 Determines if the player is currently inside a valid vehicle.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if a vehicle entity is valid.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Allow honking only when in a valid vehicle
@@ -211,36 +167,28 @@ end
 
 ---
 
-
 ### isNoClipping()
-
 
 **Description:**
 
-
 Returns true if the player is in noclip mode and not inside a vehicle.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – Whether the player is noclipping.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Disable certain actions while noclipping
@@ -249,36 +197,28 @@ if player:isNoClipping() then return end
 
 ---
 
-
 ### hasRagdoll()
-
 
 **Description:**
 
-
 Checks if the player currently has an active ragdoll entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True when a ragdoll entity exists.
 
 
 **Example Usage:**
-
 
 ```lua
 if player:hasRagdoll() then
@@ -288,36 +228,28 @@ end
 
 ---
 
-
 ### removeRagdoll()
-
 
 **Description:**
 
-
 Safely removes the player's ragdoll entity if present.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Clean up any ragdoll left behind
@@ -326,36 +258,28 @@ player:removeRagdoll()
 
 ---
 
-
 ### getRagdoll()
-
 
 **Description:**
 
-
 Retrieves the ragdoll entity associated with the player.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Entity|None – The ragdoll entity or None.
 
 
 **Example Usage:**
-
 
 ```lua
 local ragdoll = player:getRagdoll()
@@ -363,36 +287,28 @@ local ragdoll = player:getRagdoll()
 
 ---
 
-
 ### isStuck()
-
 
 **Description:**
 
-
 Determines whether the player's position is stuck in the world.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the trace detects a stuck state.
 
 
 **Example Usage:**
-
 
 if player:isStuck() then
 
@@ -432,18 +348,13 @@ end
 
 ---
 
-
 ### entitiesNearPlayer(radius, playerOnly)
-
 
 **Description:**
 
-
 Returns a table of entities within radius of the player.
 
-
 **Parameters:**
-
 
 * radius (number) – Search distance in units.
 
@@ -453,18 +364,15 @@ Returns a table of entities within radius of the player.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – List of nearby entities.
 
 
 **Example Usage:**
-
 
 ```lua
 for _, ent in ipairs(player:entitiesNearPlayer(256)) do
@@ -478,36 +386,28 @@ end
 
 ---
 
-
 ### getItemWeapon()
-
 
 **Description:**
 
-
 Returns the active weapon entity and associated item if equipped.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Entity|None – Weapon entity when matched.
 
 
 **Example Usage:**
-
 
 ```lua
 local weapon, item = player:getItemWeapon()
@@ -515,36 +415,28 @@ local weapon, item = player:getItemWeapon()
 
 ---
 
-
 ### isRunning()
-
 
 **Description:**
 
-
 Checks whether the player is moving faster than walking speed.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the player is running.
 
 
 **Example Usage:**
-
 
 if player:isRunning() then
 

--- a/docs/docs/meta/tool.md
+++ b/docs/docs/meta/tool.md
@@ -1,50 +1,37 @@
 # Tool Meta
 
-
 The ToolGun interacts with the world through specialized meta functions. This guide lists utilities for object manipulation and ghost entity management.
 
-
 ---
-
 
 ## Overview
 
-
 Tool meta functions track hovered entities, create ghost previews, and wrap common building operations. They ensure consistent behavior across custom tools in Lilia.
-
 
 ---
 
-
 ### Create()
-
 
 **Description:**
 
-
 Creates a new tool object with default values.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – The newly created tool object.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Create a table for a custom door tool mode
@@ -54,36 +41,28 @@ tool.Mode = "lia_dooredit"
 
 ---
 
-
 ### CreateConVars()
-
 
 **Description:**
 
-
 Creates client and server ConVars for this tool.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Ensure console variables exist for configuration
@@ -92,36 +71,28 @@ tool:CreateConVars()
 
 ---
 
-
 ### GetServerInfo(property)
-
 
 **Description:**
 
-
 Returns the server ConVar for the given property.
 
-
 **Parameters:**
-
 
 * property (string) – Property name.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * ConVar – The server ConVar object.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if the server allows using this tool
@@ -130,36 +101,28 @@ local allow = tool:GetServerInfo("allow_use"):GetBool()
 
 ---
 
-
 ### BuildConVarList()
-
 
 **Description:**
 
-
 Returns a table of client ConVars prefixed by the tool mode.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * table – Table of convars.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Get a table of client ConVars for networking
@@ -168,36 +131,28 @@ local cvars = tool:BuildConVarList()
 
 ---
 
-
 ### GetClientInfo(property)
-
 
 **Description:**
 
-
 Retrieves a client ConVar value as a string.
 
-
 **Parameters:**
-
 
 * property (string) – ConVar name without mode prefix.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – The value stored in the ConVar.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Get the client's chosen material from a ConVar
@@ -206,18 +161,13 @@ local mat = tool:GetClientInfo("material")
 
 ---
 
-
 ### GetClientNumber(property, default)
-
 
 **Description:**
 
-
 Retrieves a numeric client ConVar value.
 
-
 **Parameters:**
-
 
 * property (string) – ConVar name without mode prefix.
 
@@ -227,18 +177,15 @@ Retrieves a numeric client ConVar value.
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * number – The numeric value of the ConVar.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Read the numeric power setting with a fallback
@@ -247,36 +194,28 @@ local power = tool:GetClientNumber("power", 10)
 
 ---
 
-
 ### Allowed()
-
 
 **Description:**
 
-
 Determines whether this tool is allowed to be used.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – True if the tool is allowed.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Check if the player can use the current tool
@@ -290,36 +229,28 @@ end
 
 ---
 
-
 ### Init()
-
 
 **Description:**
 
-
 Placeholder for tool initialization.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Prepare the tool for use
@@ -328,36 +259,28 @@ local result = tool:Init()
 
 ---
 
-
 ### GetMode()
-
 
 **Description:**
 
-
 Gets the current tool mode string.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * string – Tool mode name.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Retrieve the tool's active mode string
@@ -366,36 +289,28 @@ local result = tool:GetMode()
 
 ---
 
-
 ### GetSWEP()
-
 
 **Description:**
 
-
 Returns the SWEP associated with this tool.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * SWEP – The tool's weapon entity.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Obtain the weapon entity representing this tool
@@ -404,36 +319,28 @@ local result = tool:GetSWEP()
 
 ---
 
-
 ### GetOwner()
-
 
 **Description:**
 
-
 Retrieves the tool owner's player object.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Player – Owner of the tool.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Reference the player who deployed the tool
@@ -442,36 +349,28 @@ local result = tool:GetOwner()
 
 ---
 
-
 ### GetWeapon()
-
 
 **Description:**
 
-
 Retrieves the weapon entity this tool is attached to.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * Weapon – The weapon object.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Access the underlying weapon object
@@ -480,36 +379,28 @@ local result = tool:GetWeapon()
 
 ---
 
-
 ### LeftClick()
-
 
 **Description:**
 
-
 Handles the left-click action. Override for custom behavior.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False by default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Attempt the primary tool action
@@ -518,36 +409,28 @@ local result = tool:LeftClick()
 
 ---
 
-
 ### RightClick()
-
 
 **Description:**
 
-
 Handles the right-click action. Override for custom behavior.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * boolean – False by default.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Attempt the secondary tool action
@@ -556,36 +439,28 @@ local result = tool:RightClick()
 
 ---
 
-
 ### Reload()
-
 
 **Description:**
 
-
 Clears stored objects when the tool reloads.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Clear saved objects when reloading the tool
@@ -594,36 +469,28 @@ local result = tool:Reload()
 
 ---
 
-
 ### Deploy()
-
 
 **Description:**
 
-
 Called when the tool is equipped. Releases ghost entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Equip the tool and spawn its ghost entity
@@ -632,36 +499,28 @@ local result = tool:Deploy()
 
 ---
 
-
 ### Holster()
-
 
 **Description:**
 
-
 Called when the tool is holstered. Releases ghost entity.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Unequip the tool and remove its ghost entity
@@ -670,36 +529,28 @@ local result = tool:Holster()
 
 ---
 
-
 ### Think()
-
 
 **Description:**
 
-
 Called every tick; releases ghost entities by default.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Run per-tick logic for the active tool
@@ -708,36 +559,28 @@ local result = tool:Think()
 
 ---
 
-
 ### CheckObjects()
-
 
 **Description:**
 
-
 Validates stored objects and clears them if invalid.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Validate all stored objects each tick
@@ -746,36 +589,28 @@ local result = tool:CheckObjects()
 
 ---
 
-
 ### ClearObjects()
-
 
 **Description:**
 
-
 Removes all stored objects from the tool.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove any objects the tool is storing
@@ -784,36 +619,28 @@ local result = tool:ClearObjects()
 
 ---
 
-
 ### ReleaseGhostEntity()
-
 
 **Description:**
 
-
 Removes the ghost entity used for previewing placements.
 
-
 **Parameters:**
-
 
 * None
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * None – This function does not return a value.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Remove the placement preview entity

--- a/docs/docs/meta/vector.md
+++ b/docs/docs/meta/vector.md
@@ -1,50 +1,37 @@
 # Vector Meta
 
-
 Vector utilities expand Garry's Mod's math library. This document describes additional operations for 3D vectors.
 
-
 ---
-
 
 ## Overview
 
-
 Vector meta functions provide calculations such as midpoints, distances, and axis rotations to support movement, physics, and placement tasks.
-
 
 ---
 
-
 ### Center(vec2)
-
 
 **Description:**
 
-
 Returns the midpoint between this vector and the supplied vector.
 
-
 **Parameters:**
-
 
 * `vec2` (`Vector`) – The vector to average with this vector.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * `Vector` – The center point of the two vectors.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Average two vectors to find the midpoint
@@ -54,36 +41,28 @@ print(midpoint) -- Vector(5, 5, 5)
 
 ---
 
-
 ### Distance(vec2)
-
 
 **Description:**
 
-
 Calculates the distance between this vector and another vector.
 
-
 **Parameters:**
-
 
 * `vec2` (`Vector`) – The other vector.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * `number` – The distance between the two vectors.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Measure the distance between two points
@@ -93,18 +72,13 @@ print(dist) -- 5
 
 ---
 
-
 ### RotateAroundAxis(axis, degrees)
-
 
 **Description:**
 
-
 Rotates the vector around an axis by the specified degrees and returns the new vector.
 
-
 **Parameters:**
-
 
 * `axis` (`Vector`) – Axis to rotate around.
 
@@ -114,18 +88,15 @@ Rotates the vector around an axis by the specified degrees and returns the new v
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * `Vector` – The rotated vector.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Rotate a vector 90 degrees around the Z axis
@@ -135,36 +106,28 @@ print(rotated) -- Vector(0, 1, 0)
 
 ---
 
-
 ### Right(vUp)
-
 
 **Description:**
 
-
 Returns a normalized right-direction vector relative to this vector.
 
-
 **Parameters:**
-
 
 * `vUp` (`Vector`, optional) – Up direction to compare against. Defaults to `vector_up`.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * `Vector` – The calculated right vector.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Get the right direction vector
@@ -174,36 +137,28 @@ print(rightVec)
 
 ---
 
-
 ### Up(vUp)
-
 
 **Description:**
 
-
 Returns a normalized up-direction vector relative to this vector.
 
-
 **Parameters:**
-
 
 * `vUp` (`Vector`, optional) – Up direction to compare against. Defaults to `vector_up`.
 
 
 **Realm:**
 
-
 * Shared
 
 
 **Returns:**
 
-
 * `Vector` – The calculated up vector.
 
 
 **Example Usage:**
-
 
 ```lua
 -- Get the up direction vector

--- a/docs/docs/modules.md
+++ b/docs/docs/modules.md
@@ -1,20 +1,14 @@
 # Optional Modules
 
-
 These free modules expand the base mechanics of Lilia. They are all open-source and hosted in the [Modules repository](https://github.com/LiliaFramework/Modules) as well as on the [Modules website](https://liliaframework.github.io/Modules/). Click a module name to view its page or use the direct URL listed under “Download Here.”
-
 
 ## Advert
 
-
 **Description:**
-
 
 Adds an Advert command
 
-
 **Features:**
-
 
 * Adds a `/advert` chat command for server-wide announcements
 
@@ -24,24 +18,17 @@ Adds an Advert command
 
 [**Module Website**](https://liliaframework.github.io/Modules/advert.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/advert.zip)
-
 
 ---
 
-
 ## Alcoholism
-
 
 **Description:**
 
-
 Adds Alcohol and its effects
 
-
 **Features:**
-
 
 * Consumable alcohol items raise blood-alcohol content
 
@@ -54,24 +41,17 @@ Adds Alcohol and its effects
 
 [**Module Website**](https://liliaframework.github.io/Modules/alcoholism.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/alcoholism.zip)
-
 
 ---
 
-
 ## Auto Restarter
-
 
 **Description:**
 
-
 Automatically restarts the server every interval
 
-
 **Features:**
-
 
 * Schedules automatic restarts at a configurable interval
 
@@ -81,24 +61,17 @@ Automatically restarts the server every interval
 
 [**Module Website**](https://liliaframework.github.io/Modules/autorestarter.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/autorestarter.zip)
-
 
 ---
 
-
 ## Bodygrouper
-
 
 **Description:**
 
-
 Adds a bodygroup menu and bodygroup closet, akin to BodygroupR on GModStore
 
-
 **Features:**
-
 
 * Admin command to open a bodygroup menu for any player
 
@@ -108,24 +81,17 @@ Adds a bodygroup menu and bodygroup closet, akin to BodygroupR on GModStore
 
 [**Module Website**](https://liliaframework.github.io/Modules/bodygrouper.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/bodygrouper.zip)
-
 
 ---
 
-
 ## Broadcasts
-
 
 **Description:**
 
-
 Adds a Faction & Class broadcast command
 
-
 **Features:**
-
 
 * Provides `/factionbroadcast` and `/classbroadcast` commands
 
@@ -135,24 +101,17 @@ Adds a Faction & Class broadcast command
 
 [**Module Website**](https://liliaframework.github.io/Modules/broadcasts.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/broadcasts.zip)
-
 
 ---
 
-
 ## Captions
-
 
 **Description:**
 
-
 Adds an easy way of showing in-game captions
 
-
 **Features:**
-
 
 * Command-based system for displaying in-game captions
 
@@ -162,24 +121,17 @@ Adds an easy way of showing in-game captions
 
 [**Module Website**](https://liliaframework.github.io/Modules/captions.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/captions.zip)
-
 
 ---
 
-
 ## Cards
-
 
 **Description:**
 
-
 Adds the ability to draw a random card from a deck
 
-
 **Features:**
-
 
 * Draws a random playing card with `/card`
 
@@ -189,24 +141,17 @@ Adds the ability to draw a random card from a deck
 
 [**Module Website**](https://liliaframework.github.io/Modules/cards.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cards.zip)
-
 
 ---
 
-
 ## Chat Messages
-
 
 **Description:**
 
-
 Adds simple adverts
 
-
 **Features:**
-
 
 * Periodically posts custom chat messages to everyone
 
@@ -216,24 +161,17 @@ Adds simple adverts
 
 [**Module Website**](https://liliaframework.github.io/Modules/chatmessages.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/chatmessages.zip)
-
 
 ---
 
-
 ## Cinematic Text
-
 
 **Description:**
 
-
 Cinematic-looking splash text for extra flair
 
-
 **Features:**
-
 
 * Creates cinematic splash text with optional black bars
 
@@ -243,24 +181,17 @@ Cinematic-looking splash text for extra flair
 
 [**Module Website**](https://liliaframework.github.io/Modules/cinematictext.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cinematictext.zip)
-
 
 ---
 
-
 ## Climb
-
 
 **Description:**
 
-
 Adds the ability to climb up ledges
 
-
 **Features:**
-
 
 * Players can climb ledges when jumping toward them
 
@@ -270,24 +201,17 @@ Adds the ability to climb up ledges
 
 [**Module Website**](https://liliaframework.github.io/Modules/climb.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/climb.zip)
-
 
 ---
 
-
 ## Code Utils
-
 
 **Description:**
 
-
 Adds a few extensions to the `lia.util` library
 
-
 **Features:**
-
 
 * Extra helper functions added to `lia.util`
 
@@ -297,24 +221,17 @@ Adds a few extensions to the `lia.util` library
 
 [**Module Website**](https://liliaframework.github.io/Modules/codeutils.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/codeutils.zip)
-
 
 ---
 
-
 ## Community Commands
-
 
 **Description:**
 
-
 Adds links to various community content
 
-
 **Features:**
-
 
 * Chat commands that link players to community resources
 
@@ -324,24 +241,17 @@ Adds links to various community content
 
 [**Module Website**](https://liliaframework.github.io/Modules/communitycommands.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/communitycommands.zip)
-
 
 ---
 
-
 ## Corpse ID
-
 
 **Description:**
 
-
 Adds a corpse identification mechanic
 
-
 **Features:**
-
 
 * Allows identifying corpses to see their information
 
@@ -351,24 +261,17 @@ Adds a corpse identification mechanic
 
 [**Module Website**](https://liliaframework.github.io/Modules/corpseid.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/corpseid.zip)
-
 
 ---
 
-
 ## Cursor
-
 
 **Description:**
 
-
 Adds a cursor system
 
-
 **Features:**
-
 
 * Provides a custom on-screen cursor system
 
@@ -378,24 +281,17 @@ Adds a cursor system
 
 [**Module Website**](https://liliaframework.github.io/Modules/cursor.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cursor.zip)
-
 
 ---
 
-
 ## Simple Cutscenes
-
 
 **Description:**
 
-
 A system for simple cutscenes
 
-
 **Features:**
-
 
 * Framework for simple camera cutscenes
 
@@ -405,24 +301,17 @@ A system for simple cutscenes
 
 [**Module Website**](https://liliaframework.github.io/Modules/cutscenes.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/cutscenes.zip)
-
 
 ---
 
-
 ## Damage Numbers
-
 
 **Description:**
 
-
 Displays damage numbers when you hit someone or get hit
 
-
 **Features:**
-
 
 * Shows floating damage numbers when dealing or taking damage
 
@@ -432,24 +321,17 @@ Displays damage numbers when you hit someone or get hit
 
 [**Module Website**](https://liliaframework.github.io/Modules/damagenumbers.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/damagenumbers.zip)
-
 
 ---
 
-
 ## Development HUD
-
 
 **Description:**
 
-
 Adds a development HUD
 
-
 **Features:**
-
 
 * Adds an on-screen HUD with FPS and debug info
 
@@ -459,24 +341,17 @@ Adds a development HUD
 
 [**Module Website**](https://liliaframework.github.io/Modules/developmenthud.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmenthud.zip)
-
 
 ---
 
-
 ## Development Server
-
 
 **Description:**
 
-
 Adds the option for a development server that can run specific functions
 
-
 **Features:**
-
 
 * Hooks for running code only on a dev server
 
@@ -486,24 +361,17 @@ Adds the option for a development server that can run specific functions
 
 [**Module Website**](https://liliaframework.github.io/Modules/developmentserver.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/developmentserver.zip)
-
 
 ---
 
-
 ## Discord Relay
-
 
 **Description:**
 
-
 Relays logs to Discord
 
-
 **Features:**
-
 
 * Relays server logs and chat events to Discord via webhooks
 
@@ -513,24 +381,17 @@ Relays logs to Discord
 
 [**Module Website**](https://liliaframework.github.io/Modules/discordrelay.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/discordrelay.zip)
-
 
 ---
 
-
 ## Donator
-
 
 **Description:**
 
-
 Adds several donation-related libraries
 
-
 **Features:**
-
 
 * Utilities for checking donor status and granting perks
 
@@ -540,24 +401,17 @@ Adds several donation-related libraries
 
 [**Module Website**](https://liliaframework.github.io/Modules/donator.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/donator.zip)
-
 
 ---
 
-
 ## Door Kick
-
 
 **Description:**
 
-
 Allows you to kick doors open
 
-
 **Features:**
-
 
 * Lets players kick doors open with an animation
 
@@ -567,24 +421,17 @@ Allows you to kick doors open
 
 [**Module Website**](https://liliaframework.github.io/Modules/doorkick.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/doorkick.zip)
-
 
 ---
 
-
 ## Hospitals
-
 
 **Description:**
 
-
 Adds hospitals that spawn you after dying
 
-
 **Features:**
-
 
 * After death, players respawn at configured hospitals
 
@@ -594,24 +441,17 @@ Adds hospitals that spawn you after dying
 
 [**Module Website**](https://liliaframework.github.io/Modules/enhanceddeath.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/enhanceddeath.zip)
-
 
 ---
 
-
 ## Extended Descriptions
-
 
 **Description:**
 
-
 Adds support for extended descriptions
 
-
 **Features:**
-
 
 * Allows longer character or item descriptions
 
@@ -621,24 +461,17 @@ Adds support for extended descriptions
 
 [**Module Website**](https://liliaframework.github.io/Modules/extendeddescriptions.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/extendeddescriptions.zip)
-
 
 ---
 
-
 ## First Person Effects
-
 
 **Description:**
 
-
 Realistic first-person effects
 
-
 **Features:**
-
 
 * Adds screen shake and other first-person effects
 
@@ -648,24 +481,17 @@ Realistic first-person effects
 
 [**Module Website**](https://liliaframework.github.io/Modules/firstpersoneffects.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/firstpersoneffects.zip)
-
 
 ---
 
-
 ## Flashlight
-
 
 **Description:**
 
-
 Makes the flashlight more serious
 
-
 **Features:**
-
 
 * More realistic flashlight with tweakable brightness
 
@@ -675,24 +501,17 @@ Makes the flashlight more serious
 
 [**Module Website**](https://liliaframework.github.io/Modules/flashlight.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/flashlight.zip)
-
 
 ---
 
-
 ## Free Look
-
 
 **Description:**
 
-
 Adds Free Look similar to EFT
 
-
 **Features:**
-
 
 * Enables free look similar to modern shooters
 
@@ -702,24 +521,17 @@ Adds Free Look similar to EFT
 
 [**Module Website**](https://liliaframework.github.io/Modules/freelook.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/freelook.zip)
-
 
 ---
 
-
 ## Gamemaster Teleport Points
-
 
 **Description:**
 
-
 Allows GMs to teleport to predefined points on the map
 
-
 **Features:**
-
 
 * Teleport system for gamemasters
 
@@ -729,24 +541,17 @@ Allows GMs to teleport to predefined points on the map
 
 [**Module Website**](https://liliaframework.github.io/Modules/gamemasterpoints.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/gamemasterpoints.zip)
-
 
 ---
 
-
 ## Extra HUD Elements
-
 
 **Description:**
 
-
 Implements extra HUD elements
 
-
 **Features:**
-
 
 * Adds HUD elements such as ammo or status bars
 
@@ -756,24 +561,17 @@ Implements extra HUD elements
 
 [**Module Website**](https://liliaframework.github.io/Modules/hud_extras.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/hud_extras.zip)
-
 
 ---
 
-
 ## Instant Killing
-
 
 **Description:**
 
-
 Enables instant kills on headshots
 
-
 **Features:**
-
 
 * Optional headshot insta-kill mechanic
 
@@ -783,24 +581,17 @@ Enables instant kills on headshots
 
 [**Module Website**](https://liliaframework.github.io/Modules/instakill.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/instakill.zip)
-
 
 ---
 
-
 ## Join Leave Messages
-
 
 **Description:**
 
-
 Adds join and leave messages
 
-
 **Features:**
-
 
 * Announces player join and leave events in chat
 
@@ -810,24 +601,17 @@ Adds join and leave messages
 
 [**Module Website**](https://liliaframework.github.io/Modules/joinleavemessages.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/joinleavemessages.zip)
-
 
 ---
 
-
 ## Load Messages
-
 
 **Description:**
 
-
 Sends faction-based messages when players first load their character
 
-
 **Features:**
-
 
 * Shows a welcome message when players load in
 
@@ -837,24 +621,17 @@ Sends faction-based messages when players first load their character
 
 [**Module Website**](https://liliaframework.github.io/Modules/loadmessages.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loadmessages.zip)
-
 
 ---
 
-
 ## Loyalism
-
 
 **Description:**
 
-
 System for loyalist tiers
 
-
 **Features:**
-
 
 * System of loyalist tiers that players can gain
 
@@ -864,24 +641,17 @@ System for loyalist tiers
 
 [**Module Website**](https://liliaframework.github.io/Modules/loyalism.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/loyalism.zip)
-
 
 ---
 
-
 ## Map Cleaner
-
 
 **Description:**
 
-
 Adds a map cleaner with configurable timings
 
-
 **Features:**
-
 
 * Periodically cleans dropped items and debris
 
@@ -891,24 +661,17 @@ Adds a map cleaner with configurable timings
 
 [**Module Website**](https://liliaframework.github.io/Modules/mapcleaner.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/mapcleaner.zip)
-
 
 ---
 
-
 ## Model Pay
-
 
 **Description:**
 
-
 Adds a system to pay per model
 
-
 **Features:**
-
 
 * Charges players currency based on their chosen model
 
@@ -918,24 +681,17 @@ Adds a system to pay per model
 
 [**Module Website**](https://liliaframework.github.io/Modules/modelpay.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modelpay.zip)
-
 
 ---
 
-
 ## Model Tweaker
-
 
 **Description:**
 
-
 Adds a Model-Tweaker entity
 
-
 **Features:**
-
 
 * Entity that lets admins tweak model bodygroups and skins
 
@@ -945,24 +701,17 @@ Adds a Model-Tweaker entity
 
 [**Module Website**](https://liliaframework.github.io/Modules/modeltweaker.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/modeltweaker.zip)
-
 
 ---
 
-
 ## NPC Drops
-
 
 **Description:**
 
-
 Adds NPCs that drop items
 
-
 **Features:**
-
 
 * NPCs can drop items when killed based on weighted tables
 
@@ -972,24 +721,17 @@ Adds NPCs that drop items
 
 [**Module Website**](https://liliaframework.github.io/Modules/npcdrop.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcdrop.zip)
-
 
 ---
 
-
 ## NPC Spawner
-
 
 **Description:**
 
-
 Adds automatic NPC spawning
 
-
 **Features:**
-
 
 * Automatically spawns NPCs at defined points
 
@@ -999,24 +741,17 @@ Adds automatic NPC spawning
 
 [**Module Website**](https://liliaframework.github.io/Modules/npcspawner.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/npcspawner.zip)
-
 
 ---
 
-
 ## Perma Remove
-
 
 **Description:**
 
-
 Allows staff to permanently remove map entities
 
-
 **Features:**
-
 
 * Allows staff to permanently remove map entities
 
@@ -1026,24 +761,17 @@ Allows staff to permanently remove map entities
 
 [**Module Website**](https://liliaframework.github.io/Modules/permaremove.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/permaremove.zip)
-
 
 ---
 
-
 ## Radio
-
 
 **Description:**
 
-
 Radio system
 
-
 **Features:**
-
 
 * Adds handheld radios with multiple channels
 
@@ -1053,24 +781,17 @@ Radio system
 
 [**Module Website**](https://liliaframework.github.io/Modules/radio.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/radio.zip)
-
 
 ---
 
-
 ## Raised Weapons
-
 
 **Description:**
 
-
 Adds a safety system that holsters sweps
 
-
 **Features:**
-
 
 * Implements a holster/safety system for weapons
 
@@ -1080,24 +801,17 @@ Adds a safety system that holsters sweps
 
 [**Module Website**](https://liliaframework.github.io/Modules/raisedweapons.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/raisedweapons.zip)
-
 
 ---
 
-
 ## Realistic Damage
-
 
 **Description:**
 
-
 Adds damage scalers for realism
 
-
 **Features:**
-
 
 * Damage scaling for more realistic combat
 
@@ -1107,24 +821,17 @@ Adds damage scalers for realism
 
 [**Module Website**](https://liliaframework.github.io/Modules/realisticdamage.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticdamage.zip)
-
 
 ---
 
-
 ## Realistic View
-
 
 **Description:**
 
-
 Adds a realistic 1st-person view that allows you to see the entire body
 
-
 **Features:**
-
 
 * Shows the player body in first person
 
@@ -1134,24 +841,17 @@ Adds a realistic 1st-person view that allows you to see the entire body
 
 [**Module Website**](https://liliaframework.github.io/Modules/realisticview.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/realisticview.zip)
-
 
 ---
 
-
 ## Rumour
-
 
 **Description:**
 
-
 Adds a Rumour command
 
-
 **Features:**
-
 
 * Adds a `/rumour` chat command for sharing gossip
 
@@ -1161,24 +861,17 @@ Adds a Rumour command
 
 [**Module Website**](https://liliaframework.github.io/Modules/rumour.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/rumour.zip)
-
 
 ---
 
-
 ## Shoot Locks
-
 
 **Description:**
 
-
 Shoot locks to open doors
 
-
 **Features:**
-
 
 * Allows shooting certain locks to open doors
 
@@ -1188,24 +881,17 @@ Shoot locks to open doors
 
 [**Module Website**](https://liliaframework.github.io/Modules/shootlock.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/shootlock.zip)
-
 
 ---
 
-
 ## Lockpicking
-
 
 **Description:**
 
-
 Adds simple lockpicking to brute-force doors
 
-
 **Features:**
-
 
 * Brute-force-style lockpicking minigame
 
@@ -1215,24 +901,17 @@ Adds simple lockpicking to brute-force doors
 
 [**Module Website**](https://liliaframework.github.io/Modules/simple_lockpicking.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/simple_lockpicking.zip)
-
 
 ---
 
-
 ## Slots
-
 
 **Description:**
 
-
 Adds a slot-machine entity
 
-
 **Features:**
-
 
 * Slot machine entity that players can gamble on
 
@@ -1242,24 +921,17 @@ Adds a slot-machine entity
 
 [**Module Website**](https://liliaframework.github.io/Modules/slots.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slots.zip)
-
 
 ---
 
-
 ## Heavy Weapons
-
 
 **Description:**
 
-
 Slows movement when carrying heavy weapons
 
-
 **Features:**
-
 
 * Heavy weapons slow down player movement
 
@@ -1269,24 +941,17 @@ Slows movement when carrying heavy weapons
 
 [**Module Website**](https://liliaframework.github.io/Modules/slowweapons.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/slowweapons.zip)
-
 
 ---
 
-
 ## Stun Gun
-
 
 **Description:**
 
-
 A stun gun reworked from CustomHQ
 
-
 **Features:**
-
 
 * Non-lethal stun-gun weapon
 
@@ -1296,24 +961,17 @@ A stun gun reworked from CustomHQ
 
 [**Module Website**](https://liliaframework.github.io/Modules/stungun.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/stungun.zip)
-
 
 ---
 
-
 ## Tying
-
 
 **Description:**
 
-
 Adds tying items that serve as handcuffs, enhancing role-play
 
-
 **Features:**
-
 
 * Adds handcuff-style tying items
 
@@ -1323,24 +981,17 @@ Adds tying items that serve as handcuffs, enhancing role-play
 
 [**Module Website**](https://liliaframework.github.io/Modules/tying.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/tying.zip)
-
 
 ---
 
-
 ## View Bob
-
 
 **Description:**
 
-
 Adds custom view-bob
 
-
 **Features:**
-
 
 * Adds camera bobbing while moving
 
@@ -1350,24 +1001,17 @@ Adds custom view-bob
 
 [**Module Website**](https://liliaframework.github.io/Modules/viewbob.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/viewbob.zip)
-
 
 ---
 
-
 ## VManip
-
 
 **Description:**
 
-
 Adds VManip compatibility to Lilia
 
-
 **Features:**
-
 
 * Integrates VManip animations with the framework
 
@@ -1377,24 +1021,17 @@ Adds VManip compatibility to Lilia
 
 [**Module Website**](https://liliaframework.github.io/Modules/vmanip.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/vmanip.zip)
-
 
 ---
 
-
 ## Warrant
-
 
 **Description:**
 
-
 Adds warrants
 
-
 **Features:**
-
 
 * System for creating and tracking search warrants
 
@@ -1404,24 +1041,17 @@ Adds warrants
 
 [**Module Website**](https://liliaframework.github.io/Modules/warrants.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/warrants.zip)
-
 
 ---
 
-
 ## War Table
-
 
 **Description:**
 
-
 Adds an interactive war table
 
-
 **Features:**
-
 
 * Interactive war-table entity for planning
 
@@ -1431,24 +1061,17 @@ Adds an interactive war table
 
 [**Module Website**](https://liliaframework.github.io/Modules/wartable.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wartable.zip)
-
 
 ---
 
-
 ## Weight Inv
-
 
 **Description:**
 
-
 Adds a weight-based inventory
 
-
 **Features:**
-
 
 * Inventory system that tracks total weight
 
@@ -1458,24 +1081,17 @@ Adds a weight-based inventory
 
 [**Module Website**](https://liliaframework.github.io/Modules/weightinv.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/weightinv.zip)
-
 
 ---
 
-
 ## Whitelist
-
 
 **Description:**
 
-
 Adds a server whitelist
 
-
 **Features:**
-
 
 * Simple server whitelist management
 
@@ -1485,24 +1101,17 @@ Adds a server whitelist
 
 [**Module Website**](https://liliaframework.github.io/Modules/whitelist.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/whitelist.zip)
-
 
 ---
 
-
 ## Word Filter
-
 
 **Description:**
 
-
 Filters unwanted words out of the chat
 
-
 **Features:**
-
 
 * Filters unwanted words from chat
 
@@ -1512,8 +1121,6 @@ Filters unwanted words out of the chat
 
 [**Module Website**](https://liliaframework.github.io/Modules/wordfilter.html)
 
-
 [**Download Here**](https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/Downloads/wordfilter.zip)
-
 
 ---


### PR DESCRIPTION
## Summary
- remove extra spacing in command definition docs but keep one blank line after each standard line
- avoid inserting blank lines in table rows and Lua code blocks
- apply same spacing rules to all documentation

## Testing
- `git diff --stat HEAD~1`

------
https://chatgpt.com/codex/tasks/task_e_68621356d06c83278e06377695b08290