### PR TITLE
Fix localization for commands

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -27,7 +27,7 @@ function lia.command.add(command, data)
         if hasAccess then
             return onRun(client, arguments)
         else
-            return "noPerm"
+            return "@noPerm"
         end
     end
 

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -210,6 +210,7 @@ LANGUAGE = {
     unlocking = "Unlocking this entity...",
     notNow = "You are not allowed to do this right now.",
     areYouSure = "Are you sure?",
+    descChanged = "Character description updated.",
     descChangedTarget = "%s has changed %s's character description.",
     disconnect = "Disconnect",
     noPerm = "You are not allowed to do this.",

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -185,7 +185,7 @@ lia.command.add("chardesc", {
         if not desc:find("%S") then return client:requestString(L("chgName"), L("chgNameDesc"), function(text) lia.command.run(client, "chardesc", {text}) end, client:getChar() and client:getChar():getDesc() or "") end
         local character = client:getChar()
         if character then character:setDesc(desc) end
-        return "descChanged"
+        return "@descChanged"
     end
 })
 


### PR DESCRIPTION
## Summary
- localize generic command denial message
- localize character description changed response
- add `descChanged` language key

## Testing
- `luacheck . --codes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678eab6ef88327b8c1cf4261e92d13