### PR TITLE
Add hooks for setLocalVar and setNetVar

### DIFF
--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -2988,6 +2988,80 @@ end)
 
 ---
 
+### LocalVarChanged
+
+**Description:**
+
+Triggered when `setLocalVar` updates a player's local variable. Provides both the old and new values.
+
+**Parameters:**
+
+* player (Player) – Affected player.
+
+* key (string) – Variable name.
+
+* oldValue (any) – Previous value.
+
+* value (any) – New value.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+-- Print when a player's stamina local var changes
+hook.Add("LocalVarChanged", "TrackStamina", function(ply, k, old, new)
+    if k == "stamina" then
+        print(ply:Name(), "stamina:", new)
+    end
+end)
+```
+
+---
+
+### NetVarChanged
+
+**Description:**
+
+Runs when `setNetVar` changes an entity's networked variable. Works for global variables when the entity argument is nil.
+
+**Parameters:**
+
+* entity (Entity|nil) – Entity with the updated variable, or nil for global vars.
+
+* key (string) – Variable name.
+
+* oldValue (any) – Previous value.
+
+* value (any) – New value.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+-- React to door network vars
+hook.Add("NetVarChanged", "WatchDoors", function(ent, k, old, new)
+    if IsValid(ent) and ent:isDoor() then
+        print("Door var", k, "changed to", new)
+    end
+end)
+```
+
+---
+
 ### ItemDataChanged
 
 **Description:**

--- a/docs/docs/libraries/lia.networking.md
+++ b/docs/docs/libraries/lia.networking.md
@@ -18,6 +18,8 @@ Stores a global networked variable and broadcasts it to clients. When a
 
 receiver is specified the update is only sent to those players.
 
+Calling this fires the **NetVarChanged** hook on both server and clients.
+
 **Parameters:**
 
 * key (string) – Name of the variable.

--- a/docs/docs/meta/entity.md
+++ b/docs/docs/meta/entity.md
@@ -721,6 +721,8 @@ end
 
 Updates a network variable and sends it to recipients.
 
+This will trigger the **NetVarChanged** hook on both server and client.
+
 **Parameters:**
 
 * key (string) – Variable name.

--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -2156,6 +2156,8 @@ player:syncVars()
 
 Sets a networked local variable on the player.
 
+Triggers the **LocalVarChanged** hook on both server and client.
+
 **Parameters:**
 
 * key (string) – Variable name.

--- a/gamemode/core/libraries/networking.lua
+++ b/gamemode/core/libraries/networking.lua
@@ -16,9 +16,11 @@ if SERVER then
 
     function setNetVar(key, value, receiver)
         if checkBadType(key, value) then return end
-        if getNetVar(key) == value then return end
+        local oldValue = getNetVar(key)
+        if oldValue == value then return end
         lia.net.globals[key] = value
         netstream.Start(receiver, "gVar", key, value)
+        hook.Run("NetVarChanged", nil, key, oldValue, value)
     end
 
     function getNetVar(key, default)

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -137,8 +137,10 @@ if SERVER then
     function entityMeta:setNetVar(key, value, receiver)
         if checkBadType(key, value) then return end
         lia.net[self] = lia.net[self] or {}
-        if lia.net[self][key] ~= value then lia.net[self][key] = value end
+        local oldValue = lia.net[self][key]
+        if oldValue ~= value then lia.net[self][key] = value end
         self:sendNetVar(key, receiver)
+        hook.Run("NetVarChanged", self, key, oldValue, value)
     end
 
     function entityMeta:getNetVar(key, default)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -754,8 +754,10 @@ if SERVER then
     function playerMeta:setLocalVar(key, value)
         if checkBadType(key, value) then return end
         lia.net[self] = lia.net[self] or {}
+        local oldValue = lia.net[self][key]
         lia.net[self][key] = value
         netstream.Start(self, "nLcl", key, value)
+        hook.Run("LocalVarChanged", self, key, oldValue, value)
     end
 else
     function playerMeta:getPlayTime()

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -246,12 +246,18 @@ end)
 
 netstream.Hook("nVar", function(index, key, value)
     lia.net[index] = lia.net[index] or {}
+    local oldValue = lia.net[index][key]
     lia.net[index][key] = value
+    local entity = Entity(index)
+    if IsValid(entity) then hook.Run("NetVarChanged", entity, key, oldValue, value) end
 end)
 
 netstream.Hook("nLcl", function(key, value)
-    lia.net[LocalPlayer():EntIndex()] = lia.net[LocalPlayer():EntIndex()] or {}
-    lia.net[LocalPlayer():EntIndex()][key] = value
+    local idx = LocalPlayer():EntIndex()
+    lia.net[idx] = lia.net[idx] or {}
+    local oldValue = lia.net[idx][key]
+    lia.net[idx][key] = value
+    hook.Run("LocalVarChanged", LocalPlayer(), key, oldValue, value)
 end)
 
 net.Receive("actBar", function()
@@ -560,5 +566,9 @@ end)
 
 netstream.Hook("charInfo", function(data, id, client) lia.char.loaded[id] = lia.char.new(data, id, client == nil and LocalPlayer() or client) end)
 netstream.Hook("charKick", function(id, isCurrentChar) hook.Run("KickedFromChar", id, isCurrentChar) end)
-netstream.Hook("gVar", function(key, value) lia.net.globals[key] = value end)
+netstream.Hook("gVar", function(key, value)
+    local oldValue = lia.net.globals[key]
+    lia.net.globals[key] = value
+    hook.Run("NetVarChanged", nil, key, oldValue, value)
+end)
 netstream.Hook("nDel", function(index) lia.net[index] = nil end)


### PR DESCRIPTION
## Summary
- fire new `LocalVarChanged` and `NetVarChanged` hooks
- document the two new hooks
- note hook behavior in player and entity docs
- trigger hooks clientside when receiving net messages

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/core/meta/entity.lua gamemode/core/netcalls/client.lua gamemode/core/libraries/networking.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_68635cba9a2483279b0fb43cd93bbade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced hooks that notify when player local variables or entity networked variables change, allowing for real-time responses to these updates.

* **Documentation**
  * Updated documentation to describe the new hooks and clarify that certain functions now trigger these hooks when variables are updated. Usage examples and detailed descriptions were added for better understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->