### PR TITLE
Localize Force Say adminstick entry

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -746,6 +746,7 @@ LANGUAGE = {
     globalBotSayDesc = "Force all bots on the server to say something.",
     botSayDesc = "Force a specific bot to say something.",
     forceSayDesc = "Force a player to say something in chat.",
+    forceSayName = "Force Say",
     getModelDesc = "Get the model of the entity you are looking at.",
     getCharModelDesc = "Get the model of a player's character.",
     checkAllMoneyDesc = "Check every player's money balance.",

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -1146,7 +1146,7 @@ lia.command.add("forcesay", {
     desc = L("forceSayDesc"),
     syntax = "[player Player Name] [string Message]",
     AdminStick = {
-        Name = "Force Say",
+        Name = "forceSayName",
         Category = "moderationTools",
         SubCategory = "misc",
         Icon = "icon16/comments.png"


### PR DESCRIPTION
## Summary
- add translation key for Force Say command
- use translation key in Force Say adminstick entry

## Testing
- `python3 - <<'EOF'...` script verifies all AdminStick names have translation keys

------
https://chatgpt.com/codex/tasks/task_e_6869fb8c54548327883347f7d020cad0