### PR TITLE
Move logs to database

### DIFF
--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -161,3 +161,33 @@ and appends the log string to a log file corresponding to its category in the lo
     -- This snippet demonstrates a common usage of lia.log.add
     lia.log.add(client, "mytype", "info")
 ```
+
+---
+
+### lia.log.convertToDatabase(changeMap)
+
+**Description:**
+
+Moves legacy log files from `data/lilia/logs` into the `lia_logs` database table.
+
+While the conversion is running, players are prevented from joining the server.
+If `changeMap` is true, the current level will reload after conversion completes.
+
+**Parameters:**
+
+* changeMap (boolean) – Whether to reload the current map when finished.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+    -- Force log conversion and reload the map
+    lia.log.convertToDatabase(true)
+```

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -261,7 +261,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_items`;
     DROP TABLE IF EXISTS `lia_invdata`;
     DROP TABLE IF EXISTS `lia_config`;
-    DROP TABLE IF EXISTS `lilia_logs`;
+    DROP TABLE IF EXISTS `lia_logs`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -286,6 +286,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_items;
     DROP TABLE IF EXISTS lia_invdata;
     DROP TABLE IF EXISTS lia_config;
+    DROP TABLE IF EXISTS lia_logs;
 ]], realCallback)
     end
 end
@@ -351,6 +352,13 @@ function lia.db.loadTables()
                 _key text PRIMARY KEY,
                 _value text
             );
+
+            CREATE TABLE IF NOT EXISTS lia_logs (
+                _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                _timestamp DATETIME,
+                _category VARCHAR,
+                _message TEXT
+            );
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -411,6 +419,14 @@ function lia.db.loadTables()
                 `_key` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_key`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_logs` (
+                `_id` INT(12) NOT NULL AUTO_INCREMENT,
+                `_timestamp` DATETIME NOT NULL,
+                `_category` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`_id`)
             );
         ]])
         local i = 1

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -308,3 +308,12 @@ concommand.Add("lia_convertconfig", function(client)
 
     lia.config.convertToDatabase(true)
 end)
+
+concommand.Add("lia_convertlogs", function(client)
+    if IsValid(client) then
+        client:notifyLocalized("commandConsoleOnly")
+        return
+    end
+
+    lia.log.convertToDatabase(true)
+end)


### PR DESCRIPTION
## Summary
- create new `lia_logs` table in the database
- migrate text log files to the database when tables are loaded
- store new log entries in the DB
- block joins during conversion and allow manual conversion with `lia_convertlogs`
- document `lia.log.convertToDatabase`

## Testing
- `luac` not available; could not run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_6866fe6ab51483279f992149b404c71d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new console command to convert legacy log files to a database format, with an option to reload the map after conversion.
  * Added support for storing logs in a database, with automatic migration from legacy text files.
  * Player connections are temporarily blocked during the log conversion process to ensure data integrity.

* **Documentation**
  * Updated logger library documentation to describe the new log conversion function and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->