### PR TITLE
Update notice library docs

### DIFF
--- a/docs/docs/libraries/lia.notice.md
+++ b/docs/docs/libraries/lia.notice.md
@@ -6,7 +6,10 @@ This page describes how popup notices are displayed.
 
 ## Overview
 
-The notice library displays temporary popup notifications at the top of the player's screen. Notices can be queued or targeted to specific players.
+The notice library displays temporary popup notifications at the top of the
+player's screen. Server functions send network messages to connected clients,
+which create `liaNotice` panels on the client. These panels are stored in the
+`lia.notices` table and automatically expire after roughly 7.5 seconds.
 
 ---
 
@@ -14,14 +17,15 @@ The notice library displays temporary popup notifications at the top of the play
 
 **Description:**
 
-Sends a notification message to a specific player or all players.
+Queues a text notice to display to a specific player or everyone. The
+message is sent over the `liaNotify` network string.
 
 **Parameters:**
 
-* message (string) – Message text to send.
+* message (string) – Message text to send. Converted to a string internally.
 
 
-* recipient (Player|nil) – Target player, or nil to broadcast.
+* recipient (Player|nil) – Optional target player. Leave nil to broadcast.
 
 
 **Realm:**
@@ -37,8 +41,11 @@ Sends a notification message to a specific player or all players.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.notices.notify
-    lia.notices.notifyLocalized("serverRestarting", nil)
+-- Broadcast a restart warning to everyone
+lia.notices.notify("Server restarting in 10 seconds.")
+
+-- Notify just one player about an error
+lia.notices.notify("Your quest failed.", player)
 ```
 
 ---
@@ -47,14 +54,17 @@ Sends a notification message to a specific player or all players.
 
 **Description:**
 
-Sends a localized notification to a player or all players.
+Sends a localized notice to a player or everyone. When the second argument
+isn't a player, it becomes the first formatting parameter and the notice is
+broadcast. Messages use the `liaNotifyL` network string.
 
 **Parameters:**
 
 * key (string) – Localization key.
 
 
-* recipient (Player|nil) – Target player or nil to broadcast.
+* recipient (Player|nil) – Optional target player. Leave nil or pass a
+  non-player as the second argument to broadcast.
 
 
 * ... (any) – Formatting arguments for the localization string.
@@ -73,8 +83,11 @@ Sends a localized notification to a player or all players.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
-    lia.notices.notifyLocalized("welcome", client)
+-- Send a localized greeting to one player
+lia.notices.notifyLocalized("welcome", player)
+
+-- Broadcast a formatted message when no recipient is provided
+lia.notices.notifyLocalized("questFoundItem", nil, "golden_key")
 ```
 
 ---
@@ -83,7 +96,8 @@ Sends a localized notification to a player or all players.
 
 **Description:**
 
-Creates a visual notification panel on the client's screen.
+Creates a `liaNotice` panel on the local client and stores it in
+`lia.notices`. Notices fade out after about 7.5 seconds.
 
 **Parameters:**
 
@@ -103,8 +117,11 @@ Creates a visual notification panel on the client's screen.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.notices.notify
-    lia.notices.notifyLocalized("itemPickedUp")
+-- Display a pickup notice on the local client
+lia.notices.notify("Item picked up")
+
+-- Print an informational message locally
+lia.notices.notify("Welcome back!")
 ```
 
 ---
@@ -113,7 +130,7 @@ Creates a visual notification panel on the client's screen.
 
 **Description:**
 
-Displays a localized notification on the client's screen.
+Translates the key using `L` and displays the result on the local client.
 
 **Parameters:**
 
@@ -136,6 +153,10 @@ Displays a localized notification on the client's screen.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.notices.notifyLocalized
-    lia.notices.notifyLocalized("item_picked_up")
+-- Show a localized pickup message
+lia.notices.notifyLocalized("item_picked_up")
+
+-- Include formatting parameters
+lia.notices.notifyLocalized("foundCoins", 10)
 ```
+


### PR DESCRIPTION
## Summary
- clarify how notice panels are created and timed
- detail the network strings used by server functions
- show improved examples for sending localized and plain notices

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68686d21d7548327bc3d89020af1a32b