### PR TITLE
Fix doc examples for tool meta

### DIFF
--- a/docs/docs/meta/tool.md
+++ b/docs/docs/meta/tool.md
@@ -218,12 +218,9 @@ Determines whether this tool is allowed to be used.
 **Example Usage:**
 
 ```lua
--- Check if the player can use the current tool
+-- Simple permission check
 if tool:Allowed() then
-    tool:GetOwner():ChatPrint(L("toolPermitted"))
-    hook.Run("PlayerToolPermitted", tool:GetOwner(), tool:GetMode())
-else
-    tool:GetOwner():ChatPrint(L("toolBlocked"))
+    print("Tool can be used")
 end
 ```
 
@@ -493,7 +490,7 @@ Called when the tool is equipped. Releases ghost entity.
 **Example Usage:**
 
 ```lua
--- Equip the tool and spawn its ghost entity
+-- Reset ghost entity when equipping
 local result = tool:Deploy()
 ```
 


### PR DESCRIPTION
## Summary
- document a simpler `Allowed` example in `tool.md`
- clarify the ghost entity behavior in the `Deploy` example

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c41e78e88327b23878ef0e0631e6