### PR TITLE
Add perma-prop save logging

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -826,4 +826,5 @@ LANGUAGE = {
     ToggleCarBlacklist = "Toggle Car Blacklist",
     addedToBlacklist = "Added to blacklist: %s",
     removedFromBlacklist = "Removed from blacklist: %s",
+    permaPropOverlapWarning = "Warning: perma-props spawning too close together!",
 }

--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -572,5 +572,15 @@
     ["unprotectedVJNetCall"] = {
         func = function(client, netMessage) return string.format("[%s] %s triggered unprotected net message '%s'", client:SteamID64(), client:Name(), netMessage) end,
         category = "VJ Base"
+    },
+    ["permaPropSaved"] = {
+        func = function(client, class, model, pos)
+            return string.format("[%s] %s perma-propped %s (%s) at %s", client:SteamID64(), client:Name(), class, model, pos)
+        end,
+        category = "PermaProps"
+    },
+    ["permaPropOverlap"] = {
+        func = function(_, pos, other) return string.format("Perma-prop spawned at %s overlapping prop at %s.", pos, other) end,
+        category = "PermaProps"
     }
 }


### PR DESCRIPTION
## Summary
- warn if perma-props spawn too close together
- log overlapping spawns in the admin log
- track player who saves a perma-prop and log it
- remove comments from perma-prop compatibility library

## Testing
- `luacheck gamemode/core/libraries/compatibility/permaprops.lua gamemode/languages/english.lua modules/administration/submodules/logging/logs.lua` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6866a602d7f0832788610f476e2e8641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring and warning for permanent props placed too close together, including localized warning messages.
  * Implemented detailed logging for when permanent props are saved and when overlaps are detected.

* **Bug Fixes**
  * Improved detection and prevention of overlapping permanent props to enhance map stability.

* **Documentation**
  * Added a new English language entry for overlap warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->