### PR TITLE
Fix faction syntax in commands

### DIFF
--- a/modules/doors/commands.lua
+++ b/modules/doors/commands.lua
@@ -445,7 +445,7 @@ lia.command.add("doorinfo", {
 
 lia.command.add("dooraddfaction", {
     desc = L("dooraddfactionDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)
@@ -495,7 +495,7 @@ lia.command.add("dooraddfaction", {
 
 lia.command.add("doorremovefaction", {
     desc = L("doorremovefactionDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     adminOnly = true,
     privilege = "Manage Doors",
     onRun = function(client, arguments)

--- a/modules/spawns/commands.lua
+++ b/modules/spawns/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("spawnadd", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnAddDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     onRun = function(client, arguments)
         local factionName = arguments[1]
         if not factionName then return L("invalidArg") end
@@ -57,7 +57,7 @@ lia.command.add("spawnremovebyname", {
     privilege = "Manage Spawns",
     adminOnly = true,
     desc = L("spawnRemoveByNameDesc"),
-    syntax = "[string Faction]",
+    syntax = "[faction Faction]",
     onRun = function(_, arguments)
         local factionName = arguments[1]
         local factionInfo = lia.faction.indices[factionName:lower()]

--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Manage Transfers",
     desc = L("plyTransferDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"charsetfaction"},
     AdminStick = {
         Name = L("adminStickTransferName"),
@@ -46,7 +46,7 @@ lia.command.add("plywhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyWhitelistDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -70,7 +70,7 @@ lia.command.add("plyunwhitelist", {
     adminOnly = true,
     privilege = "Manage Whitelists",
     desc = L("plyUnwhitelistDesc"),
-    syntax = "[player Name] [string Faction]",
+    syntax = "[player Name] [faction Faction]",
     alias = {"factionunwhitelist"},
     AdminStick = {
         Name = L("adminStickUnwhitelistName"),


### PR DESCRIPTION
## Summary
- use the `faction` argument type instead of `string` for faction arguments

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6869f3c352d08327a2e007ab9c37b48c