### PR TITLE
Add command access overrides via hook and faction/class

### DIFF
--- a/docs/docs/definitions/class.md
+++ b/docs/docs/definitions/class.md
@@ -39,6 +39,7 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `model` | `string` | `""` | Model path (or table of paths) used by this class. |
 | `index` | `number` | `auto` | Unique team index assigned at registration. |
 | `uniqueID` | `string` | `filename` | Optional identifier; defaults to the file name when omitted. |
+| `commands` | `table` | `{}` | Command names members may always use. |
 
 ---
 
@@ -511,6 +512,27 @@ Model path (or list of paths) assigned to this class.
 
 ```lua
 CLASS.model = "models/player/alyx.mdl"
+```
+
+---
+
+#### `commands`
+
+**Type:**
+
+`table`
+
+**Description:**
+
+Table of command names that members of this class may always use,
+overriding standard command permissions.
+
+**Example Usage:**
+
+```lua
+CLASS.commands = {
+    plytransfer = true,
+}
 ```
 
 ---

--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -46,6 +46,7 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `RecognizesGlobally` | `boolean` | `false` | Global player recognition. |
 | `isGloballyRecognized` | `boolean` | `false` | Everyone automatically recognizes this faction.
 | `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
+| `commands` | `table` | `{}` | Command names members may always use. |
 
 ---
 
@@ -604,6 +605,27 @@ If `true`, members of this faction are hidden from the scoreboard.
 
 ```lua
 FACTION.ScoreboardHidden = false
+```
+
+---
+
+#### `commands`
+
+**Type:**
+
+`table`
+
+**Description:**
+
+Table of command names that members of this faction may always use,
+even if they normally lack the required privilege.
+
+**Example Usage:**
+
+```lua
+FACTION.commands = {
+    plytransfer = true,
+}
 ```
 
 ---

--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -6689,7 +6689,9 @@ end)
 
 **Description:**
 
-Determines if a player can use a specific command. Return `false` to block usage.
+Determines if a player can use a specific command. Returning either
+`true` or `false` overrides the normal permission logic; returning
+`nil` falls back to the default checks.
 
 **Parameters:**
 
@@ -6706,7 +6708,8 @@ Determines if a player can use a specific command. Return `false` to block usage
 
 **Returns:**
 
-* boolean|nil: false to block, nil to allow.
+* boolean|nil: non-nil values override the result; return `nil` to
+  allow built‑in checks to decide.
 
 
 **Example Usage:**

--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -43,6 +43,11 @@ Registers a new command with its associated data.
 **Description:**
 
 Determines if a player may run the specified command.
+Before checking CAMI privileges, the function consults the
+`CanPlayerUseCommand` hook. If that hook returns either `true` or
+`false`, the result overrides the default permission logic. In
+addition, factions and classes can whitelist commands by placing them
+in a `commands` table on their definition.
 
 **Parameters:**
 
@@ -71,7 +76,17 @@ Determines if a player may run the specified command.
 **Example Usage:**
 
 ```lua
-    -- TODO
+-- Whitelist `/plytransfer` for the "Staff" faction
+FACTION.commands = {
+    plytransfer = true,
+}
+
+-- Globally block a command for non-admins via hook
+hook.Add("CanPlayerUseCommand", "BlockReserve", function(client, cmd)
+    if cmd == "reserve" and not client:IsAdmin() then
+        return false
+    end
+end)
 ```
 
 ### lia.command.extractArgs

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -63,7 +63,24 @@ function lia.command.hasAccess(client, command, data)
         hasAccess = client:hasPrivilege(privilegeName)
     end
 
-    if hook.Run("CanPlayerUseCommand", client, command) == false then hasAccess = false end
+    local hookResult = hook.Run("CanPlayerUseCommand", client, command)
+    if hookResult ~= nil then
+        return hookResult, privilege
+    end
+
+    local char = IsValid(client) and client.getChar and client:getChar()
+    if char then
+        local faction = lia.faction.indices[char:getFaction()]
+        if faction and faction.commands and faction.commands[command] then
+            return true, privilege
+        end
+
+        local classData = lia.class.list[char:getClass()]
+        if classData and classData.commands and classData.commands[command] then
+            return true, privilege
+        end
+    end
+
     return hasAccess, privilege
 end
 


### PR DESCRIPTION
## Summary
- allow `CanPlayerUseCommand` hook to override command access result
- permit factions and classes to whitelist commands with a `commands` table
- document override behavior and new fields in the docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68669c2078c88327a8c718985048a672