### PR TITLE
Fix schema item loading order

### DIFF
--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -59,7 +59,8 @@ It also registers the module in the module list if applicable.
 
 Initializes the module system by loading the schema and various module directories,
 
-then running the appropriate hooks after modules have been loaded.
+then running the appropriate hooks after modules have been loaded. Items within
+`schema/items/` are loaded during this stage so all modules are available first.
 
 **Parameters:**
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -43,7 +43,9 @@ local function loadExtras(path)
     end
 
     lia.includeEntities(path .. "/entities")
-    lia.item.loadFromDir(path .. "/items")
+    if MODULE.uniqueID ~= "schema" then
+        lia.item.loadFromDir(path .. "/items")
+    end
     hook.Run("DoModuleIncludes", path, MODULE)
 end
 
@@ -165,6 +167,7 @@ function lia.module.initialize()
     lia.module.loadFromDir(schemaPath .. "/modules", "module")
     lia.module.loadFromDir(schemaPath .. "/overrides", "module")
     hook.Run("InitializedModules")
+    lia.item.loadFromDir(schemaPath .. "/schema/items")
     for id, mod in pairs(lia.module.list) do
         if id ~= "schema" then
             local ok = isfunction(mod.enabled) and mod.enabled() or mod.enabled


### PR DESCRIPTION
## Summary
- skip item loading when loading the schema module
- load schema items after modules are initialized
- mention new load order in docs

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866edf81f608327a6a85da9f6a93f51