### PR TITLE
Fix SAM send_message nil target and bag inventory nil check

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -164,7 +164,11 @@ function sam.player.send_message(client, msg, tbl)
             net.Start("send_message")
             net.WriteString(msg)
             net.WriteTable(tbl)
-            net.Send(client)
+            if istable(client) or IsValid(client) then
+                net.Send(client)
+            else
+                net.Broadcast()
+            end
             return
         end
     else

--- a/modules/inventory/libraries/client.lua
+++ b/modules/inventory/libraries/client.lua
@@ -42,11 +42,13 @@ hook.Add("CreateMenuButtons", "liaInventory", function(tabs)
         for _, item in pairs(inventory:getItems()) do
             if item.isBag and hook.Run("CanOpenBagPanel", item) ~= false then
                 local bagInv = item:getInv()
-                local bagPanel = bagInv:show(mainPanel)
-                lia.gui["inv" .. bagInv:getID()] = bagPanel
-                table.insert(panels, bagPanel)
-                totalWidth = totalWidth + bagPanel:GetWide() + margin
-                maxHeight = math.max(maxHeight, bagPanel:GetTall())
+                if bagInv then
+                    local bagPanel = bagInv:show(mainPanel)
+                    lia.gui["inv" .. bagInv:getID()] = bagPanel
+                    table.insert(panels, bagPanel)
+                    totalWidth = totalWidth + bagPanel:GetWide() + margin
+                    maxHeight = math.max(maxHeight, bagPanel:GetTall())
+                end
             end
         end
 


### PR DESCRIPTION
## Summary
- handle nil client when SAM sends notifications
- guard against missing bag inventory when opening F1 menu

## Testing
- `apt-get update`
- `apt-get install -y lua-check`
- `luacheck gamemode/core/libraries/compatibility/sam.lua modules/inventory/libraries/client.lua` *(fails: `expected '=' near 'end'`)*

------
https://chatgpt.com/codex/tasks/task_e_68687df74ef8832791667e29fec118e0