### PR TITLE
Localize missing description prompt

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -221,6 +221,7 @@ LANGUAGE = {
     noPerm = "You are not allowed to do this.",
     chgName = "Change Name",
     chgNameDesc = "Enter the character's new name below.",
+    chgDescTitle = "Change %s's Description",
     whitelist = "%s has whitelisted %s for the %s faction.",
     unwhitelist = "%s has unwhitelisted %s from the %s faction.",
     load = "Load",

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -913,7 +913,14 @@ lia.command.add("charsetdesc", {
         end
 
         local desc = table.concat(arguments, " ", 2)
-        if not desc:find("%S") then return client:requestString("Change " .. target:Name() .. "'s Description", L("enterNewDesc"), function(text) lia.command.run(client, "charsetdesc", {arguments[1], text}) end, target:getChar():getDesc()) end
+        if not desc:find("%S") then
+            return client:requestString(
+                L("chgDescTitle", target:Name()),
+                L("enterNewDesc"),
+                function(text) lia.command.run(client, "charsetdesc", {arguments[1], text}) end,
+                target:getChar():getDesc()
+            )
+        end
         target:getChar():setDesc(desc)
         return L("descChangedTarget", client:Name(), target:Name())
     end


### PR DESCRIPTION
## Summary
- add localization key for changing another character's description
- use new localization key in permission commands

## Testing
- `luac` not available; syntax checks not run

------
https://chatgpt.com/codex/tasks/task_e_6867a5e702b483278a4f9b839f23a839