### PR TITLE
Update conversion messages with bootstrap

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -148,7 +148,7 @@ if SERVER then
     function lia.config.convertToDatabase(changeMap, data)
         if lia.config.isConverting then return end
         lia.config.isConverting = true
-        print("[Lilia] Converting lia.config to database...")
+        lia.bootstrap("Database", "Converting config to database...")
         data = data or lia.data.get("config", nil, false, true) or {}
         local entryCount = table.Count(data)
         local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
@@ -162,22 +162,11 @@ if SERVER then
         lia.db.waitForTablesToLoad():next(function()
             lia.db.transaction(queries):next(function()
                 lia.config.isConverting = false
-                local counts = {}
-                deferred.all({
-                    lia.db.count("config"):next(function(n) counts.config = n end),
-                    lia.db.count("data"):next(function(n) counts.data = n end),
-                    lia.db.count("logs"):next(function(n) counts.logs = n end)
-                }):next(function()
-                    print(
-                        string.format(
-                            "[Lilia] Configuration conversion complete. Converted %d config entries, %d data entries and %d log entries.",
-                            counts.config or entryCount,
-                            counts.data or 0,
-                            counts.logs or 0
-                        )
-                    )
-                    if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
-                end)
+                lia.bootstrap(
+                    "Database",
+                    string.format("Converting config to database... Converted %d entries", entryCount)
+                )
+                if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
             end)
         end)
     end

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -124,7 +124,7 @@ if SERVER then
     function lia.data.convertToDatabase(changeMap)
         if lia.data.isConverting then return end
         lia.data.isConverting = true
-        print("[Lilia] Converting lia.data to database...")
+        lia.bootstrap("Database", "Converting data to database...")
         local dataEntries = scanLegacyData()
         local entryCount = #dataEntries
         local queries = {"DELETE FROM lia_data"}
@@ -136,22 +136,11 @@ if SERVER then
         lia.db.waitForTablesToLoad():next(function()
             lia.db.transaction(queries):next(function()
                 lia.data.isConverting = false
-                local counts = {}
-                deferred.all({
-                    lia.db.count("config"):next(function(n) counts.config = n end),
-                    lia.db.count("data"):next(function(n) counts.data = n end),
-                    lia.db.count("logs"):next(function(n) counts.logs = n end)
-                }):next(function()
-                    print(
-                        string.format(
-                            "[Lilia] Data conversion complete. Converted %d config entries, %d data entries and %d log entries.",
-                            counts.config or 0,
-                            counts.data or entryCount,
-                            counts.logs or 0
-                        )
-                    )
-                    if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
-                end)
+                lia.bootstrap(
+                    "Database",
+                    string.format("Converting data to database... Converted %d entries", entryCount)
+                )
+                if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
             end)
         end)
     end

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -107,7 +107,7 @@ if SERVER then
     function lia.log.convertToDatabase(changeMap)
         if lia.log.isConverting then return end
         lia.log.isConverting = true
-        print("[Lilia] Converting legacy logs to database...")
+        lia.bootstrap("Database", "Converting logs to database...")
         local baseDir = "lilia/logs"
         local entries = {}
         local files, dirs = file.Find(baseDir .. "/*", "DATA")
@@ -155,22 +155,11 @@ if SERVER then
                 i = i or 1
                 if i > #entries then
                     lia.log.isConverting = false
-                    local counts = {}
-                    deferred.all({
-                        lia.db.count("config"):next(function(n) counts.config = n end),
-                        lia.db.count("data"):next(function(n) counts.data = n end),
-                        lia.db.count("logs"):next(function(n) counts.logs = n end)
-                    }):next(function()
-                        print(
-                            string.format(
-                                "[Lilia] Log conversion complete. Converted %d config entries, %d data entries and %d log entries.",
-                                counts.config or 0,
-                                counts.data or 0,
-                                counts.logs or entryCount
-                            )
-                        )
-                        if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
-                    end)
+                    lia.bootstrap(
+                        "Database",
+                        string.format("Converting logs to database... Converted %d entries", entryCount)
+                    )
+                    if changeMap then game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n") end
                     return
                 end
 


### PR DESCRIPTION
## Summary
- use `lia.bootstrap` when converting data, config, and logs
- log completion counts with bootstrap formatting

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_68671b9ffbe083278b77ee65cea8df2b