### PR TITLE
Add SENT spawn logging

### DIFF
--- a/modules/administration/submodules/logging/libraries/server.lua
+++ b/modules/administration/submodules/logging/libraries/server.lua
@@ -148,6 +148,10 @@ function MODULE:PlayerSpawnedNPC(client, npc)
     lia.log.add(client, "spawned_npc", npc:GetClass(), npc:GetModel())
 end
 
+function MODULE:PlayerSpawnedSENT(client, sent)
+    lia.log.add(client, "spawned_sent", sent:GetClass(), sent:GetModel())
+end
+
 function MODULE:PlayerGiveSWEP(client, swep)
     lia.log.add(client, "swep_spawning", swep)
 end

--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -50,6 +50,10 @@
         func = function(client, npc, model) return string.format("Player [%s] '%s' spawned NPC '%s' with model '%s'. (CharID: %s)", client:SteamID64(), client:Name(), npc, model, client:getChar():getID()) end,
         category = "Spawn"
     },
+    ["spawned_sent"] = {
+        func = function(client, class, model) return string.format("Player [%s] '%s' spawned entity '%s' with model '%s'. (CharID: %s)", client:SteamID64(), client:Name(), class, model, client:getChar():getID()) end,
+        category = "Spawn"
+    },
     ["swep_spawning"] = {
         func = function(client, swep) return string.format("Player [%s] '%s' spawned SWEP '%s'. (CharID: %s)", client:SteamID64(), client:Name(), swep, client:getChar():getID()) end,
         category = "SWEP"


### PR DESCRIPTION
## Summary
- log PlayerSpawnedSENT events
- include new `spawned_sent` log type
- refine variable name

## Testing
- `luacheck modules/administration/submodules/logging/libraries/server.lua modules/administration/submodules/logging/logs.lua`

------
https://chatgpt.com/codex/tasks/task_e_6866c6c176808327b1b8e548766f3266