### PR TITLE
Improve currency docs

### DIFF
--- a/docs/docs/libraries/lia.currency.md
+++ b/docs/docs/libraries/lia.currency.md
@@ -6,7 +6,13 @@ This page covers money and currency related helpers.
 
 ## Overview
 
-The currency library formats money amounts and converts between numeric and display representations. It stores the currency symbol and helps with cost calculations.
+The currency library formats money amounts, spawns physical money entities, and exposes the configured currency names. The symbol and name values come from the configuration options defined in `gamemode/core/libraries/config.lua`.
+
+### Fields
+
+* **lia.currency.symbol** (string) – Prefix used when displaying money amounts.
+* **lia.currency.singular** (string) – Singular form of the currency name.
+* **lia.currency.plural** (string) – Plural form of the currency name.
 
 ---
 
@@ -14,11 +20,9 @@ The currency library formats money amounts and converts between numeric and disp
 
 **Description:**
 
-Formats a numeric amount into a currency string using the defined symbol,
-
-singular, and plural names. If the amount is exactly 1, it returns the singular
-
-form; otherwise, it returns the plural form.
+Formats a numeric amount into a currency string using `lia.currency.symbol`,
+`lia.currency.singular`, and `lia.currency.plural`. If the amount equals `1`
+the singular name is used, otherwise the plural form is shown.
 
 **Parameters:**
 
@@ -38,8 +42,11 @@ form; otherwise, it returns the plural form.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.currency.get
-    lia.currency.get(10)  -- e.g., "$10 dollars"
+-- Customize how money is displayed
+lia.currency.symbol = "$" -- usually configured via lia.config
+lia.currency.singular = "dollar"
+lia.currency.plural = "dollars"
+print(lia.currency.get(10)) -- "$10 dollars"
 ```
 
 ---
@@ -48,9 +55,9 @@ form; otherwise, it returns the plural form.
 
 **Description:**
 
-Spawns a currency entity at the specified position with a given amount and optional angle.
-
-Validates the position and ensures the amount is a non-negative number.
+Creates a `lia_money` entity at the specified position with the given amount.
+The position must be valid and the amount non-negative. An optional angle can
+be provided to control the entity's orientation.
 
 **Parameters:**
 
@@ -76,6 +83,11 @@ Validates the position and ensures the amount is a non-negative number.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.currency.spawn
-    lia.currency.spawn(Vector(0, 0, 0), 100)
+-- Spawn 100 dollars in front of the player
+local pos = client:GetEyeTrace().HitPos
+local ang = Angle(0, client:EyeAngles().y, 0)
+local money = lia.currency.spawn(pos, 100, ang)
+if IsValid(money) then
+    print("Spawned", lia.currency.get(money:getAmount()))
+end
 ```


### PR DESCRIPTION
## Summary
- expand docs for currency library
- clarify usage examples and state available fields

## Testing
- `luacheck . --no-color` *(fails: warnings and errors present)*

------
https://chatgpt.com/codex/tasks/task_e_686865c1b5708327998d8df4619d5eb0