### PR TITLE
Add localization for weapon and entity strings

### DIFF
--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -78,7 +78,7 @@ hook.Add("CreateInformationButtons", "liaInformationFlags", function(pages)
                         local status = hasFlag and "✓" or "✗"
                         local statusColor = hasFlag and Color(0, 255, 0) or Color(255, 0, 0)
                         derma.SkinHook("Paint", "Panel", pnl, w, h)
-                        draw.SimpleText("Flag '" .. flagName .. "'", "liaMediumFont", 20, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+                        draw.SimpleText(L("flagLabel", flagName), "liaMediumFont", 20, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
                         draw.SimpleText(status, "liaHugeFont", w - 20, h * 0.5, statusColor, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
                         if hasDesc then draw.SimpleText(flagData.desc, "liaSmallFont", 20, 45, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP) end
                     end

--- a/gamemode/entities/entities/lia_item/shared.lua
+++ b/gamemode/entities/entities/lia_item/shared.lua
@@ -1,6 +1,6 @@
 ﻿ENT.Base = "base_entity"
 ENT.Type = "anim"
-ENT.PrintName = "Item"
+ENT.PrintName = L("entityItemName")
 ENT.Category = "Lilia"
 ENT.Spawnable = false
 ENT.RenderGroup = RENDERGROUP_BOTH

--- a/gamemode/entities/entities/lia_money/shared.lua
+++ b/gamemode/entities/entities/lia_money/shared.lua
@@ -1,5 +1,5 @@
 ﻿ENT.Type = "anim"
-ENT.PrintName = "Money"
+ENT.PrintName = L("entityMoneyName")
 ENT.Category = "Lilia"
 ENT.Spawnable = false
 ENT.DrawEntityInfo = true

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -963,5 +963,25 @@ LANGUAGE = {
     giveFlagFormat = "Give Flag %s",
     takeFlagFormat = "Take Flag %s",
     setFactionTitle = "Set Faction (%s)",
+    flagLabel = "Flag '%s'",
     downloads = "Downloads",
+    adminStickWeaponName = "Admin Stick",
+    adminStickPurpose = "Instructions: Press R when looking at someone to select them \nPress Shift R to select yourself \nLeft click to open menu \nRight click with selection to freeze.",
+    keysWeaponName = "Keys",
+    keysInstructions = "Primary Fire: Lock\nSecondary Fire: Unlock",
+    keysPurpose = "Locking and Unlocking Stuff.",
+    handsWeaponName = "Hands",
+    handsInstructions = [[Primary Fire: Throw/Punch
+Secondary Fire: Knock/Pickup
+Secondary Fire + Mouse: Rotate Object
+Reload: Drop]],
+    handsPurpose = "Hitting things and knocking on doors.",
+    entityVendorName = "Vendor",
+    entityStorageName = "Storage",
+    entityItemName = "Item",
+    entityMoneyName = "Money",
+    hackingInfraction = "Hacking",
+    usingThirdPartyCheats = "using third-party cheats",
+    familySharingDisabled = "family sharing (alts are disabled)",
+    familySharedAccountBlacklisted = "using a family-shared account that is blacklisted",
 }

--- a/modules/administration/submodules/adminstick/entities/weapons/adminstick/shared.lua
+++ b/modules/administration/submodules/adminstick/entities/weapons/adminstick/shared.lua
@@ -1,6 +1,6 @@
 ﻿SWEP.Author = "Samael"
-SWEP.PrintName = "Admin Stick"
-SWEP.Purpose = "Instructions: Press R when looking at someone to select them \nPress Shift R to select yourself \nLeft click to open menu \nRight click with selection to freeze."
+SWEP.PrintName = L("adminStickWeaponName")
+SWEP.Purpose = L("adminStickPurpose")
 SWEP.ViewModelFOV = 50
 SWEP.ViewModelFlip = false
 SWEP.IsAlwaysRaised = true

--- a/modules/attributes/entities/weapons/lia_hands/shared.lua
+++ b/modules/attributes/entities/weapons/lia_hands/shared.lua
@@ -1,14 +1,11 @@
-﻿SWEP.PrintName = "Hands"
+SWEP.PrintName = L("handsWeaponName")
 SWEP.Slot = 0
 SWEP.SlotPos = 1
 SWEP.DrawAmmo = false
 SWEP.DrawCrosshair = true
 SWEP.Author = "Samael"
-SWEP.Instructions = [[Primary Fire: Throw/Punch
-Secondary Fire: Knock/Pickup
-Secondary Fire + Mouse: Rotate Object
-Reload: Drop]]
-SWEP.Purpose = "Hitting things and knocking on doors."
+SWEP.Instructions = L("handsInstructions")
+SWEP.Purpose = L("handsPurpose")
 SWEP.Drop = false
 SWEP.ViewModelFOV = 45
 SWEP.ViewModelFlip = false

--- a/modules/doors/entities/weapons/lia_keys/cl_init.lua
+++ b/modules/doors/entities/weapons/lia_keys/cl_init.lua
@@ -1,4 +1,4 @@
-﻿SWEP.PrintName = "Keys"
+SWEP.PrintName = L("keysWeaponName")
 SWEP.Slot = 0
 SWEP.SlotPos = 2
 SWEP.DrawAmmo = false

--- a/modules/doors/entities/weapons/lia_keys/shared.lua
+++ b/modules/doors/entities/weapons/lia_keys/shared.lua
@@ -1,6 +1,6 @@
 ﻿SWEP.Author = "Samael"
-SWEP.Instructions = "Primary Fire: Lock\nSecondary Fire: Unlock"
-SWEP.Purpose = "Locking and Unlocking Stuff."
+SWEP.Instructions = L("keysInstructions")
+SWEP.Purpose = L("keysPurpose")
 SWEP.Drop = false
 SWEP.ViewModelFOV = 45
 SWEP.ViewModelFlip = false

--- a/modules/inventory/submodules/storage/entities/entities/lia_storage/shared.lua
+++ b/modules/inventory/submodules/storage/entities/entities/lia_storage/shared.lua
@@ -1,6 +1,6 @@
 ﻿local MODULE = MODULE
 ENT.Type = "anim"
-ENT.PrintName = "Storage"
+ENT.PrintName = L("entityStorageName")
 ENT.Category = "Lilia"
 ENT.Spawnable = false
 ENT.isStorageEntity = true

--- a/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
+++ b/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
@@ -1,6 +1,6 @@
 ﻿LiliaVendors = LiliaVendors or {}
 ENT.Type = "anim"
-ENT.PrintName = "Vendor"
+ENT.PrintName = L("entityVendorName")
 ENT.Category = "Lilia"
 ENT.Spawnable = true
 ENT.AdminOnly = true

--- a/modules/protection/libraries/server.lua
+++ b/modules/protection/libraries/server.lua
@@ -74,18 +74,18 @@ function MODULE:PlayerAuthed(client, steamid)
     local steamName = client:SteamName()
     local steamID = client:SteamID64()
     if KnownCheaters[steamID64] or KnownCheaters[ownerSteamID64] then
-        lia.applyPunishment(client, "using third-party cheats", false, true, 0)
+        lia.applyPunishment(client, L("usingThirdPartyCheats"), false, true, 0)
         lia.notifyAdmin(L("bannedCheaterNotify", steamName, steamID))
         lia.log.add(nil, "cheaterBanned", steamName, steamID)
         return
     end
 
     if lia.config.get("AltsDisabled", false) and ownerSteamID64 ~= steamID64 then
-        lia.applyPunishment(client, "family sharing (alts are disabled)", true, false)
+        lia.applyPunishment(client, L("familySharingDisabled"), true, false)
         lia.notifyAdmin(L("kickedAltNotify", steamName, steamID))
         lia.log.add(nil, "altKicked", steamName, steamID)
     elseif lia.module.list["whitelist"] and lia.module.list["whitelist"].BlacklistedSteamID64[ownerSteamID64] then
-        lia.applyPunishment(client, "using a family-shared account that is blacklisted", false, true, 0)
+        lia.applyPunishment(client, L("familySharedAccountBlacklisted"), false, true, 0)
         lia.notifyAdmin(L("bannedAltNotify", steamName, steamID))
         lia.log.add(nil, "altBanned", steamName, steamID)
     end

--- a/modules/protection/netcalls/server.lua
+++ b/modules/protection/netcalls/server.lua
@@ -27,5 +27,5 @@ end)
 
 net.Receive("CheckHack", function(_, client)
     lia.log.add(client, "hackAttempt")
-    lia.applyPunishment(client, "Hacking", true, true, 0, "kickedForInfractionPeriod", "bannedForInfractionPeriod")
+    lia.applyPunishment(client, L("hackingInfraction"), true, true, 0, "kickedForInfractionPeriod", "bannedForInfractionPeriod")
 end)


### PR DESCRIPTION
## Summary
- localize flag panel label
- localize SWEP names/instructions
- localize entity print names
- localize anti-cheat infraction messages
- add English translations for the new keys

## Testing
- `luacheck .` *(fails: 9962 warnings / 22 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867728bffa88327894dc8021383186f