### PR TITLE
Fix upvalue shadowing warnings

### DIFF
--- a/modules/doors/commands.lua
+++ b/modules/doors/commands.lua
@@ -454,11 +454,11 @@ lia.command.add("dooraddfaction", {
                 local json = util.TableToJSON(facs)
                 door:setNetVar("factions", json)
                 MODULE:callOnDoorChildren(door, function()
-                    local facs = door:getNetVar("factions", "[]")
-                    facs = util.JSONToTable(facs)
-                    facs[faction.index] = true
-                    local json = util.TableToJSON(facs)
-                    door:setNetVar("factions", json)
+                    local childFacs = door:getNetVar("factions", "[]")
+                    childFacs = util.JSONToTable(childFacs)
+                    childFacs[faction.index] = true
+                    local childJson = util.TableToJSON(childFacs)
+                    door:setNetVar("factions", childJson)
                 end)
 
                 lia.log.add(client, "doorSetFaction", door, faction.name)
@@ -504,11 +504,11 @@ lia.command.add("doorremovefaction", {
                 local json = util.TableToJSON(facs)
                 door:setNetVar("factions", json)
                 MODULE:callOnDoorChildren(door, function()
-                    local facs = door:getNetVar("factions", "[]")
-                    facs = util.JSONToTable(facs)
-                    facs[faction.index] = nil
-                    local json = util.TableToJSON(facs)
-                    door:setNetVar("factions", json)
+                    local childFacs = door:getNetVar("factions", "[]")
+                    childFacs = util.JSONToTable(childFacs)
+                    childFacs[faction.index] = nil
+                    local childJson = util.TableToJSON(childFacs)
+                    door:setNetVar("factions", childJson)
                 end)
 
                 lia.log.add(client, "doorRemoveFaction", door, faction.name)


### PR DESCRIPTION
## Summary
- fix variable shadowing inside door faction commands

## Testing
- `luacheck modules/doors/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c60e3ae48327809ecd9f6ee8dae3