### PR TITLE
Add SteamID column to logs

### DIFF
--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -91,7 +91,7 @@ if SERVER then
         if IsValid(client) then
             local char = client:getChar()
             charID = char and char:getID() or nil
-            steamID = client:SteamID64()
+            steamID = client:SteamID()
         end
 
         lia.db.insertTable({
@@ -118,7 +118,7 @@ if SERVER then
             for line in data:gmatch("[^\r\n]+") do
                 local ts, msg = line:match("^%[([^%]]+)%]%s*(.+)")
                 if ts and msg then
-                    local steamID = msg:match("%[(%d+)%]")
+                    local steamID = msg:match("%[(STEAM_[0-5]:[01]:%d+)%]") or msg:match("%[(%d+)%]")
                     local charID = msg:match("CharID:%s*(%d+)")
                     entries[#entries + 1] = {
                         _timestamp = ts,

--- a/modules/administration/submodules/logging/libraries/client.lua
+++ b/modules/administration/submodules/logging/libraries/client.lua
@@ -40,6 +40,7 @@ function OpenLogsUI(panel, categorizedLogs)
     list:SetMultiSelect(false)
     list:AddColumn(L("timestamp")):SetFixedWidth(150)
     list:AddColumn(L("logMessage"))
+    list:AddColumn(L("steamID")):SetFixedWidth(110)
     local copyButton = contentPanel:Add("liaMediumButton")
     copyButton:Dock(BOTTOM)
     copyButton:SetText(L("copySelectedRow"))
@@ -59,7 +60,7 @@ function OpenLogsUI(panel, categorizedLogs)
             list:Clear()
             currentLogs = logs
             for _, log in ipairs(logs) do
-                list:AddLine(log.timestamp, log.message)
+                list:AddLine(log.timestamp, log.message, log.steamID or "")
             end
         end
     end
@@ -68,7 +69,11 @@ function OpenLogsUI(panel, categorizedLogs)
         local query = string.lower(search:GetValue())
         list:Clear()
         for _, log in ipairs(currentLogs) do
-            if query == "" or string.find(string.lower(log.message), query, 1, true) then list:AddLine(log.timestamp, log.message) end
+            local msgMatch = string.find(string.lower(log.message), query, 1, true)
+            local idMatch = log.steamID and string.find(string.lower(log.steamID), query, 1, true)
+            if query == "" or msgMatch or idMatch then
+                list:AddLine(log.timestamp, log.message, log.steamID or "")
+            end
         end
     end
 
@@ -76,7 +81,10 @@ function OpenLogsUI(panel, categorizedLogs)
         local sel = list:GetSelectedLine()
         if sel then
             local line = list:GetLine(sel)
-            SetClipboardText("[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2))
+            local text = "[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2)
+            local id = line:GetColumnText(3)
+            if id and id ~= "" then text = text .. " [" .. id .. "]" end
+            SetClipboardText(text)
         end
     end
 

--- a/modules/administration/submodules/logging/libraries/server.lua
+++ b/modules/administration/submodules/logging/libraries/server.lua
@@ -29,13 +29,14 @@ function MODULE:ReadLogEntries(category)
     }, " AND ") ..
         " ORDER BY _id DESC LIMIT " .. maxLines
 
-    lia.db.select({"_timestamp", "_message"}, "logs", condition):next(function(res)
+    lia.db.select({"_timestamp", "_message", "_steamID"}, "logs", condition):next(function(res)
         local rows = res.results or {}
         local logs = {}
         for _, row in ipairs(rows) do
             logs[#logs + 1] = {
                 timestamp = row._timestamp,
-                message = row._message
+                message = row._message,
+                steamID = row._steamID
             }
         end
         d:resolve(logs)


### PR DESCRIPTION
## Summary
- log SteamID (not SteamID64)
- include SteamID field when converting logs
- show SteamID in the logs UI and enable searching by it

## Testing
- `luacheck gamemode/core/libraries/logger.lua modules/administration/submodules/logging/libraries/client.lua modules/administration/submodules/logging/libraries/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_686729b156e883279665861468cab536