### PR TITLE
Improve languages lib documentation

### DIFF
--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -6,7 +6,11 @@ This page explains how translations and phrases are loaded.
 
 ## Overview
 
-The languages library loads localization files from directories. It resolves phrase keys to translated text and allows runtime language switching. Language files live in `languages/langname.lua` within schemas or modules and contain tables of localized phrases.
+The languages library loads localization files from directories. It resolves phrase
+keys to translated text and allows runtime language switching. Language files live
+in `languages/langname.lua` within schemas or modules and contain tables of
+localized phrases. Loaded phrases are stored in `lia.lang.stored` while display
+names are kept in `lia.lang.names`.
 
 ---
 
@@ -20,7 +24,7 @@ includes them as shared files, and merges any defined LANGUAGE table
 
 into the stored language data. If a language name (NAME) is provided in the file,
 
-it is registered in lia.lang.names.
+it is registered in lia.lang.names. Once all files have been processed, the `OnLocalizationLoaded` hook is triggered.
 
 **Parameters:**
 
@@ -31,11 +35,6 @@ it is registered in lia.lang.names.
 
 * Shared
 
-
-    Internal Function:
-
-    true
-
 **Returns:**
 
 * None
@@ -44,8 +43,8 @@ it is registered in lia.lang.names.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.lang.loadFromDir
-    lia.lang.loadFromDir("languages")
+    -- Load language files bundled with the current schema
+    lia.lang.loadFromDir(SCHEMA.folder .. "/languages")
 ```
 
 ---
@@ -81,6 +80,39 @@ will be merged with the existing ones.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.lang.AddTable
-    lia.lang.AddTable("english", {greeting = "Hello"})
+    -- Add or override phrases for English
+lia.lang.AddTable("english", {
+        greeting = "Hello",
+        farewell = "Goodbye"
+    })
+```
+
+---
+
+### L(key, ...)
+
+**Description:**
+
+Looks up the phrase associated with `key` in the language selected by the `Language`
+configuration option. Additional arguments are inserted using `string.format`.
+If the key has no translation, the key itself is returned.
+
+**Parameters:**
+
+* key (string) – Localization key.
+
+* ... (vararg) – Values to format into the phrase.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* string – The translated phrase or the key when missing.
+
+**Example Usage:**
+
+```lua
+    print(L("vendorShowAll")) -- prints "Show All" in the active language
 ```


### PR DESCRIPTION
## Summary
- clarify description and mention stored language tables
- drop obsolete `Internal Function` note
- show schema-based path example
- expand AddTable example
- document the `L` helper function
- mention `OnLocalizationLoaded` hook

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: `luacheck: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68686d0d48cc83278c1bd3b2cec91324