### PR TITLE
Default localization for chat registration

### DIFF
--- a/docs/docs/libraries/lia.chatbox.md
+++ b/docs/docs/libraries/lia.chatbox.md
@@ -80,7 +80,7 @@ Registers a new chat class and sets up command aliases.
 
   - `syntax` (string) – Argument usage description shown in command help.
 
-  - `desc` (string) – Description of the command shown in menus.
+  - `desc` (string) – Description of the command shown in menus. The value is automatically localized using `L`.
 
   - `prefix` (string or table) – Command prefixes that trigger this chat type.
 
@@ -104,7 +104,7 @@ Registers a new chat class and sets up command aliases.
 
   - `color` (Color) – Default color used with the fallback `onChatAdd`.
 
-  - `format` (string) – Format string for the fallback `onChatAdd`.
+  - `format` (string) – Format string for the fallback `onChatAdd`. The value is automatically localized using `L`.
 
   - `filter` (string) – Chat filter category used by the chat UI.
 

--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -6,7 +6,7 @@ end
 
 function lia.chat.register(chatType, data)
     data.syntax = data.syntax or ""
-    data.desc = data.desc or ""
+    data.desc = L(data.desc or "")
     if not data.onCanHear then
         if isfunction(data.radius) then
             data.onCanHear = function(speaker, listener) return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= data.radius() ^ 2 end
@@ -30,7 +30,7 @@ function lia.chat.register(chatType, data)
     end
 
     data.color = data.color or Color(242, 230, 160)
-    data.format = data.format or "%s: \"%s\""
+    data.format = L(data.format or "%s: \"%s\"")
     data.onChatAdd = data.onChatAdd or function(speaker, text, anonymous)
         local name = anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, chatType) or IsValid(speaker) and speaker:Name() or "Console"
         chat.AddText(lia.chat.timestamp(false), data.color, string.format(data.format, name, text))


### PR DESCRIPTION
## Summary
- localize the description and format strings in `lia.chat.register`
- document automatic localization in the chatbox library

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869f7d6c3008327a34bfcdacc3ee1e6