### PR TITLE
Fix faction syntax in commands

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -125,6 +125,8 @@ function lia.command.parseSyntaxFields(syntax)
                 typ = "item"
             elseif typ == "faction" then
                 typ = "faction"
+            elseif typ == "class" then
+                typ = "class"
             else
                 valid = false
             end
@@ -341,6 +343,12 @@ else
                 for _, fac in ipairs(lia.faction.indices) do
                     ctrl:AddChoice(L(fac.name), fac.index)
                 end
+            elseif fieldType == "class" then
+                ctrl = vgui.Create("DComboBox", panel)
+                ctrl:SetValue(L("selectClassPrompt"))
+                for id, class in pairs(lia.class.list) do
+                    ctrl:AddChoice(L(class.name), id)
+                end
             elseif fieldType == "text" or fieldType == "number" then
                 ctrl = vgui.Create("DTextEntry", panel)
                 ctrl:SetFont("liaSmallFont")
@@ -416,7 +424,7 @@ else
                     local ctl = data.ctrl
                     local ftype = data.type
                     local filled = false
-                    if isfunction(ftype) or ftype == "player" or ftype == "item" or ftype == "faction" then
+                    if isfunction(ftype) or ftype == "player" or ftype == "item" or ftype == "faction" or ftype == "class" then
                         local txt, _ = ctl:GetSelected()
                         filled = txt ~= nil and txt ~= ""
                     elseif ftype == "text" or ftype == "number" then
@@ -446,7 +454,7 @@ else
                 local ctlData = controls[key]
                 local ctl = ctlData.ctrl
                 local ftype = field.type
-                if isfunction(ftype) or ftype == "player" or ftype == "item" or ftype == "faction" then
+                if isfunction(ftype) or ftype == "player" or ftype == "item" or ftype == "faction" or ftype == "class" then
                     local txt, data = ctl:GetSelected()
                     if txt and txt ~= "" then args[#args + 1] = data or txt end
                 elseif ftype == "text" or ftype == "number" then

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -306,6 +306,7 @@ LANGUAGE = {
     selectPlayerPrompt = "Select Player",
     selectItemPrompt = "Select Item",
     selectFactionPrompt = "Select Faction",
+    selectClassPrompt = "Select Class",
     typeFieldPrompt = "Type %s",
     copyRow = "Copy Row",
     copySelectedRow = "Copy Selected Row",

--- a/modules/doors/commands.lua
+++ b/modules/doors/commands.lua
@@ -445,7 +445,7 @@ lia.command.add("doorinfo", {
 
 lia.command.add("dooraddfaction", {
     desc = L("dooraddfactionDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)
@@ -495,7 +495,7 @@ lia.command.add("dooraddfaction", {
 
 lia.command.add("doorremovefaction", {
     desc = L("doorremovefactionDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)
@@ -545,7 +545,7 @@ lia.command.add("doorremovefaction", {
 
 lia.command.add("doorsetclass", {
     desc = L("doorsetclassDesc"),
-    syntax = "[string Class]",
+    syntax = "[class Class]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)

--- a/modules/spawns/commands.lua
+++ b/modules/spawns/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("spawnadd", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnAddDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     onRun = function(client, arguments)
         local factionName = arguments[1]
         if not factionName then return L("invalidArg") end
@@ -57,7 +57,7 @@ lia.command.add("spawnremovebyname", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnRemoveByNameDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     onRun = function(_, arguments)
         local factionName = arguments[1]
         local factionInfo = lia.faction.indices[factionName:lower()]

--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Manage Transfers",
     desc = L("plyTransferDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"charsetfaction"},
     AdminStick = {
         Name = L("adminStickTransferName"),
@@ -46,7 +46,7 @@ lia.command.add("plywhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyWhitelistDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -70,7 +70,7 @@ lia.command.add("plyunwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyUnwhitelistDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"factionunwhitelist"},
     AdminStick = {
         Name = L("adminStickUnwhitelistName"),
@@ -99,7 +99,7 @@ lia.command.add("plyunwhitelist", {
 lia.command.add("beclass", {
     adminOnly = false,
     desc = L("beClassDesc"),
-    syntax = "[string Class]",
+    syntax = "[class Class]",
     onRun = function(client, arguments)
         local className = table.concat(arguments, " ")
         local character = client:getChar()
@@ -127,7 +127,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("setClassDesc"),
-    syntax = "[player Player Name] [string Class]",
+    syntax = "[player Player Name] [class Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -158,7 +158,7 @@ lia.command.add("classwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("classWhitelistDesc"),
-    syntax = "[player Name] [string Class]",
+    syntax = "[player Name] [class Class]",
     AdminStick = {
         Name = L("adminStickClassWhitelistName"),
         Category = "characterManagement",
@@ -194,7 +194,7 @@ lia.command.add("classunwhitelist", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = L("classUnwhitelistDesc"),
-    syntax = "[player Name] [string Class]",
+    syntax = "[player Name] [class Class]",
     AdminStick = {
         Name = L("adminStickClassUnwhitelistName"),
         Category = "characterManagement",


### PR DESCRIPTION
## Summary
- correct syntax type for faction-related commands
- add class field type to argument prompts
- update english language strings

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f089f8cc8327807557c67e4413e2