### PR TITLE
Move lia.data storage to database

### DIFF
--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -143,3 +143,30 @@ Otherwise, reads from the file, decodes, and caches the value.
         end
     end)
 ```
+
+---
+
+### lia.data.convertToDatabase(changeMap)
+
+**Description:**
+
+Moves legacy `lia.data` files from `data/lilia` into the `lia_data` database table. While the conversion is running, players are prevented from joining the server. If `changeMap` is true, the current level will reload after conversion completes.
+
+**Parameters:**
+
+* changeMap (boolean) – Whether to reload the current map when finished.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+    -- Force data conversion and reload the map
+    lia.data.convertToDatabase(true)
+```

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -1,29 +1,148 @@
-﻿file.CreateDir("lilia")
+file.CreateDir("lilia")
 lia.data = lia.data or {}
 lia.data.stored = lia.data.stored or {}
+
 if SERVER then
+    lia.data.isConverting = lia.data.isConverting or false
+
+    local function buildCondition(key, folder, map)
+        local cond = "_key = " .. lia.db.convertDataType(key)
+        cond = cond .. " AND " .. (folder and "_folder = " .. lia.db.convertDataType(folder) or "_folder IS NULL")
+        cond = cond .. " AND " .. (map and "_map = " .. lia.db.convertDataType(map) or "_map IS NULL")
+        return cond
+    end
+
+    local function scanLegacyData()
+        local entries = {}
+        local base = "lilia"
+
+        local function scan(dir)
+            local files, dirs = file.Find(dir .. "/*", "DATA")
+            for _, f in ipairs(files) do
+                if f:sub(-4) == ".txt" then
+                    local rel = string.sub(dir .. "/" .. f, #base + 2)
+                    if not rel:StartWith("logs/") then
+                        local segments = string.Explode("/", rel)
+                        local key = string.StripExtension(segments[#segments])
+                        local folder
+                        local map
+                        if #segments == 2 then
+                            folder = segments[1]
+                        elseif #segments >= 3 then
+                            folder = segments[1]
+                            map = segments[2]
+                        end
+                        local data = file.Read(dir .. "/" .. f, "DATA")
+                        local ok, decoded = pcall(pon.decode, data)
+                        if ok and decoded then
+                            entries[#entries + 1] = {
+                                key = key,
+                                folder = folder,
+                                map = map,
+                                value = decoded[1]
+                            }
+                        end
+                    end
+                end
+            end
+            for _, d in ipairs(dirs) do
+                scan(dir .. "/" .. d)
+            end
+        end
+
+        scan(base)
+        return entries
+    end
+
     function lia.data.set(key, value, global, ignoreMap)
         local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-        if not global then file.CreateDir("lilia/" .. folder .. "/") end
-        file.CreateDir(path)
-        file.Write(path .. key .. ".txt", pon.encode({value}))
+        local map = ignoreMap and nil or game.GetMap()
+        if global then
+            folder = nil
+            map = nil
+        end
+
         lia.data.stored[key] = value
-        return path
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.upsert({
+                _key = key,
+                _folder = folder,
+                _map = map,
+                _value = {value}
+            }, "data")
+        end)
+
+        return "lilia/" .. (folder and folder .. "/" or "") .. (map and map .. "/" or "")
     end
 
     function lia.data.delete(key, global, ignoreMap)
         local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-        local contents = file.Read(path .. key .. ".txt", "DATA")
-        if contents and contents ~= "" then
-            file.Delete(path .. key .. ".txt")
-            lia.data.stored[key] = nil
-            return true
-        else
-            return false
+        local map = ignoreMap and nil or game.GetMap()
+        if global then
+            folder = nil
+            map = nil
         end
+
+        lia.data.stored[key] = nil
+        local condition = buildCondition(key, folder, map)
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.delete("data", condition)
+        end)
+        return true
     end
+
+    function lia.data.convertToDatabase(changeMap)
+        if lia.data.isConverting then return end
+        lia.data.isConverting = true
+        SetGlobalBool("liaDataConverting", true)
+        print("[Lilia] Converting lia.data to database...")
+        local dataEntries = scanLegacyData()
+        local queries = {"DELETE FROM lia_data"}
+        for _, entry in ipairs(dataEntries) do
+            print("[Lilia]  - " .. entry.key)
+            lia.data.stored[entry.key] = entry.value
+            queries[#queries + 1] = "INSERT INTO lia_data (_key,_folder,_map,_value) VALUES (" ..
+                lia.db.convertDataType(entry.key) .. ", " ..
+                lia.db.convertDataType(entry.folder or NULL) .. ", " ..
+                lia.db.convertDataType(entry.map or NULL) .. ", " ..
+                lia.db.convertDataType({entry.value}) .. ")"
+        end
+
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.transaction(queries):next(function()
+                lia.data.isConverting = false
+                SetGlobalBool("liaDataConverting", false)
+                print("[Lilia] Data conversion complete.")
+                if changeMap then
+                    game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n")
+                end
+            end)
+        end)
+    end
+
+    function lia.data.loadTables()
+        lia.db.waitForTablesToLoad():next(function()
+            lia.db.select({"_key", "_folder", "_map", "_value"}, "data"):next(function(res)
+                local rows = res.results or {}
+                for _, row in ipairs(rows) do
+                    local decoded = util.JSONToTable(row._value or "[]")
+                    lia.data.stored[row._key] = decoded and decoded[1]
+                end
+                local legacy = scanLegacyData()
+                lia.db.count("data"):next(function(n)
+                    if n == 0 and #legacy > 0 then
+                        lia.data.convertToDatabase(true)
+                    end
+                end)
+            end)
+        end)
+    end
+
+    hook.Add("CheckPassword", "liaDataConversion", function()
+        if lia.data.isConverting then
+            return false, "Server is converting data, please retry later"
+        end
+    end)
 
     timer.Create("liaSaveData", lia.config.get("DataSaveInterval", 600), 0, function()
         hook.Run("SaveData")
@@ -37,23 +156,5 @@ function lia.data.get(key, default, global, ignoreMap, refresh)
         if stored ~= nil then return stored end
     end
 
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local path = "lilia/" .. (global and "" or folder .. "/") .. (ignoreMap and "" or game.GetMap() .. "/")
-    local contents = file.Read(path .. key .. ".txt", "DATA")
-    if contents and contents ~= "" then
-        local status, decoded = pcall(pon.decode, contents)
-        if status and decoded then
-            local value = decoded[1]
-            lia.data.stored[key] = value
-            if value ~= nil then
-                return value
-            else
-                return default
-            end
-        else
-            return default
-        end
-    else
-        return default
-    end
+    return default
 end

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -261,6 +261,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_items`;
     DROP TABLE IF EXISTS `lia_invdata`;
     DROP TABLE IF EXISTS `lia_config`;
+    DROP TABLE IF EXISTS `lia_data`;
     DROP TABLE IF EXISTS `lia_logs`;
 ]])
             local done = 0
@@ -286,6 +287,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_items;
     DROP TABLE IF EXISTS lia_invdata;
     DROP TABLE IF EXISTS lia_config;
+    DROP TABLE IF EXISTS lia_data;
     DROP TABLE IF EXISTS lia_logs;
 ]], realCallback)
     end
@@ -351,6 +353,14 @@ function lia.db.loadTables()
             CREATE TABLE IF NOT EXISTS lia_config (
                 _key text PRIMARY KEY,
                 _value text
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_data (
+                _key text,
+                _folder text,
+                _map text,
+                _value text,
+                PRIMARY KEY (_key, _folder, _map)
             );
 
             CREATE TABLE IF NOT EXISTS lia_logs (
@@ -419,6 +429,14 @@ function lia.db.loadTables()
                 `_key` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_key`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_data` (
+                `_key` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_folder` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+                `_map` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+                `_value` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`_key`, `_folder`, `_map`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_logs` (

--- a/gamemode/core/loader.lua
+++ b/gamemode/core/loader.lua
@@ -476,6 +476,7 @@ if SERVER then
         lia.db.connect(function()
             lia.db.loadTables()
             lia.log.loadTables()
+            lia.data.loadTables()
             hook.Run("DatabaseConnected")
         end)
     end

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -317,3 +317,12 @@ concommand.Add("lia_convertlogs", function(client)
 
     lia.log.convertToDatabase(true)
 end)
+
+concommand.Add("lia_convertdata", function(client)
+    if IsValid(client) then
+        client:notifyLocalized("commandConsoleOnly")
+        return
+    end
+
+    lia.data.convertToDatabase(true)
+end)


### PR DESCRIPTION
## Summary
- store lia.data entries in new `lia_data` table
- load legacy files and convert them to database
- prevent joining while conversion runs
- add `lia_convertdata` command for admins
- call data load during database setup

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670377b95483278309cf268c64321a