### PR TITLE
Update database docs

### DIFF
--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -30,7 +30,7 @@ or re-establish one.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -64,7 +64,7 @@ tables. This action is irreversible and will remove all stored data.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -98,7 +98,7 @@ storing Lilia data. This ensures the schema is properly set up.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -130,7 +130,7 @@ This allows asynchronous code to wait for table creation before proceeding.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -207,7 +207,7 @@ The callback is invoked after the insert query is complete.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -250,7 +250,7 @@ provided condition. The callback is invoked once the update query finishes.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -295,7 +295,7 @@ object that resolves with the query results.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -334,7 +334,7 @@ Returns a deferred object that resolves when the operation completes.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -369,7 +369,7 @@ If no condition is specified, all rows are deleted. Returns a deferred object.
 
 **Realm:**
 
-* Shared
+* Server
 
 
 **Returns:**
@@ -415,5 +415,416 @@ This is useful for debugging or database maintenance tasks.
 
 ```lua
     -- This snippet demonstrates a common usage of lia.db.GetCharacterTable
-    lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)
+lia.db.GetCharacterTable(function(columns) PrintTable(columns) end)
+```
+
+---
+
+### lia.db.count(dbTable, condition)
+
+**Description:**
+
+Counts rows in the given table optionally filtered by a condition.
+
+**Parameters:**
+
+* dbTable (string) – Table name without the `lia_` prefix.
+
+* condition (string) – Optional SQL condition.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves to the number of matching rows.
+
+**Example Usage:**
+
+```lua
+    lia.db.count("characters", "faction = 1"):next(function(n)
+        print("Character count:", n)
+    end)
+```
+
+---
+
+### lia.db.exists(dbTable, condition)
+
+**Description:**
+
+Checks whether any rows satisfy the provided condition.
+
+**Parameters:**
+
+* dbTable (string) – Table name without the `lia_` prefix.
+
+* condition (string) – SQL condition to filter results.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves to `true` if at least one row exists.
+
+**Example Usage:**
+
+```lua
+    lia.db.exists("characters", "id = 5"):next(function(found)
+        print("Character exists:", found)
+    end)
+```
+
+---
+
+### lia.db.selectOne(fields, dbTable, condition)
+
+**Description:**
+
+Fetches a single row from the given table.
+
+**Parameters:**
+
+* fields (table|string) – Columns to select.
+
+* dbTable (string) – Table name without the `lia_` prefix.
+
+* condition (string) – SQL condition to filter results.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves with the first result row or `nil`.
+
+**Example Usage:**
+
+```lua
+    lia.db.selectOne("*", "characters", "id = 1"):next(function(row)
+        if row then
+            print("Found character:", row._name)
+        end
+    end)
+```
+
+---
+
+### lia.db.bulkInsert(dbTable, rows)
+
+**Description:**
+
+Inserts multiple rows in a single query.
+
+**Parameters:**
+
+* dbTable (string) – Table name without the `lia_` prefix.
+
+* rows (table) – Array of row tables to insert.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves when insertion finishes.
+
+**Example Usage:**
+
+```lua
+    lia.db.bulkInsert("items", {
+        { _invID = 1, _uniqueID = "pistol", _x = 0, _y = 0, _quantity = 1 },
+        { _invID = 1, _uniqueID = "ammo", _x = 1, _y = 0, _quantity = 30 },
+    })
+```
+
+---
+
+### lia.db.insertOrIgnore(value, dbTable)
+
+**Description:**
+
+Inserts a row but ignores it if a unique constraint fails.
+
+**Parameters:**
+
+* value (table) – Column/value pairs to insert.
+
+* dbTable (string) – Table name without the `lia_` prefix.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves with query results and last insert ID.
+
+**Example Usage:**
+
+```lua
+    lia.db.insertOrIgnore({ id = 1, name = "Bob" }, "characters"):next(function(r)
+        print("Insert ID:", r.lastID)
+    end)
+```
+
+---
+
+### lia.db.transaction(queries)
+
+**Description:**
+
+Runs multiple queries inside a transaction, rolling back on error.
+
+**Parameters:**
+
+* queries (table) – Array of SQL strings to execute.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred – Resolves when the transaction completes.
+
+**Example Usage:**
+
+```lua
+    lia.db.transaction({
+        "INSERT INTO lia_logs (_message) VALUES ('start')",
+        "INSERT INTO lia_logs (_message) VALUES ('end')",
+    }):next(function()
+        print("Transaction complete")
+    end)
+```
+
+---
+
+### lia.db.escapeIdentifier(id)
+
+**Description:**
+
+Escapes an identifier for use in manual SQL queries.
+
+**Parameters:**
+
+* id (string) – Identifier to escape.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* string – The escaped identifier.
+
+**Example Usage:**
+
+```lua
+    local col = lia.db.escapeIdentifier("desc")
+    print(col)
+```
+
+---
+
+### lia.db.prepare(key, query, types)
+
+**Description:**
+
+Registers a prepared statement. Only available when using MySQLOO.
+
+**Parameters:**
+
+* key (string) – Identifier for the prepared statement.
+
+* query (string) – SQL query string with placeholders.
+
+* types (table) – Array of MySQLOO type constants.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+    lia.db.prepare(
+        "updateName",
+        "UPDATE lia_characters SET _name = ? WHERE _id = ?",
+        { MYSQLOO_STRING, MYSQLOO_INTEGER }
+    )
+```
+
+---
+
+### lia.db.preparedCall(key, callback, ...)
+
+**Description:**
+
+Executes a prepared statement previously registered with `lia.db.prepare`.
+
+**Parameters:**
+
+* key (string) – Name of the prepared statement.
+
+* callback (function) – Called with results and last insert ID.
+
+* ... (variant) – Arguments for the placeholders.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+    lia.db.preparedCall("updateName", nil, "Alice", 1)
+```
+---
+
+### lia.db.query(query, callback)
+
+**Description:**
+
+Executes a raw SQL statement using the active backend. When no callback is
+supplied a deferred object is returned.
+
+**Parameters:**
+
+* query (string) – SQL query string to execute.
+
+* callback (function) – Optional function called with results and last insert ID.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* deferred|nil – Deferred results when no callback is provided.
+
+**Example Usage:**
+
+```lua
+    lia.db.query("SELECT 1"):next(function(res)
+        PrintTable(res.results)
+    end)
+```
+
+---
+
+### lia.db.escape(value)
+
+**Description:**
+
+Escapes a string for safe use in manual SQL queries.
+
+**Parameters:**
+
+* value (string) – String to escape.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* string – The escaped string.
+
+**Example Usage:**
+
+```lua
+    local safe = lia.db.escape(userInput)
+```
+
+---
+
+### lia.db.queue()
+
+**Description:**
+
+Returns the number of queued queries waiting to be executed.
+
+**Parameters:**
+
+* None
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* number – Total count of queued queries.
+
+**Example Usage:**
+
+```lua
+    print("Queue size:", lia.db.queue())
+```
+
+---
+
+### lia.db.abort()
+
+**Description:**
+
+Cancels all running queries on every connection in the pool.
+
+**Parameters:**
+
+* None
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+    lia.db.abort()
+```
+
+---
+
+### lia.db.getObject()
+
+**Description:**
+
+Returns the least busy database object along with its index in the pool.
+
+**Parameters:**
+
+* None
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* database, number – The connection object and its pool index.
+
+**Example Usage:**
+
+```lua
+    local db = lia.db.getObject()
 ```


### PR DESCRIPTION
## Summary
- document `lia.db.query`, `lia.db.escape`, `lia.db.queue`, `lia.db.abort`, and `lia.db.getObject`
- mark database operations as server-side

## Testing
- `luacheck gamemode/core/libraries/database.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686865c9e4388327a7d352fd7543412e