### PR TITLE
Fix command validation and network entity handling

### DIFF
--- a/gamemode/core/derma/panels/itempanel.lua
+++ b/gamemode/core/derma/panels/itempanel.lua
@@ -155,7 +155,7 @@ function PANEL:openInspect()
         if IsValid(self.ent) then
             net.Start("invAct")
             net.WriteString("take")
-            net.WriteEntity(self.ent)
+            net.WriteType(self.ent)
             net.SendToServer()
         end
         if IsValid(overlay) then overlay:Remove() end
@@ -173,7 +173,7 @@ function PANEL:buildButtons()
             if not fn.onClick or fn.onClick(self.item) ~= false then
                 net.Start("invAct")
                 net.WriteString(key)
-                net.WriteEntity(self.ent)
+                net.WriteType(self.ent)
                 net.SendToServer()
             end
             self:Remove()

--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -346,7 +346,7 @@ function GM:ItemShowEntityMenu(entity)
         if IsValid(entity) then
             net.Start("invAct")
             net.WriteString("take")
-            net.WriteEntity(entity)
+            net.WriteType(entity)
             net.SendToServer()
         end
         return

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -298,6 +298,7 @@ else
         surface.SetFont("liaSmallFont")
         local controls = {}
         local watchers = {}
+        local validate
         for name, data in pairs(fields) do
             local fieldType = data.type
             local optional = data.optional
@@ -394,7 +395,7 @@ else
         submit:SetFont("liaSmallFont")
         submit:SetIcon("icon16/tick.png")
         submit:SetEnabled(false)
-        local function validate()
+        function validate()
             for _, data in pairs(controls) do
                 if not data.optional then
                     local ctl = data.ctrl


### PR DESCRIPTION
## Summary
- ensure `validate` is in scope before hooking watchers in commands library
- use `net.WriteType` for entity data in `invAct` net messages

## Testing
- `luac` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686876bd277c8327956ce69d4f95d206