### PR TITLE
Fix quoting for sqlite insert

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -515,7 +515,7 @@ local function genInsertValues(value, dbTable)
     local values = {}
     for k, v in pairs(value) do
         keys[#keys + 1] = k
-        values[#keys] = k:find("steamID64") and v or lia.db.convertDataType(v)
+        values[#keys] = lia.db.convertDataType(v)
     end
     return query .. table.concat(keys, ", ") .. ") VALUES (" .. table.concat(values, ", ") .. ")"
 end
@@ -523,7 +523,7 @@ end
 local function genUpdateList(value)
     local changes = {}
     for k, v in pairs(value) do
-        changes[#changes + 1] = k .. " = " .. (k:find("steamID64") and v or lia.db.convertDataType(v))
+        changes[#changes + 1] = k .. " = " .. lia.db.convertDataType(v)
     end
     return table.concat(changes, ", ")
 end


### PR DESCRIPTION
## Summary
- remove steamID64 special case from DB helpers
- always convert values when building SQL queries

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_6867684393688327a05e8ff61e62d606