### PR TITLE
Fix stamina bar and remove unused args

### DIFF
--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -73,7 +73,7 @@ hook.Add("CreateInformationButtons", "liaInformationFlags", function(pages)
                     flagPanel:Dock(TOP)
                     flagPanel:DockMargin(10, 5, 10, 0)
                     flagPanel:SetTall(height)
-                    flagPanel.Paint = function(pnl, w, h)
+                    flagPanel.Paint = function(_, w, h)
                         local hasFlag = client:getChar():hasFlags(flagName)
                         local status = hasFlag and "✓" or "✗"
                         local statusColor = hasFlag and Color(0, 255, 0) or Color(255, 0, 0)

--- a/modules/attributes/libraries/client.lua
+++ b/modules/attributes/libraries/client.lua
@@ -73,5 +73,8 @@ end
 
 lia.bar.add(function()
     local client = LocalPlayer()
-    return client:getLocalVar("stamina", 0) / 100
+    local char = client:getChar()
+    if not char then return 0 end
+    local max = char:getMaxStamina()
+    return (predictedStamina or client:getLocalVar("stamina", max)) / max
 end, Color(200, 200, 40), nil, "stamina")

--- a/modules/inventory/gridinv.lua
+++ b/modules/inventory/gridinv.lua
@@ -277,7 +277,7 @@ if SERVER then
 
             targetInventory:addItem(newItem, noReplicate)
             d:resolve(newItem)
-        end):next(function(resultItem)
+        end):next(function()
             if isStackCommand and remainingQuantity > 0 then
                 for targetItem, assignedQuantity in pairs(targetAssignments) do
                     targetItem:addQuantity(assignedQuantity)


### PR DESCRIPTION
## Summary
- use predicted stamina and character max for stamina bar
- mark unused paint argument in flags panel
- remove unused argument from grid inventory

## Testing
- `luacheck modules/inventory/gridinv.lua gamemode/core/libraries/flags.lua` *(fails: gamemode/core/libraries/flags.lua:66:57: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_6863511cfcb88327901bdd8e5492046a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The stamina bar now accurately reflects each character's unique maximum stamina, providing a more personalized display.

* **Refactor**
  * Improved code clarity by updating parameter names and removing unused parameters in internal functions, with no impact on user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->