### PR TITLE
Clean up doc formatting

### DIFF
--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -227,10 +227,6 @@ Loads config values from the database (server side) and stores them in `lia.conf
 * Shared
 
 
-    Internal Function:
-
-    true
-
 **Returns:**
 
 * None

--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -163,10 +163,6 @@ executed.
 * Server
 
 
-    Internal Function:
-
-    true
-
 **Returns:**
 
 * None

--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -121,10 +121,6 @@ to key codes.
 * Client
 
 
-    Internal Function:
-
-    true
-
 **Returns:**
 
 * None
@@ -159,10 +155,6 @@ This function is automatically called when the gamemode initializes or reloads.
 
 * Client
 
-
-    Internal Function:
-
-    true
 
 **Returns:**
 

--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -40,10 +40,6 @@ automatically converts any legacy text logs if no entries are present.
 * Server
 
 
-    Internal Function:
-
-    true
-
 **Returns:**
 
 * None
@@ -126,10 +122,6 @@ function.
 
 * Server
 
-
-    Internal Function:
-
-    true
 
 **Returns:**
 
@@ -228,9 +220,17 @@ Console command that prints how many legacy log lines exist inside
 `data/lilia/logs` and how many are valid for import. Run this from the server
 console to estimate conversion time.
 
+**Parameters:**
+
+* None
+
 **Realm:**
 
 * `Server` (`Console`)
+
+**Returns:**
+
+* None
 
 **Example Usage:**
 


### PR DESCRIPTION
## Summary
- remove stray `Internal Function` notes in multiple docs
- fill missing `Parameters` and `Returns` on `lia_log_legacy_count`

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_6868a32dd8f88327801b39e45d73b523