### PR TITLE
Silence duplicate config error logs

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -8,7 +8,7 @@ MYSQLOO_STRING = 1
 MYSQLOO_BOOL = 2
 local modules = {}
 local function ThrowQueryFault(query, fault)
-    if string.find(fault, "duplicate column name:") then return end
+    if string.find(fault, "duplicate column name:") or string.find(fault, "UNIQUE constraint failed: lia_config") then return end
     MsgC(Color(83, 143, 239), "[Lilia] ", Color(0, 255, 0), "[Database]", Color(255, 255, 255), " * " .. query .. "\n")
     MsgC(Color(83, 143, 239), "[Lilia] ", Color(0, 255, 0), "[Database]", Color(255, 255, 255), " " .. fault .. "\n")
 end


### PR DESCRIPTION
## Summary
- ignore duplicate config errors from the database library

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68689dc35f68832793dac825f01c1594