### PR TITLE
Improve conversion summaries

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -126,8 +126,22 @@ if SERVER then
         lia.db.waitForTablesToLoad():next(function()
             lia.db.transaction(queries):next(function()
                 lia.data.isConverting = false
-                print("[Lilia] Data conversion complete. Ported " .. entryCount .. " entries.")
-                if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
+                local counts = {}
+                deferred.all({
+                    lia.db.count("config"):next(function(n) counts.config = n end),
+                    lia.db.count("data"):next(function(n) counts.data = n end),
+                    lia.db.count("logs"):next(function(n) counts.logs = n end)
+                }):next(function()
+                    print(
+                        string.format(
+                            "[Lilia] Data conversion complete. Converted %d config entries, %d data entries and %d log entries.",
+                            counts.config or 0,
+                            counts.data or entryCount,
+                            counts.logs or 0
+                        )
+                    )
+                    if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
+                end)
             end)
         end)
     end

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -751,6 +751,10 @@ end
 
 function GM:DatabaseConnected()
     lia.bootstrap("Database", "Lilia has connected to the database. We are using " .. lia.db.module .. "!", Color(0, 255, 0))
+    if SERVER then
+        lia.log.loadTables()
+        lia.data.loadTables()
+    end
 end
 
 function GM:OnMySQLOOConnected()

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -155,8 +155,22 @@ if SERVER then
                 i = i or 1
                 if i > #entries then
                     lia.log.isConverting = false
-                    print("[Lilia] Log conversion complete. Ported " .. entryCount .. " entries.")
-                    if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
+                    local counts = {}
+                    deferred.all({
+                        lia.db.count("config"):next(function(n) counts.config = n end),
+                        lia.db.count("data"):next(function(n) counts.data = n end),
+                        lia.db.count("logs"):next(function(n) counts.logs = n end)
+                    }):next(function()
+                        print(
+                            string.format(
+                                "[Lilia] Log conversion complete. Converted %d config entries, %d data entries and %d log entries.",
+                                counts.config or 0,
+                                counts.data or 0,
+                                counts.logs or entryCount
+                            )
+                        )
+                        if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
+                    end)
                     return
                 end
 

--- a/gamemode/core/loader.lua
+++ b/gamemode/core/loader.lua
@@ -476,8 +476,6 @@ if SERVER then
         lia.db.connect(function()
             lia.db.loadTables()
             hook.Run("DatabaseConnected")
-            lia.log.loadTables()
-            lia.data.loadTables()
         end)
     end
 


### PR DESCRIPTION
## Summary
- enhance the lia.config and lia.log conversion messages to match lia.data and include table counts
- start log and data table loading only after the DatabaseConnected message

## Testing
- `luac -p /tmp/config_no_bom.lua`
- `luac -p /tmp/logger_no_bom.lua`
- `luac -p /tmp/data_no_bom.lua`
- `luac -p /tmp/loader_no_bom.lua`
- `luac -p /tmp/database_no_bom.lua`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867103cbfec8327a541044f2bd434a4