### PR TITLE
Document isGloballyRecognized field

### DIFF
--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -44,6 +44,7 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `bodyGroups` | `table` | `{}` | Bodygroup name→index mapping applied on spawn. |
 | `NPCRelations` | `table` | `{}` | NPC class→disposition mapping on spawn/creation. |
 | `RecognizesGlobally` | `boolean` | `false` | Global player recognition. |
+| `isGloballyRecognized` | `boolean` | `false` | Everyone automatically recognizes this faction.
 | `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 
 ---
@@ -531,6 +532,22 @@ If `true`, members recognize all players globally, regardless of faction.
 ```lua
 FACTION.RecognizesGlobally = false
 ```
+#### `isGloballyRecognized`
+
+**Type:**
+
+`boolean`
+
+**Description:**
+
+If set to `true`, all players will automatically recognize members of this faction.
+
+**Example Usage:**
+
+```lua
+FACTION.isGloballyRecognized = true
+```
+
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify faction docs by documenting `isGloballyRecognized`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686376706f508327a0311d8c5b58ef94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated faction documentation to include the new boolean field `isGloballyRecognized`, detailing its purpose, default value, and usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->