### PR TITLE
Move lia.config to database

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -260,6 +260,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_inventories`;
     DROP TABLE IF EXISTS `lia_items`;
     DROP TABLE IF EXISTS `lia_invdata`;
+    DROP TABLE IF EXISTS `lia_config`;
     DROP TABLE IF EXISTS `lilia_logs`;
 ]])
             local done = 0
@@ -284,6 +285,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_inventories;
     DROP TABLE IF EXISTS lia_items;
     DROP TABLE IF EXISTS lia_invdata;
+    DROP TABLE IF EXISTS lia_config;
 ]], realCallback)
     end
 end
@@ -344,6 +346,11 @@ function lia.db.loadTables()
                 FOREIGN KEY(_invID) REFERENCES lia_inventories(_invID),
                 PRIMARY KEY (_invID, _key)
             );
+
+            CREATE TABLE IF NOT EXISTS lia_config (
+                _key text PRIMARY KEY,
+                _value text
+            );
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -398,6 +405,12 @@ function lia.db.loadTables()
                 `_value` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
                 FOREIGN KEY (`_invID`) REFERENCES lia_inventories(_invID) ON DELETE CASCADE,
                 PRIMARY KEY (`_invID`, `_key`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_config` (
+                `_key` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`_key`)
             );
         ]])
         local i = 1

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -299,3 +299,12 @@ end
 
 handleDatabaseWipe("lia_recreatedb")
 handleDatabaseWipe("lia_wipedb")
+
+concommand.Add("lia_convertconfig", function(client)
+    if IsValid(client) then
+        client:notifyLocalized("commandConsoleOnly")
+        return
+    end
+
+    lia.config.convertToDatabase(true)
+end)


### PR DESCRIPTION
## Summary
- store configuration values in a new `lia_config` table
- migrate existing `lia.config` file data to the database
- ensure clients can't join while conversion occurs
- provide command `lia_convertconfig` to force conversion
- update wipe logic to drop the new table

## Testing
- `luacheck gamemode/core/libraries/config.lua gamemode/core/libraries/database.lua modules/administration/submodules/permissions/libraries/server.lua` *(fails: `luacheck: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866f8966e4c8327a721ec4c06736772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration settings are now stored in a database instead of legacy file-based storage.
  * Added a console command to manually trigger configuration conversion to the database.
  * Server displays a message and temporarily blocks connections during configuration conversion.

* **Improvements**
  * Configuration changes are saved directly to the database for improved reliability.

* **Bug Fixes**
  * Prevents concurrent configuration conversions to ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->