### PR TITLE
Fix variable shadowing warnings

### DIFF
--- a/gamemode/core/derma/panels/scoreboard.lua
+++ b/gamemode/core/derma/panels/scoreboard.lua
@@ -229,9 +229,9 @@ function PANEL:addPlayer(ply, parent)
     slot.model:SetModel(ply:GetModel(), ply:GetSkin())
     slot.model:SetCamPos(Vector(0, 0, 55))
     slot.model:SetLookAt(Vector(0, 0, 0))
-    slot.model.LayoutEntity = function(self, ent)
+    slot.model.LayoutEntity = function(_, ent)
         ent:SetAngles(Angle(0, 0, 0))
-        self:RunAnimation()
+        slot.model:RunAnimation()
     end
 
     for i = 0, ply:GetNumBodyGroups() - 1 do

--- a/gamemode/core/libraries/thirdperson.lua
+++ b/gamemode/core/libraries/thirdperson.lua
@@ -82,7 +82,7 @@ hook.Add("CreateMove", "liaThirdPersonCreateMove", function(cmd)
     end
 end)
 
-hook.Add("InputMouseApply", "liaThirdPersonInputMouseApply", function(cmd, x, y)
+hook.Add("InputMouseApply", "liaThirdPersonInputMouseApply", function(_, x, y)
     local client = LocalPlayer()
     if not client.camAng then client.camAng = angle_zero end
     if client:CanOverrideView() and client:GetViewEntity() == client then

--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -183,14 +183,14 @@ else
         if not lia.config.get("AutoDownloadWorkshop", true) then return end
         table.insert(pages, {
             name = L("workshopAddons"),
-            drawFunc = function(panel)
+            drawFunc = function(container)
                 local ids = gather()
-                local search = vgui.Create("DTextEntry", panel)
+                local search = vgui.Create("DTextEntry", container)
                 search:Dock(TOP)
                 search:DockMargin(0, 0, 0, 5)
                 search:SetTall(30)
                 search:SetPlaceholderText(L("searchAddons"))
-                local info = vgui.Create("DPanel", panel)
+                local info = vgui.Create("DPanel", container)
                 info:Dock(TOP)
                 info:DockMargin(10, 0, 10, 5)
                 info:SetTall(30)
@@ -201,7 +201,7 @@ else
                 lbl:SetTextColor(color_white)
                 lbl:SetContentAlignment(5)
                 lbl:SetText(L("totalAutoAddons", table.Count(ids)))
-                local sc = vgui.Create("DScrollPanel", panel)
+                local sc = vgui.Create("DScrollPanel", container)
                 sc:Dock(FILL)
                 sc:DockPadding(0, 10, 0, 0)
                 local canvas = sc:GetCanvas()

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -157,12 +157,12 @@ local DisallowedTools = {
 }
 
 function GM:CanTool(client, _, tool)
-    local function CheckDuplicationScale(client, entities)
+    local function CheckDuplicationScale(ply, entities)
         entities = entities or {}
         for _, v in pairs(entities) do
             if v.ModelScale and v.ModelScale > 10 then
-                client:notifyLocalized("duplicationSizeLimit")
-                print("[Server Warning] Potential server crash using dupes attempt by player: " .. client:Name() .. " (" .. client:SteamID64() .. ")")
+                ply:notifyLocalized("duplicationSizeLimit")
+                print("[Server Warning] Potential server crash using dupes attempt by player: " .. ply:Name() .. " (" .. ply:SteamID64() .. ")")
                 return false
             end
 

--- a/modules/inventory/derma/cl_grid_inventory_item.lua
+++ b/modules/inventory/derma/cl_grid_inventory_item.lua
@@ -51,7 +51,7 @@ function PANEL:setItemType(itemTypeOrID)
     self:updateTooltip()
     if item.icon then
         self.Icon:SetVisible(false)
-        self.ExtraPaint = function(self, w, h) drawIcon(item.icon, self, w, h) end
+        self.ExtraPaint = function(_, w, h) drawIcon(item.icon, self, w, h) end
     else
         renderNewIcon(self, item)
     end

--- a/modules/inventory/items/base/bags.lua
+++ b/modules/inventory/items/base/bags.lua
@@ -54,14 +54,14 @@ ITEM.functions.View = {
     onClick = function(item)
         local inventory = item:getInv()
         if not inventory then return false end
-        local panel = lia.gui["inv" .. inventory:getID()]
+        local existingPanel = lia.gui["inv" .. inventory:getID()]
         local parent = item.invID and lia.gui["inv" .. item.invID] or nil
-        if IsValid(panel) then panel:Remove() end
+        if IsValid(existingPanel) then existingPanel:Remove() end
         if inventory then
-            local panel = lia.inventory.show(inventory, parent)
-            if IsValid(panel) then
-                panel:ShowCloseButton(true)
-                panel:SetTitle(item:getName())
+            local invPanel = lia.inventory.show(inventory, parent)
+            if IsValid(invPanel) then
+                invPanel:ShowCloseButton(true)
+                invPanel:SetTitle(item:getName())
             end
         end
         return false
@@ -123,9 +123,9 @@ function ITEM:onCombine(other)
     if not invID then return end
     local res = hook.Run("HandleItemTransferRequest", client, other:getID(), nil, nil, invID)
     if not res then return end
-    res:next(function(res)
+    res:next(function(result)
         if not IsValid(client) then return end
-        if istable(res) and isstring(res.error) then return client:notifyLocalized(res.error) end
+        if istable(result) and isstring(result.error) then return client:notifyLocalized(result.error) end
         client:EmitSound(unpack(self.BagSound))
     end)
 end


### PR DESCRIPTION
## Summary
- adjust ExtraPaint parameter to avoid self shadowing
- avoid reusing local variable names in bag inventory UI
- fix result callback variable name in bags
- rename parameter in duplication check function
- update workshop info draw function argument
- note unused command argument in thirdperson library
- prevent scoreboard model layout callback from shadowing

## Testing
- `luarocks install luacheck`
- `luacheck modules/inventory/derma/cl_grid_inventory_item.lua modules/inventory/items/base/bags.lua modules/administration/submodules/permissions/libraries/server.lua gamemode/core/libraries/workshop.lua gamemode/core/libraries/thirdperson.lua gamemode/core/derma/panels/scoreboard.lua`

------
https://chatgpt.com/codex/tasks/task_e_6863c75675ec83279091cb47bc780ebe