### PR TITLE
Ensure character name prefix is always applied

### DIFF
--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -6979,6 +6979,7 @@ end)
 **Description:**
 
 Retrieves a default name for a character during creation. Return `(defaultName, overrideBool)`.
+If the character's faction defines a prefix it will automatically be prepended to the name.
 
 **Parameters:**
 

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -109,10 +109,22 @@ lia.char.registerVar("name", {
     end,
     onAdjust = function(client, data, value, newData)
         local name, override = hook.Run("GetDefaultCharName", client, data.faction, data)
+        local info = lia.faction.indices[data.faction]
+        local prefix = info and (isfunction(info.prefix) and info.prefix(client) or info.prefix) or ""
+
         if isstring(name) and override then
-            newData.name = name
+            if prefix ~= "" then
+                newData.name = string.Trim(prefix .. " " .. name)
+            else
+                newData.name = name
+            end
         else
-            newData.name = string.Trim(value):sub(1, 70)
+            local trimmed = string.Trim(value):sub(1, 70)
+            if prefix ~= "" then
+                newData.name = string.Trim(prefix .. " " .. trimmed)
+            else
+                newData.name = trimmed
+            end
         end
     end,
 })

--- a/modules/core/teams/libraries/shared.lua
+++ b/modules/core/teams/libraries/shared.lua
@@ -23,10 +23,7 @@ function MODULE:GetDefaultCharName(client, faction, data)
     end
     baseName = baseName or client:SteamName()
 
-    local prefix = info and (isfunction(info.prefix) and info.prefix(client) or info.prefix) or ""
-    local nameWithPrefix = prefix ~= "" and string.Trim(prefix .. " " .. baseName) or baseName
-
-    return nameWithPrefix, false
+    return baseName, false
 end
 
 function MODULE:GetDefaultCharDesc(client, faction)


### PR DESCRIPTION
## Summary
- keep GetDefaultCharName focused on base name only
- always apply faction prefix to character names when adjusting data
- document that prefixes are prepended automatically

## Testing
- `luacheck .` *(fails: many warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e4f8ab7883279f281319424fb5ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation for character naming to clarify that faction prefixes are automatically added to default names when applicable.

* **Bug Fixes**
  * Ensured that faction prefixes are consistently prepended to character names when creating or adjusting characters, regardless of whether a default or custom name is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->