### PR TITLE
Fix doc examples using L() translations

### DIFF
--- a/docs/docs/definitions/attribute.md
+++ b/docs/docs/definitions/attribute.md
@@ -36,7 +36,7 @@ Human readable title shown in menus. When the attribute is loaded,
 
 `lia.attribs.loadFromDir` automatically defaults this to the translated
 
-string `L("unknown")` if no name is provided.
+string "Unknown" if no name is provided.
 
 ```lua
 ATTRIBUTE.name = "Strength"
@@ -48,7 +48,7 @@ ATTRIBUTE.name = "Strength"
 
 Concise description or lore text for the attribute. Defaults to the
 
-translation `L("noDesc")` when omitted.
+translation "No Description" when omitted.
 
 ```lua
 ATTRIBUTE.desc = "Determines physical power and carrying capacity."

--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -55,7 +55,7 @@ hook.Add("LoadCharInformation", "AddHungerField", function()
         return string.format("%d%%", hunger), color
     end
 
-    hook.Run("AddTextField", L("generalInfo"), "hunger", "Hunger", hungerField)
+    hook.Run("AddTextField", "General Info", "hunger", "Hunger", hungerField)
 end)
 ```
 
@@ -832,7 +832,7 @@ Lets modules insert additional information on the main menu info panel. Allows m
 hook.Add("LoadMainMenuInformation", "AddFactionInfo", function(info, character)
     local fac = lia.faction.indices[character:getFaction()]
     local facName = fac and fac.name or "Citizen"
-    info[#info + 1] = L("faction") .. ": " .. facName
+    info[#info + 1] = "Faction" .. ": " .. facName
 end)
 ```
 
@@ -2152,7 +2152,7 @@ Runs after the player entity has spawned and data is ready. Allows post-initiali
 -- Initialize some default variables for new players.
 hook.Add("PostPlayerInitialSpawn", "SetupTutorialState", function(ply)
     ply:setNetVar("inTutorial", true)
-    ply:ChatPrint(L("welcomeTutorial"))
+    ply:ChatPrint("Welcome! Follow the arrows to begin the tutorial.")
 end)
 ```
 
@@ -6936,7 +6936,7 @@ hook.Add("CreateSalaryTimer", "SetupSalaryTimer", function(client)
         if IsValid(client) and MODULE:CanPlayerEarnSalary(client, client:getFaction(), client:getClass()) then
             local salary = MODULE:GetSalaryAmount(client, client:getFaction(), client:getClass())
             client:addMoney(salary)
-            client:ChatPrint(string.format(L("salaryReceived"), salary))
+            client:ChatPrint(string.format("You have received your salary of $%s", salary))
             print("Salary of $" .. salary .. " awarded to:", client:Name())
         end
     end)
@@ -7287,7 +7287,7 @@ Called when `lia.option` is fully initialized.
 ```lua
 -- Prints a message when this hook is triggered
 function MODULE:InitializedOptions()
-    LocalPlayer():ChatPrint(L("optionsLoaded"))
+    LocalPlayer():ChatPrint("LOADED OPTIONS!")
 end
 ```
 
@@ -9539,7 +9539,7 @@ Called when a ragdolled character finishes getting up.
 ```lua
 -- Prints a message when OnCharGetup is triggered
 hook.Add("OnCharGetup", "NotifyGetup", function(ply)
-    ply:ChatPrint(L("youStoodUp"))
+    ply:ChatPrint("You stood up")
 end)
 ```
 
@@ -9644,7 +9644,7 @@ Called after a player finishes loading a character. The client receives the same
 ```lua
 -- Prints a message when PlayerLoadedChar is triggered
 hook.Add("PlayerLoadedChar", "WelcomeBack", function(ply, char)
-    ply:ChatPrint(string.format(L("welcomePlayer"), char:getName()))
+    ply:ChatPrint(string.format("Welcome, %s", char:getName()))
 end)
 ```
 
@@ -9827,7 +9827,7 @@ Fired when a staff member claims a help ticket.
 ```lua
 -- Prints a message when TicketSystemClaim is triggered
 hook.Add("TicketSystemClaim", "NotifyClaim", function(staff, ply)
-    staff:ChatPrint(string.format(L("ticketClaimed"), ply:Name()))
+    staff:ChatPrint(string.format("Claimed ticket from %s", ply:Name()))
 end)
 ```
 

--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -58,7 +58,7 @@ local inv
 lia.keybind.add(KEY_F1, "Open Inventory",
     function()
         inv = vgui.Create("liaMenu")
-        inv:setActiveTab(L("inv"))
+        inv:setActiveTab("Inventory")
     end,
     function()
         if IsValid(inv) then inv:Close() end

--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -120,5 +120,5 @@ If the key has no translation, the key itself is returned.
 **Example Usage:**
 
 ```lua
-    print(L("vendorShowAll")) -- prints "Show All" in the active language
+    print("Show All") -- prints "Show All" in the active language
 ```

--- a/docs/docs/libraries/lia.networking.md
+++ b/docs/docs/libraries/lia.networking.md
@@ -103,11 +103,11 @@ so any values assigned with `setNetVar` will be available after `PlayerInitialSp
     -- Inform new players of the current round and previous champion
     hook.Add("PlayerInitialSpawn", "ShowRound", function(ply)
         local round = getNetVar("round", 0)
-        ply:ChatPrint(string.format(L("currentRound"), round))
+        ply:ChatPrint(string.format("Current round: %s", round))
 
         local lastWinner = getNetVar("last_winner")
         if IsValid(lastWinner) then
-            ply:ChatPrint(string.format(L("lastRoundWinner"), lastWinner:Name()))
+            ply:ChatPrint(string.format("Last round won by %s", lastWinner:Name()))
         end
     end)
 ```

--- a/docs/docs/libraries/lia.time.md
+++ b/docs/docs/libraries/lia.time.md
@@ -43,9 +43,9 @@ hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
     local last = lia.data.get(key, nil, true)
 
     if last then
-        ply:ChatPrint(string.format(L("welcomeBack"), lia.time.TimeSince(last)))
+        ply:ChatPrint(string.format("Welcome back! You last joined %s.", lia.time.TimeSince(last)))
     else
-        ply:ChatPrint(L("welcomeFirst"))
+        ply:ChatPrint("Welcome for the first time!")
     end
 
     -- Store the current time for the next login
@@ -126,7 +126,7 @@ Returns the full current date and time formatted based on the
     timer.Create("ServerTimeAnnounce", 3600, 0, function()
         local dateString = lia.time.GetDate()
         for _, ply in player.GetAll() do
-            ply:ChatPrint(L("serverTime") .. dateString)
+            ply:ChatPrint("Server time: " .. dateString)
         end
     end)
 ```

--- a/docs/docs/libraries/lia.util.md
+++ b/docs/docs/libraries/lia.util.md
@@ -286,7 +286,7 @@ Returns all players considered staff or admins, as determined by client:isStaff(
     -- Notify all online staff members about an upcoming restart
     local admins = lia.util.getAdmins()
     for _, admin in ipairs(admins) do
-        admin:ChatPrint(L("serverRestarting") .. " in 5 minutes!")
+        admin:ChatPrint("Server restarting" .. " in 5 minutes!")
     end
 ```
 

--- a/docs/docs/meta/character.md
+++ b/docs/docs/meta/character.md
@@ -132,7 +132,7 @@ Returns the player entity currently controlling this character.
 -- Notify the controlling player that the character loaded
 local ply = char:getPlayer()
 if IsValid(ply) then
-    ply:ChatPrint(L("charReady"))
+    ply:ChatPrint("Character ready")
 end
 ```
 
@@ -163,7 +163,7 @@ Returns the character's name as it should be shown to the given player.
 
 ```lua
 -- Announce the character's name to a viewer
-client:ChatPrint(string.format(L("youSee"), char:getDisplayedName(client)))
+client:ChatPrint(string.format("You see %s", char:getDisplayedName(client)))
 ```
 
 ---

--- a/docs/docs/meta/item.md
+++ b/docs/docs/meta/item.md
@@ -396,7 +396,7 @@ Registers a hook callback for this item instance.
 
 ```lua
 -- Run code when the item is used
-item:hook("use", function(ply) ply:ChatPrint(L("usedItem")) end)
+item:hook("use", function(ply) ply:ChatPrint("Used!") end)
 ```
 
 ---
@@ -625,7 +625,7 @@ Returns the display name of this item. On the client this value is localized.
 
 ```lua
 -- Inform the player which item they found
-client:ChatPrint(string.format(L("pickedUpItem"), item:getName()))
+client:ChatPrint(string.format("Picked up: %s", item:getName()))
 ```
 
 ---
@@ -686,7 +686,7 @@ Removes this item from its inventory without deleting it when `preserveItem` is 
 ```lua
 -- Unequip and drop the item while keeping it saved
 item:removeFromInventory(true):next(function()
-    client:ChatPrint(L("itemUnequipped"))
+    client:ChatPrint("Item unequipped")
 end)
 ```
 

--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -441,7 +441,7 @@ Returns a table of entities within radius of the player.
 ```lua
 for _, ent in ipairs(player:entitiesNearPlayer(256)) do
     if ent:IsPlayer() then
-        ent:ChatPrint(L("nearPlayer"))
+        ent:ChatPrint("Someone is close to you!")
     else
         DebugDrawBox(ent:GetPos(), ent:OBBMins(), ent:OBBMaxs(), 0, 255, 0, 0, 5)
     end
@@ -690,7 +690,7 @@ local target = player:getEyeEnt(128)
 
 if IsValid(target) then
 
-    player:ChatPrint(string.format(L("targetClass"), target:GetClass()))
+    player:ChatPrint(string.format("Class: %s", target:GetClass()))
 
 end
 


### PR DESCRIPTION
## Summary
- remove `L()` shorthand from documentation examples
- replace translation keys with full strings

## Testing
- `grep -R "L(\"" -n docs/docs | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6868b87e7f448327af9268b311ab9c73