### PR TITLE
Fix GitHub release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.LiliaGitSecret }}
       - name: Recreate GitHub release
         run: |
+          cd lilia
           gh release delete release -y || true
-          gh release create release lilia.zip \
+          gh release create release ../lilia.zip \
             -t "Lilia ${VERSION}" -n ""
         env:
           GITHUB_TOKEN: ${{ secrets.LiliaGitSecret }}


### PR DESCRIPTION
## Summary
- fix path for release step so `gh release` works from repository directory

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_6868a4f009c08327a6b13a25f89d9931