### PR TITLE
Move lia.data storage to database

### DIFF
--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -6,7 +6,7 @@ This page describes persistent data storage helpers.
 
 ## Overview
 
-The data library persists key/value pairs either on disk or through the database backend. It supplies convenience methods for saving, retrieving, and deleting stored data.
+The data library persists key/value pairs. Legacy versions stored values as files within the `data/lilia` directory, but data is now written directly to the `lia_data` database table. Existing files are kept for compatibility and can be migrated using the `lia_convertdata` console command.
 
 ---
 

--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -88,8 +88,9 @@ tables. This action is irreversible and will remove all stored data.
 **Description:**
 
 Creates the required database tables if they do not already exist for
-
-storing Lilia data. This ensures the schema is properly set up.
+storing Lilia data. This includes tables such as `lia_players`,
+`lia_characters`, and the `lia_data` table used by `lia.data`.
+This ensures the schema is properly set up.
 
 **Parameters:**
 

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -1,29 +1,126 @@
-﻿file.CreateDir("lilia")
+file.CreateDir("lilia")
+
 lia.data = lia.data or {}
 lia.data.stored = lia.data.stored or {}
+lia.data.isConverting = lia.data.isConverting or false
+
+local function buildKey(key, global, ignoreMap)
+    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local prefix = ""
+    if not global then prefix = prefix .. folder .. "/" end
+    if not ignoreMap then prefix = prefix .. game.GetMap() .. "/" end
+    return prefix .. key, "lilia/" .. prefix, "lilia/" .. prefix .. key .. ".txt"
+end
+
+local function loadFromLegacy()
+    local function scan(dir, prefix, data)
+        local files, dirs = file.Find(dir .. "*", "DATA")
+        for _, f in ipairs(files) do
+            if f:sub(-4) == ".txt" then
+                local path = dir .. f
+                local content = file.Read(path, "DATA")
+                if content and content ~= "" then
+                    local ok, dec = pcall(pon.decode, content)
+                    if ok and dec then
+                        data[prefix .. f:sub(1, -5)] = dec[1]
+                    end
+                end
+            end
+        end
+        for _, d in ipairs(dirs) do
+            scan(dir .. d .. "/", prefix .. d .. "/", data)
+        end
+    end
+    local legacy = {}
+    scan("lilia/", "", legacy)
+    return legacy
+end
+
 if SERVER then
     function lia.data.set(key, value, global, ignoreMap)
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-        if not global then file.CreateDir("lilia/" .. folder .. "/") end
-        file.CreateDir(path)
-        file.Write(path .. key .. ".txt", pon.encode({value}))
-        lia.data.stored[key] = value
-        return path
+        local dbKey, dir, filePath = buildKey(key, global, ignoreMap)
+        file.CreateDir(dir)
+        file.Write(filePath, pon.encode({value}))
+        lia.data.stored[dbKey] = value
+        if lia.db and lia.db.tablesLoaded then
+            lia.db.upsert({_key = dbKey, _value = {value}}, "data")
+        end
+        return dir
     end
 
     function lia.data.delete(key, global, ignoreMap)
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-        local contents = file.Read(path .. key .. ".txt", "DATA")
+        local dbKey, _, filePath = buildKey(key, global, ignoreMap)
+        local contents = file.Read(filePath, "DATA")
         if contents and contents ~= "" then
-            file.Delete(path .. key .. ".txt")
-            lia.data.stored[key] = nil
+            file.Delete(filePath)
+            lia.data.stored[dbKey] = nil
+            if lia.db and lia.db.tablesLoaded then
+                lia.db.delete("data", "_key = " .. lia.db.convertDataType(dbKey))
+            end
             return true
         else
+            if lia.db and lia.db.tablesLoaded then
+                lia.db.delete("data", "_key = " .. lia.db.convertDataType(dbKey))
+            end
             return false
         end
     end
+
+    function lia.data.load()
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.select({"_key", "_value"}, "data"):next(function(res)
+                local rows = res.results or {}
+                if #rows == 0 then
+                    local legacy = loadFromLegacy()
+                    if next(legacy) then
+                        for k, v in pairs(legacy) do
+                            lia.data.stored[k] = v
+                        end
+                        lia.data.convertToDatabase(false, legacy)
+                    end
+                else
+                    for _, row in ipairs(rows) do
+                        local decoded = util.JSONToTable(row._value)
+                        lia.data.stored[row._key] = decoded and decoded[1]
+                    end
+                end
+            end)
+        end)
+    end
+
+    function lia.data.convertToDatabase(changeMap, data)
+        if lia.data.isConverting then return end
+        lia.data.isConverting = true
+        SetGlobalBool("liaDataConverting", true)
+        print("[Lilia] Converting lia.data to database...")
+        data = data or loadFromLegacy()
+        local queries = {"DELETE FROM lia_data"}
+        for k, v in pairs(data) do
+            print("[Lilia]  - " .. k)
+            queries[#queries + 1] = "INSERT INTO lia_data (_key,_value) VALUES (" .. lia.db.convertDataType(k) .. ", " .. lia.db.convertDataType({v}) .. ")"
+            lia.data.stored[k] = v
+        end
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.transaction(queries):next(function()
+                lia.data.isConverting = false
+                SetGlobalBool("liaDataConverting", false)
+                print("[Lilia] Data conversion complete.")
+                if changeMap then
+                    game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n")
+                end
+            end)
+        end)
+    end
+
+    hook.Add("CheckPassword", "liaDataConversion", function()
+        if lia.data.isConverting then
+            return false, "Server is converting data, please retry later"
+        end
+    end)
+
+    hook.Add("LiliaTablesLoaded", "liaDataLoad", function()
+        lia.data.load()
+    end)
 
     timer.Create("liaSaveData", lia.config.get("DataSaveInterval", 600), 0, function()
         hook.Run("SaveData")
@@ -32,19 +129,20 @@ if SERVER then
 end
 
 function lia.data.get(key, default, global, ignoreMap, refresh)
+    local dbKey, _, filePath = buildKey(key, global, ignoreMap)
     if not refresh then
-        local stored = lia.data.stored[key]
+        local stored = lia.data.stored[dbKey]
         if stored ~= nil then return stored end
     end
-
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-    local contents = file.Read(path .. key .. ".txt", "DATA")
+    local contents = file.Read(filePath, "DATA")
     if contents and contents ~= "" then
-        local status, decoded = pcall(pon.decode, contents)
-        if status and decoded then
+        local ok, decoded = pcall(pon.decode, contents)
+        if ok and decoded then
             local value = decoded[1]
-            lia.data.stored[key] = value
+            lia.data.stored[dbKey] = value
+            if SERVER and lia.db and lia.db.tablesLoaded then
+                lia.db.upsert({_key = dbKey, _value = {value}}, "data")
+            end
             if value ~= nil then
                 return value
             else

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -261,6 +261,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_items`;
     DROP TABLE IF EXISTS `lia_invdata`;
     DROP TABLE IF EXISTS `lia_config`;
+    DROP TABLE IF EXISTS `lia_data`;
     DROP TABLE IF EXISTS `lilia_logs`;
 ]])
             local done = 0
@@ -286,6 +287,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_items;
     DROP TABLE IF EXISTS lia_invdata;
     DROP TABLE IF EXISTS lia_config;
+    DROP TABLE IF EXISTS lia_data;
 ]], realCallback)
     end
 end
@@ -351,6 +353,11 @@ function lia.db.loadTables()
                 _key text PRIMARY KEY,
                 _value text
             );
+
+            CREATE TABLE IF NOT EXISTS lia_data (
+                _key text PRIMARY KEY,
+                _value text
+            );
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -409,6 +416,12 @@ function lia.db.loadTables()
 
             CREATE TABLE IF NOT EXISTS `lia_config` (
                 `_key` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`_key`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_data` (
+                `_key` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_key`)
             );

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -308,3 +308,12 @@ concommand.Add("lia_convertconfig", function(client)
 
     lia.config.convertToDatabase(true)
 end)
+
+concommand.Add("lia_convertdata", function(client)
+    if IsValid(client) then
+        client:notifyLocalized("commandConsoleOnly")
+        return
+    end
+
+    lia.data.convertToDatabase(true)
+end)


### PR DESCRIPTION
## Summary
- add migration of lia.data from data files to database
- create `lia_data` table and hook migration on startup
- update command permissions to include `lia_convertdata`
- document new storage behavior and database table

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686700cdb3cc832785375a3d8c1c3e76