### PR TITLE
Remove redundant localization wrappers from AdminStick commands

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -207,9 +207,9 @@ lia.command.add("plygetplaytime", {
     privilege = "View Playtime",
     syntax = "[player Char Name]",
     AdminStick = {
-        Name = L("adminStickGetPlayTimeName"),
+        Name = "adminStickGetPlayTimeName",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/time.png"
     },
     desc = L("plygetplaytimeDesc"),

--- a/modules/administration/commands.lua
+++ b/modules/administration/commands.lua
@@ -77,9 +77,9 @@ lia.command.add("sendtositroom", {
     desc = L("sendToSitRoomDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("sendToSitRoom"),
+        Name = "sendToSitRoom",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/arrow_down.png"
     },
     onRun = function(client, arguments)
@@ -123,9 +123,9 @@ lia.command.add("returnsitroom", {
     desc = L("returnFromSitroomDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("returnFromSitroom"),
+        Name = "returnFromSitroom",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/arrow_up.png"
     },
     onRun = function(client, arguments)

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -4,9 +4,9 @@
     desc = L("togglePermakillDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickTogglePermakillName"),
+        Name = "adminStickTogglePermakillName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryBans"),
+        SubCategory = "adminStickSubCategoryBans",
         Icon = "icon16/user_delete.png"
     },
     onRun = function(client, arguments)
@@ -279,9 +279,9 @@ lia.command.add("checkinventory", {
     desc = L("checkInventoryDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickCheckInventoryName"),
+        Name = "adminStickCheckInventoryName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/box.png"
     },
     onRun = function(client, arguments)
@@ -347,9 +347,9 @@ lia.command.add("flaggiveall", {
     desc = L("giveAllFlagsDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGiveAllFlagsName"),
+        Name = "adminStickGiveAllFlagsName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/flag_blue.png"
     },
     onRun = function(client, arguments)
@@ -375,9 +375,9 @@ lia.command.add("flagtakeall", {
     desc = L("takeAllFlagsDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickTakeAllFlagsName"),
+        Name = "adminStickTakeAllFlagsName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/flag_green.png"
     },
     onRun = function(client, arguments)
@@ -444,9 +444,9 @@ lia.command.add("charvoicetoggle", {
     desc = L("charVoiceToggleDesc"),
     syntax = "[string Name]",
     AdminStick = {
-        Name = L("toggleVoice"),
+        Name = "toggleVoice",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/sound_mute.png"
     },
     onRun = function(client, arguments)
@@ -596,9 +596,9 @@ lia.command.add("clearinv", {
     desc = L("clearInvDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickClearInventoryName"),
+        Name = "adminStickClearInventoryName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/bin.png"
     },
     onRun = function(client, arguments)
@@ -619,9 +619,9 @@ lia.command.add("charkick", {
     desc = L("kickCharDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickKickCharacterName"),
+        Name = "adminStickKickCharacterName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryBans"),
+        SubCategory = "adminStickSubCategoryBans",
         Icon = "icon16/user_delete.png"
     },
     onRun = function(client, arguments)
@@ -679,9 +679,9 @@ lia.command.add("charban", {
     desc = L("banCharDesc"),
     syntax = "[string Name or Number ID]",
     AdminStick = {
-        Name = L("adminStickBanCharacterName"),
+        Name = "adminStickBanCharacterName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryBans"),
+        SubCategory = "adminStickSubCategoryBans",
         Icon = "icon16/user_red.png"
     },
     onRun = function(client, arguments)
@@ -729,9 +729,9 @@ lia.command.add("checkmoney", {
     desc = L("checkMoneyDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickCheckMoneyName"),
+        Name = "adminStickCheckMoneyName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/money.png"
     },
     onRun = function(client, arguments)
@@ -797,9 +797,9 @@ lia.command.add("charsetspeed", {
     desc = L("setSpeedDesc"),
     syntax = "[player Player Name] [number Speed]",
     AdminStick = {
-        Name = L("adminStickSetCharSpeedName"),
+        Name = "adminStickSetCharSpeedName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/lightning.png"
     },
     onRun = function(client, arguments)
@@ -840,9 +840,9 @@ lia.command.add("chargiveitem", {
     desc = L("giveItemDesc"),
     syntax = "[player Player Name] [string Item Name Or ID]",
     AdminStick = {
-        Name = L("adminStickGiveItemName"),
+        Name = "adminStickGiveItemName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
@@ -889,9 +889,9 @@ lia.command.add("charsetdesc", {
     desc = L("setDescDesc"),
     syntax = "[player Player Name] [string Description]",
     AdminStick = {
-        Name = L("adminStickSetCharDescName"),
+        Name = "adminStickSetCharDescName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_comment.png"
     },
     onRun = function(client, arguments)
@@ -919,9 +919,9 @@ lia.command.add("charsetname", {
     desc = L("setNameDesc"),
     syntax = "[player Player Name] [string New Name]",
     AdminStick = {
-        Name = L("adminStickSetCharNameName"),
+        Name = "adminStickSetCharNameName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_edit.png"
     },
     onRun = function(client, arguments)
@@ -944,9 +944,9 @@ lia.command.add("charsetscale", {
     desc = L("setScaleDesc"),
     syntax = "[player Player Name] [number Scale]",
     AdminStick = {
-        Name = L("adminStickSetCharScaleName"),
+        Name = "adminStickSetCharScaleName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/arrow_out.png"
     },
     onRun = function(client, arguments)
@@ -968,9 +968,9 @@ lia.command.add("charsetjump", {
     desc = L("setJumpDesc"),
     syntax = "[player Player Name] [number Power]",
     AdminStick = {
-        Name = L("adminStickSetCharJumpName"),
+        Name = "adminStickSetCharJumpName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/arrow_up.png"
     },
     onRun = function(client, arguments)
@@ -1021,9 +1021,9 @@ lia.command.add("charsetskin", {
     desc = L("setSkinDesc"),
     syntax = "[player Player Name] [number Skin]",
     AdminStick = {
-        Name = L("adminStickSetCharSkinName"),
+        Name = "adminStickSetCharSkinName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
@@ -1148,7 +1148,7 @@ lia.command.add("forcesay", {
     AdminStick = {
         Name = "Force Say",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/comments.png"
     },
     onRun = function(client, arguments)
@@ -1215,9 +1215,9 @@ lia.command.add("chargetmodel", {
     desc = L("getCharModelDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharModelName"),
+        Name = "adminStickGetCharModelName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
@@ -1249,9 +1249,9 @@ lia.command.add("checkflags", {
     desc = L("checkFlagsDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharFlagsName"),
+        Name = "adminStickGetCharFlagsName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/flag_yellow.png"
     },
     onRun = function(client, arguments)
@@ -1276,9 +1276,9 @@ lia.command.add("chargetname", {
     desc = L("getCharNameDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharNameName"),
+        Name = "adminStickGetCharNameName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/user.png"
     },
     onRun = function(client, arguments)
@@ -1298,9 +1298,9 @@ lia.command.add("chargethealth", {
     desc = L("getHealthDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharHealthName"),
+        Name = "adminStickGetCharHealthName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/heart.png"
     },
     onRun = function(client, arguments)
@@ -1320,9 +1320,9 @@ lia.command.add("chargetmoney", {
     desc = L("getMoneyDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharMoneyName"),
+        Name = "adminStickGetCharMoneyName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/money.png"
     },
     onRun = function(client, arguments)
@@ -1343,9 +1343,9 @@ lia.command.add("chargetinventory", {
     desc = L("getInventoryDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickGetCharInventoryName"),
+        Name = "adminStickGetCharInventoryName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategoryGetInfos"),
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/box.png"
     },
     onRun = function(client, arguments)

--- a/modules/administration/submodules/tickets/commands.lua
+++ b/modules/administration/submodules/tickets/commands.lua
@@ -4,9 +4,9 @@
     desc = L("plyViewClaimsDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("viewTicketClaims"),
+        Name = "viewTicketClaims",
         Category = "moderationTools",
-        SubCategory = L("misc"),
+        SubCategory = "misc",
         Icon = "icon16/page_white_text.png"
     },
     onRun = function(client, arguments)

--- a/modules/administration/submodules/warns/commands.lua
+++ b/modules/administration/submodules/warns/commands.lua
@@ -4,9 +4,9 @@
     desc = L("warnDesc"),
     syntax = "[player Target] [string Reason]",
     AdminStick = {
-        Name = L("warnPlayer"),
+        Name = "warnPlayer",
         Category = "moderationTools",
-        SubCategory = L("warnings"),
+        SubCategory = "warnings",
         Icon = "icon16/error.png"
     },
     onRun = function(client, arguments)
@@ -40,9 +40,9 @@ lia.command.add("viewwarns", {
     desc = L("viewWarnsDesc"),
     syntax = "[player Target]",
     AdminStick = {
-        Name = L("viewPlayerWarnings"),
+        Name = "viewPlayerWarnings",
         Category = "moderationTools",
-        SubCategory = L("warnings"),
+        SubCategory = "warnings",
         Icon = "icon16/eye.png"
     },
     onRun = function(client, arguments)

--- a/modules/attributes/commands.lua
+++ b/modules/attributes/commands.lua
@@ -4,9 +4,9 @@
     syntax = "[player Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
-        Name = L("setAttributes"),
+        Name = "setAttributes",
         Category = "characterManagement",
-        SubCategory = L("attributes"),
+        SubCategory = "attributes",
         Icon = "icon16/wrench.png"
     },
     onRun = function(client, arguments)
@@ -39,9 +39,9 @@ lia.command.add("checkattributes", {
     syntax = "[player Player Name]",
     privilege = "Manage Attributes",
     AdminStick = {
-        Name = L("checkAttributes"),
+        Name = "checkAttributes",
         Category = "characterManagement",
-        SubCategory = L("attributes"),
+        SubCategory = "attributes",
         Icon = "icon16/zoom.png"
     },
     onRun = function(client, arguments)
@@ -101,9 +101,9 @@ lia.command.add("charaddattrib", {
     syntax = "[player Player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
-        Name = L("addAttributes"),
+        Name = "addAttributes",
         Category = "characterManagement",
-        SubCategory = L("attributes"),
+        SubCategory = "attributes",
         Icon = "icon16/add.png"
     },
     onRun = function(client, arguments)

--- a/modules/chatbox/commands.lua
+++ b/modules/chatbox/commands.lua
@@ -6,9 +6,9 @@ lia.command.add("banooc", {
     desc = L("banOOCCommandDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("banOOCCommandName"),
+        Name = "banOOCCommandName",
         Category = "moderationTools",
-        SubCategory = L("oocCategory"),
+        SubCategory = "oocCategory",
         Icon = "icon16/sound_mute.png"
     },
     onRun = function(client, arguments)
@@ -30,9 +30,9 @@ lia.command.add("unbanooc", {
     desc = L("unbanOOCCommandDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("unbanOOCCommandName"),
+        Name = "unbanOOCCommandName",
         Category = "moderationTools",
-        SubCategory = L("oocCategory"),
+        SubCategory = "oocCategory",
         Icon = "icon16/sound.png"
     },
     onRun = function(client, arguments)

--- a/modules/doors/commands.lua
+++ b/modules/doors/commands.lua
@@ -2,7 +2,7 @@
     desc = L("doorsellDesc"),
     adminOnly = false,
     AdminStick = {
-        Name = L("adminStickDoorSellName"),
+        Name = "adminStickDoorSellName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -30,7 +30,7 @@ lia.command.add("admindoorsell", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickAdminDoorSellName"),
+        Name = "adminStickAdminDoorSellName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -60,7 +60,7 @@ lia.command.add("doortogglelock", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickToggleDoorLockName"),
+        Name = "adminStickToggleDoorLockName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -98,7 +98,7 @@ lia.command.add("doorbuy", {
     desc = L("doorbuyDesc"),
     adminOnly = false,
     AdminStick = {
-        Name = L("adminStickDoorBuyName"),
+        Name = "adminStickDoorBuyName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -136,7 +136,7 @@ lia.command.add("doortoggleownable", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickToggleDoorOwnableName"),
+        Name = "adminStickToggleDoorOwnableName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -160,7 +160,7 @@ lia.command.add("doorresetdata", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickResetDoorDataName"),
+        Name = "adminStickResetDoorDataName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -199,7 +199,7 @@ lia.command.add("doortoggleenabled", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickToggleDoorEnabledName"),
+        Name = "adminStickToggleDoorEnabledName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -223,7 +223,7 @@ lia.command.add("doortogglehidden", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickToggleDoorHiddenName"),
+        Name = "adminStickToggleDoorHiddenName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -252,7 +252,7 @@ lia.command.add("doorsetprice", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickSetDoorPriceName"),
+        Name = "adminStickSetDoorPriceName",
         TargetClass = "Door"
     },
     onRun = function(client, arguments)
@@ -277,7 +277,7 @@ lia.command.add("doorsettitle", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickSetDoorTitleName"),
+        Name = "adminStickSetDoorTitleName",
         TargetClass = "Door"
     },
     onRun = function(client, arguments)
@@ -306,7 +306,7 @@ lia.command.add("doorsetparent", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickSetDoorParentName"),
+        Name = "adminStickSetDoorParentName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -326,7 +326,7 @@ lia.command.add("doorsetchild", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickSetDoorChildName"),
+        Name = "adminStickSetDoorChildName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -355,7 +355,7 @@ lia.command.add("doorremovechild", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickRemoveDoorChildName"),
+        Name = "adminStickRemoveDoorChildName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -390,7 +390,7 @@ lia.command.add("savedoors", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickSaveDoorsName"),
+        Name = "adminStickSaveDoorsName",
         TargetClass = "Door"
     },
     onRun = function(client)
@@ -405,7 +405,7 @@ lia.command.add("doorinfo", {
     adminOnly = true,
     privilege = "Manage Doors",
     AdminStick = {
-        Name = L("adminStickDoorInfoName"),
+        Name = "adminStickDoorInfoName",
         TargetClass = "Door"
     },
     onRun = function(client)

--- a/modules/inventory/commands.lua
+++ b/modules/inventory/commands.lua
@@ -4,9 +4,9 @@
     desc = L("updateInventorySizeDesc"),
     syntax = "[player Player Name]",
     AdminStick = {
-        Name = L("adminStickUpdateInvSizeName"),
+        Name = "adminStickUpdateInvSizeName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/box_add.png"
     },
     onRun = function(client, arguments)
@@ -50,9 +50,9 @@ lia.command.add("setinventorysize", {
     desc = L("setInventorySizeDesc"),
     syntax = "[player Player Name] [number Width] [number Height]",
     AdminStick = {
-        Name = L("adminStickSetInvSizeName"),
+        Name = "adminStickSetInvSizeName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/box_edit.png"
     },
     onRun = function(client, args)

--- a/modules/inventory/submodules/vendor/commands.lua
+++ b/modules/inventory/submodules/vendor/commands.lua
@@ -3,7 +3,7 @@
     superAdminOnly = true,
     desc = L("restockVendorDesc"),
     AdminStick = {
-        Name = L("restockVendorStickName"),
+        Name = "restockVendorStickName",
         TargetClass = "lia_vendor"
     },
     onRun = function(client)
@@ -52,7 +52,7 @@ lia.command.add("resetallvendormoney", {
     desc = L("resetAllVendorMoneyDesc"),
     syntax = "[number Amount]",
     AdminStick = {
-        Name = L("resetAllVendorMoneyStickName"),
+        Name = "resetAllVendorMoneyStickName",
         TargetClass = "lia_vendor"
     },
     onRun = function(client, arguments)
@@ -78,7 +78,7 @@ lia.command.add("restockvendormoney", {
     desc = L("restockVendorMoneyDesc"),
     syntax = "[number Amount]",
     AdminStick = {
-        Name = L("restockVendorMoneyStickName"),
+        Name = "restockVendorMoneyStickName",
         TargetClass = "lia_vendor"
     },
     onRun = function(client, arguments)

--- a/modules/spawns/commands.lua
+++ b/modules/spawns/commands.lua
@@ -92,9 +92,9 @@ lia.command.add("returnitems", {
     desc = L("returnItemsDesc"),
     syntax = "[player Name]",
     AdminStick = {
-        Name = L("returnItemsName"),
+        Name = "returnItemsName",
         Category = "characterManagement",
-        SubCategory = L("items"),
+        SubCategory = "items",
         Icon = "icon16/arrow_refresh.png"
     },
     onRun = function(client, arguments)

--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -5,9 +5,9 @@
     syntax = "[player Name] [faction Faction]",
     alias = {"charsetfaction"},
     AdminStick = {
-        Name = L("adminStickTransferName"),
+        Name = "adminStickTransferName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_go.png"
     },
     onRun = function(client, arguments)
@@ -73,9 +73,9 @@ lia.command.add("plyunwhitelist", {
     syntax = "[player Name] [faction Faction]",
     alias = {"factionunwhitelist"},
     AdminStick = {
-        Name = L("adminStickUnwhitelistName"),
+        Name = "adminStickUnwhitelistName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_delete.png"
     },
     onRun = function(client, arguments)
@@ -160,9 +160,9 @@ lia.command.add("classwhitelist", {
     desc = L("classWhitelistDesc"),
     syntax = "[player Name] [class Class]",
     AdminStick = {
-        Name = L("adminStickClassWhitelistName"),
+        Name = "adminStickClassWhitelistName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_add.png"
     },
     onRun = function(client, arguments)
@@ -196,9 +196,9 @@ lia.command.add("classunwhitelist", {
     desc = L("classUnwhitelistDesc"),
     syntax = "[player Name] [class Class]",
     AdminStick = {
-        Name = L("adminStickClassUnwhitelistName"),
+        Name = "adminStickClassUnwhitelistName",
         Category = "characterManagement",
-        SubCategory = L("adminStickSubCategorySetInfos"),
+        SubCategory = "adminStickSubCategorySetInfos",
         Icon = "icon16/user_delete.png"
     },
     onRun = function(client, arguments)


### PR DESCRIPTION
## Summary
- simplify AdminStick command definitions by storing localization keys directly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6869f9a750288327901fc21506b84299