### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,21 +139,18 @@ jobs:
           cp -R lilia packaged/lilia
           cd packaged
           zip -r ../lilia.zip lilia
-      - id: create_release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: Lilia ${{ env.VERSION }}
-          draft: false
-          prerelease: false
+      - name: Update release tag
+        run: |
+          cd lilia
+          git tag -f release
+          git push --force origin release
         env:
           GITHUB_TOKEN: ${{ secrets.LiliaGitSecret }}
-      - uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: lilia.zip
-          asset_name: lilia.zip
-          asset_content_type: application/zip
+      - name: Recreate GitHub release
+        run: |
+          gh release delete release -y || true
+          gh release create release lilia.zip \
+            -t "Lilia ${VERSION}" -n ""
         env:
           GITHUB_TOKEN: ${{ secrets.LiliaGitSecret }}
 


### PR DESCRIPTION
## Summary
- update workflow to reuse single `release` tag

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_6868984c225c8327b9de6f88b0e1694e