### PR TITLE
Update Workshop Library docs

### DIFF
--- a/docs/docs/libraries/lia.workshop.md
+++ b/docs/docs/libraries/lia.workshop.md
@@ -6,15 +6,49 @@ This page documents Workshop addon helpers.
 
 ## Overview
 
-The workshop library tracks required Workshop addon IDs and mounts them on clients. It helps ensure that players have the assets needed for the gamemode.
+The workshop library tracks required Workshop addon IDs and mounts them on clients. It helps ensure that players have the assets needed for the gamemode. When the `AutoDownloadWorkshop` configuration is enabled, connecting players automatically receive the cached list of IDs so missing content can be downloaded.
+
+`lia.workshop.send` is automatically called 10 seconds after each player's initial spawn when this configuration is on.
+
+### Fields
+
+* **lia.workshop.ids** (table) – IDs registered through `lia.workshop.AddWorkshop`.
+* **lia.workshop.known** (table) – IDs that have previously been added and announced.
+* **lia.workshop.cache** (table) – Cached list of IDs built after the `InitializedModules` hook.
+* **resource.AddWorkshop** (function) – Alias of `lia.workshop.AddWorkshop` for compatibility.
 
 ---
+
+### lia.workshop.AddWorkshop(id)
+
+**Description:**
+
+Registers a Steam Workshop addon ID so it will be downloaded by clients. The ID is stored in `lia.workshop.ids` and announced the first time it is added.
+
+**Parameters:**
+
+* id (string|number) – Workshop item ID to add.
+
+**Realm:**
+
+* Server
+
+**Returns:**
+
+* None
+
+**Example Usage:**
+
+```lua
+-- Add a custom model pack from the Workshop
+lia.workshop.AddWorkshop("1234567890")
+```
 
 ### lia.workshop.gather()
 
 **Description:**
 
-Collects workshop IDs from installed addons and registered modules.
+Collects Workshop IDs added with `lia.workshop.AddWorkshop`, from installed addons, and from modules that define `WorkshopContent`.
 
 **Parameters:**
 
@@ -36,6 +70,9 @@ Collects workshop IDs from installed addons and registered modules.
 ```lua
     -- This snippet demonstrates a common usage of lia.workshop.gather
     local ids = lia.workshop.gather()
+for id in pairs(ids) do
+    print("Needs addon:", id)
+end
 ```
 
 ---
@@ -44,7 +81,7 @@ Collects workshop IDs from installed addons and registered modules.
 
 **Description:**
 
-Sends the collected workshop IDs to a connecting player.
+Sends the cached list of Workshop IDs to the specified player using the "WorkshopDownloader_Start" net message.
 
 **Parameters:**
 
@@ -64,6 +101,14 @@ Sends the collected workshop IDs to a connecting player.
 **Example Usage:**
 
 ```lua
-    -- This snippet demonstrates a common usage of lia.workshop.send
+    -- Send the cached list when a player spawns
+hook.Add("PlayerInitialSpawn", "SendWorkshopList", function(ply)
     lia.workshop.send(ply)
+end)
 ```
+
+### Console Commands
+
+`workshop_force_redownload` – clears the local queue and downloads all Workshop items again. Useful if a client
+needs to re-fetch content that may have been corrupted.
+


### PR DESCRIPTION
## Summary
- document lia.workshop.AddWorkshop
- clarify workshop gathering and sending
- mention automatic sending and redownload command

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68687a0f7d248327b83a802797e07b12