### PR TITLE
Add server requestArguments

### DIFF
--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -1861,6 +1861,34 @@ player:requestString("Name", "Enter text", print)
 ```
 ---
 
+### requestArguments
+
+Description:
+Prompts the client for multiple typed values.
+
+Parameters:
+
+- `title` (string): Window title.
+
+- `argTypes` (table): Field definitions.
+
+- `callback` (function|None): Called with a table of values.
+
+Realm: Server
+
+Returns:
+
+- deferred|None: Deferred object when no callback supplied.
+
+Example Usage:
+
+```lua
+
+player:requestArguments("Info", {Name = "string", Age = "int"}, print)
+
+```
+---
+
 ### binaryQuestion
 
 Description: 

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -593,6 +593,23 @@ if SERVER then
         return d
     end
 
+    function playerMeta:requestArguments(title, argTypes, callback)
+        local d
+        if not isfunction(callback) then
+            d = deferred.new()
+            callback = function(value) d:resolve(value) end
+        end
+
+        self.liaArgReqs = self.liaArgReqs or {}
+        local id = table.insert(self.liaArgReqs, callback)
+        net.Start("ArgumentsRequest")
+        net.WriteUInt(id, 32)
+        net.WriteString(title or "")
+        net.WriteTable(argTypes)
+        net.Send(self)
+        return d
+    end
+
     function playerMeta:binaryQuestion(question, option1, option2, manualDismiss, callback)
         net.Start("BinaryQuestionRequest")
         net.WriteString(question)

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -414,6 +414,18 @@ net.Receive("RequestDropdown", function()
     end
 end)
 
+net.Receive("ArgumentsRequest", function()
+    local id = net.ReadUInt(32)
+    local title = net.ReadString()
+    local fields = net.ReadTable()
+    lia.util.requestArguments(title, fields, function(data)
+        net.Start("ArgumentsRequest")
+        net.WriteUInt(id, 32)
+        net.WriteTable(data)
+        net.SendToServer()
+    end)
+end)
+
 net.Receive("StringRequest", function()
     local id = net.ReadUInt(32)
     local title = net.ReadString()

--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -7,6 +7,15 @@ net.Receive("StringRequest", function(_, client)
     end
 end)
 
+net.Receive("ArgumentsRequest", function(_, client)
+    local id = net.ReadUInt(32)
+    local data = net.ReadTable()
+    if client.liaArgReqs and client.liaArgReqs[id] then
+        client.liaArgReqs[id](data)
+        client.liaArgReqs[id] = nil
+    end
+end)
+
 net.Receive("RequestDropdown", function(_, client)
     local selectedOption = net.ReadString()
     if client.dropdownCallback then


### PR DESCRIPTION
## Summary
- add `requestArguments` to player meta
- handle `ArgumentsRequest` net messages on server and client
- document new method in player docs

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f28e9fac8327a2e6a80b8e159730