### PR TITLE
Fix faction color default in docs

### DIFF
--- a/docs/docs/definitions/faction.md
+++ b/docs/docs/definitions/faction.md
@@ -19,7 +19,7 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `name` | `string` | `"Unknown"` | Display name shown to players. |
 | `desc` | `string` | `"No Description"` | Lore or descriptive text. |
 | `isDefault` | `boolean` | `true` | Whether the faction is available without whitelist. |
-| `color` | `Color` | `Color(255,255,255)` | UI color representing the faction. |
+| `color` | `Color` | `Color(150,150,150)` | UI color representing the faction. |
 | `models` | `table` | `DefaultModels` | Available player model paths. |
 | `uniqueID` | `string` | `filename` | Internal string identifier. |
 | `weapons` | `table` | `{}` | Automatically granted weapons. |
@@ -154,7 +154,7 @@ FACTION_STAFF = FACTION.index
 
 **Description:**
 
-Color used in UI elements to represent the faction. Defaults to `Color(255, 255, 255)` if not specified.
+Color used in UI elements to represent the faction. Defaults to `Color(150, 150, 150)` if not specified.
 
 **Example Usage:**
 


### PR DESCRIPTION
## Summary
- update `faction.md` color defaults to match source

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68675505cc7083278e23b1525af0a56d