### PR TITLE
Store config per gamemode

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -351,8 +351,10 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS lia_config (
-                _key text PRIMARY KEY,
-                _value text
+                _schema text,
+                _key text,
+                _value text,
+                PRIMARY KEY (_schema, _key)
             );
 
             CREATE TABLE IF NOT EXISTS lia_data (
@@ -426,9 +428,10 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS `lia_config` (
+                `_schema` VARCHAR(24) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_key` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_value` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-                PRIMARY KEY (`_key`)
+                PRIMARY KEY (`_schema`, `_key`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_data` (


### PR DESCRIPTION
## Summary
- include current schema when loading configs
- save configs per schema
- convert configs with gamemode column
- create schema-aware config table definitions

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670dde405083278be6c08154b2ff51