### PR TITLE
Prevent bag from being dragged into itself

### DIFF
--- a/modules/administration/submodules/permissions/libraries/client.lua
+++ b/modules/administration/submodules/permissions/libraries/client.lua
@@ -24,7 +24,7 @@ function MODULE:HUDPaint()
         elseif ent.isItem and ent:isItem() and lia.option.get("espItems") then
             entityType = "Items"
             local itemTable = ent.getItemTable and ent:getItemTable()
-            label = L("itemESPLabel", itemTable and itemTable.name or L("invalid"))
+            label = L("itemESPLabel", itemTable and itemTable.name or L("unknown"))
         elseif ent.isProp and ent:isProp() and lia.option.get("espProps") then
             entityType = "Props"
             label = L("propModelESPLabel", ent:GetModel() or L("unknown"))

--- a/modules/inventory/libraries/server.lua
+++ b/modules/inventory/libraries/server.lua
@@ -90,6 +90,12 @@ function MODULE:HandleItemTransferRequest(client, itemID, x, y, invID)
         return
     end
 
+    local canAccessTransferTo, accessReasonTo = newInventory:canAccess("transfer", context)
+    if not canAccessTransferTo then
+        if isstring(accessReasonTo) then client:notifyLocalized(accessReasonTo) end
+        return
+    end
+
     local oldX, oldY = item:getData("x"), item:getData("y")
     local dropPos = client:getItemDropPos()
     if client.invTransferTransaction and client.invTransferTransactionTimeout > RealTime() then return end


### PR DESCRIPTION
## Summary
- check destination inventory access when transferring items
- stop transfers that would place a bag inside itself
- fix bad argument to `L` in ESP

## Testing
- `luacheck modules/administration/submodules/permissions/libraries/client.lua` *(fails: `command not found`)*
- `sudo apt-get install -y luacheck` *(fails: `Unable to locate package luacheck`)*

------
https://chatgpt.com/codex/tasks/task_e_6868ace125388327a2d18d078079fb2b