### PR TITLE
Fix redundant localization entry

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -390,7 +390,6 @@ LANGUAGE = {
     vendorRestocked = "The vendor has been restocked.",
     NotLookingAtValidVendor = "You are not looking at a valid vendor.",
     vendorAllVendorsRestocked = "All vendors have been restocked. Total vendors restocked: %d.",
-    vendorInvalidAmount = "Invalid amount specified.",
     vendorAllMoneyReset = "All vendors' money has been reset to %s. Total vendors updated: %d.",
     vendorMoneyRestocked = "Vendor's money has been restocked to %s.",
     vendorNoMoneyVariable = "This vendor does not have a money variable.",

--- a/modules/inventory/submodules/vendor/commands.lua
+++ b/modules/inventory/submodules/vendor/commands.lua
@@ -57,7 +57,7 @@ lia.command.add("resetallvendormoney", {
     },
     onRun = function(client, arguments)
         local amount = tonumber(arguments[1])
-        if not amount or amount < 0 then return client:notifyLocalized("vendorInvalidAmount") end
+        if not amount or amount < 0 then return client:notifyLocalized("invalidAmount") end
         local count = 0
         for _, vendor in ipairs(ents.FindByClass("lia_vendor")) do
             if vendor.money ~= nil then
@@ -84,7 +84,7 @@ lia.command.add("restockvendormoney", {
     onRun = function(client, arguments)
         local target = client:getTracedEntity()
         local amount = tonumber(arguments[1])
-        if not amount or amount < 0 then return client:notifyLocalized("vendorInvalidAmount") end
+        if not amount or amount < 0 then return client:notifyLocalized("invalidAmount") end
         if not target or not IsValid(target) then
             client:notifyLocalized("targetNotFound")
             return


### PR DESCRIPTION
## Summary
- remove `vendorInvalidAmount` localization string
- use the generic `invalidAmount` key in vendor commands

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c479e1f883278d4aac5f435e7093