### PR TITLE
Fix mislocalized playermodel option

### DIFF
--- a/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/modules/administration/submodules/adminstick/libraries/client.lua
@@ -310,7 +310,7 @@ local function IncludeCharacterManagement(tgt, menu, stores)
     end
 
     if cl:hasPrivilege("Commands - Manage Character Information") then
-        charMenu:AddOption(L("Change Playermodel"), function()
+        charMenu:AddOption(L("changePlayerModel"), function()
             OpenPlayerModelUI(tgt)
             AdminStickIsOpen = false
         end):SetIcon("icon16/user_suit.png")


### PR DESCRIPTION
## Summary
- fix a typo using the English translation value as key for the admin stick playermodel option

## Testing
- `python3 - <<'PY' ...` (check for missing localization keys)


------
https://chatgpt.com/codex/tasks/task_e_6867ae658aa08327a58e957406b412de