### PR TITLE
Remove unused exploit log categories

### DIFF
--- a/gamemode/core/libraries/compatibility/advdupe.lua
+++ b/gamemode/core/libraries/compatibility/advdupe.lua
@@ -3,7 +3,7 @@
     for _, ent in pairs(entities) do
         if ent.ModelScale and ent.ModelScale > 10 then
             client:notifyLocalized("duplicationSizeLimit")
-            print("[Server Warning] Potential server crash using dupes attempt by player: " .. client:Name() .. " (" .. client:SteamID64() .. ")")
+            lia.log.add(client, "dupeCrashAttempt")
             return false
         end
 

--- a/gamemode/core/libraries/compatibility/advdupe2.lua
+++ b/gamemode/core/libraries/compatibility/advdupe2.lua
@@ -3,7 +3,7 @@
     for _, ent in pairs(entities) do
         if ent.ModelScale and ent.ModelScale > 10 then
             client:notifyLocalized("duplicationSizeLimit")
-            print("[Server Warning] Potential server crash using dupes attempt by player: " .. client:Name() .. " (" .. client:SteamID64() .. ")")
+            lia.log.add(client, "dupeCrashAttempt")
             return false
         end
 

--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -149,6 +149,14 @@
         func = function(client) return string.format("Client [%s] %s triggered hack detection.", client:SteamID64(), client:Name()) end,
         category = "Connections"
     },
+    ["dupeCrashAttempt"] = {
+        func = function(client)
+            local name = IsValid(client) and client:Name() or "Unknown"
+            local steamID = IsValid(client) and client:SteamID64() or "N/A"
+            return string.format("Player '%s' [%s] attempted to duplicate oversized entities.", name, steamID)
+        end,
+        category = "Security"
+    },
     ["doorSetClass"] = {
         func = function(client, door, className) return string.format("Client [%s] %s set door class to %s on door %s.", client:SteamID64(), client:Name(), className, door:GetClass()) end,
         category = "Doors"

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -162,7 +162,7 @@ function GM:CanTool(client, _, tool)
         for _, v in pairs(entities) do
             if v.ModelScale and v.ModelScale > 10 then
                 ply:notifyLocalized("duplicationSizeLimit")
-                print("[Server Warning] Potential server crash using dupes attempt by player: " .. ply:Name() .. " (" .. ply:SteamID64() .. ")")
+                lia.log.add(ply, "dupeCrashAttempt")
                 return false
             end
 

--- a/modules/protection/libraries/server.lua
+++ b/modules/protection/libraries/server.lua
@@ -133,7 +133,6 @@ function MODULE:OnEntityCreated(entity)
     local class = entity:GetClass():lower():Trim()
     entity:SetCustomCollisionCheck(true)
     if class == "lua_run" and not lia.config.get("DisableLuaRun", false) then
-        print(L("notifyLuaRun"))
         function entity:AcceptInput()
             return true
         end
@@ -142,10 +141,13 @@ function MODULE:OnEntityCreated(entity)
             return true
         end
 
-        timer.Simple(0, function() SafeRemoveEntity(entity) end)
+        timer.Simple(0, function()
+            if IsValid(entity) then SafeRemoveEntity(entity) end
+        end)
     elseif class == "point_servercommand" then
-        print(L("notifyPointServer"))
-        timer.Simple(0, function() SafeRemoveEntity(entity) end)
+        timer.Simple(0, function()
+            if IsValid(entity) then SafeRemoveEntity(entity) end
+        end)
     elseif class == "prop_vehicle_prisoner_pod" then
         entity:AddEFlags(EFL_NO_THINK_FUNCTION)
     end


### PR DESCRIPTION
## Summary
- keep dupe crash attempt logging
- drop lua_run and point_servercommand entity logs

## Testing
- `luacheck modules/administration/submodules/permissions/libraries/server.lua`
- `luacheck modules/protection/libraries/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_6866bc3f45dc8327b1467a293378b01c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new security log entry for attempts to duplicate oversized entities, providing clearer tracking of such events.

* **Refactor**
  * Replaced direct server warning messages with structured logging for duplication attempts involving oversized entities.
  * Improved entity removal logic by adding validity checks before removing certain entities, reducing unnecessary errors.

* **Style**
  * Removed unnecessary debug print statements for cleaner console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->