### PR TITLE
Fix unlocalized strings

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -522,6 +522,7 @@ LANGUAGE = {
     adminStickClearInventoryName = "Clear Inventory",
     adminStickKickCharacterName = "Kick Character",
     adminStickBanCharacterName = "Ban Character",
+    adminStickTogglePermakillName = "Toggle Character Killing (Ban)",
     adminStickSubCategoryBans = "Bans",
     adminStickSubCategoryGetInfos = "Get Information",
     adminStickSubCategorySetInfos = "Set Information",

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -4,7 +4,7 @@
     desc = L("togglePermakillDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = "Toggle Character Killing (Ban)",
+        Name = L("adminStickTogglePermakillName"),
         Category = "characterManagement",
         SubCategory = L("adminStickSubCategoryBans"),
         Icon = "icon16/user_delete.png"

--- a/modules/administration/submodules/tickets/commands.lua
+++ b/modules/administration/submodules/tickets/commands.lua
@@ -30,7 +30,7 @@
             return
         end
 
-        local claimedFor = "None"
+        local claimedFor = L("none")
         if next(claim.claimedFor) then
             claimedFor = table.concat((function()
                 local t = {}
@@ -96,7 +96,7 @@ lia.command.add("viewallclaims", {
 
         local claimsData = {}
         for steamID, claim in pairs(caseclaims) do
-            local claimedFor = "None"
+            local claimedFor = L("none")
             if next(claim.claimedFor) then
                 claimedFor = table.concat((function()
                     local t = {}
@@ -162,7 +162,7 @@ lia.command.add("viewclaims", {
         lia.log.add(client, "viewAllClaims")
         local claimsData = {}
         for steamID, claim in pairs(caseclaims) do
-            local claimedFor = "None"
+            local claimedFor = L("none")
             if next(claim.claimedFor) then
                 claimedFor = table.concat((function()
                     local t = {}

--- a/modules/doors/commands.lua
+++ b/modules/doors/commands.lua
@@ -415,9 +415,9 @@ lia.command.add("doorinfo", {
             local name = door:getNetVar("title", door:getNetVar("name", L("doorTitle")))
             local price = door:getNetVar("price", 0)
             local noSell = door:getNetVar("noSell", false)
-            local faction = door:getNetVar("faction", "None")
+            local faction = door:getNetVar("faction", L("none"))
             local factions = door:getNetVar("factions", "[]")
-            local class = door:getNetVar("class", "None")
+            local class = door:getNetVar("class", L("none"))
             local hidden = door:getNetVar("hidden", false)
             local locked = door:getNetVar("locked", false)
 


### PR DESCRIPTION
## Summary
- localize door info fields and ticket command output
- localize admin stick name

## Testing
- `grep -n "L(\"none\")" -R | head`


------
https://chatgpt.com/codex/tasks/task_e_686795788f68832787b3ef898f9db231