### PR TITLE
Auto-localize faction and attribute names

### DIFF
--- a/gamemode/core/libraries/attributes.lua
+++ b/gamemode/core/libraries/attributes.lua
@@ -5,8 +5,8 @@ function lia.attribs.loadFromDir(directory)
         local niceName = v:sub(1, 3) == "sh_" and v:sub(4, -5):lower() or v:sub(1, -5)
         ATTRIBUTE = lia.attribs.list[niceName] or {}
         lia.include(directory .. "/" .. v, "shared")
-        ATTRIBUTE.name = ATTRIBUTE.name or L("unknown")
-        ATTRIBUTE.desc = ATTRIBUTE.desc or L("noDesc")
+        ATTRIBUTE.name = ATTRIBUTE.name and L(ATTRIBUTE.name) or L("unknown")
+        ATTRIBUTE.desc = ATTRIBUTE.desc and L(ATTRIBUTE.desc) or L("noDesc")
         lia.attribs.list[niceName] = ATTRIBUTE
         ATTRIBUTE = nil
     end

--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -18,14 +18,17 @@ function lia.faction.loadFromDir(directory)
 
         lia.include(directory .. "/" .. v, "shared")
         if not FACTION.name then
-            FACTION.name = L("unknown")
+            FACTION.name = "unknown"
             ErrorNoHalt("Faction '" .. niceName .. "' is missing a name. You need to add a FACTION.name = \"Name\"\n")
         end
 
         if not FACTION.desc then
-            FACTION.desc = L("noDesc")
+            FACTION.desc = "noDesc"
             ErrorNoHalt("Faction '" .. niceName .. "' is missing a description. You need to add a FACTION.desc = \"Description\"\n")
         end
+
+        FACTION.name = L(FACTION.name)
+        FACTION.desc = L(FACTION.desc)
 
         if not FACTION.color then
             FACTION.color = Color(150, 150, 150)

--- a/modules/administration/submodules/permissions/factions/staff.lua
+++ b/modules/administration/submodules/permissions/factions/staff.lua
@@ -1,5 +1,5 @@
-﻿FACTION.name = L("factionStaffName")
-FACTION.desc = L("factionStaffDesc")
+﻿FACTION.name = "factionStaffName"
+FACTION.desc = "factionStaffDesc"
 FACTION.color = Color(255, 56, 252)
 FACTION.isDefault = false
 FACTION.models = {"models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl"}

--- a/modules/attributes/attributes/endurance.lua
+++ b/modules/attributes/attributes/endurance.lua
@@ -1,2 +1,2 @@
-﻿ATTRIBUTE.name = L("Endurance")
-ATTRIBUTE.desc = L("EnduranceDesc")
+﻿ATTRIBUTE.name = "Endurance"
+ATTRIBUTE.desc = "EnduranceDesc"

--- a/modules/attributes/attributes/stamina.lua
+++ b/modules/attributes/attributes/stamina.lua
@@ -1,2 +1,2 @@
-﻿ATTRIBUTE.name = L("Stamina")
-ATTRIBUTE.desc = L("StaminaDesc")
+﻿ATTRIBUTE.name = "Stamina"
+ATTRIBUTE.desc = "StaminaDesc"

--- a/modules/attributes/attributes/strength.lua
+++ b/modules/attributes/attributes/strength.lua
@@ -1,2 +1,2 @@
-﻿ATTRIBUTE.name = L("Strength")
-ATTRIBUTE.desc = L("StrengthDesc")
+﻿ATTRIBUTE.name = "Strength"
+ATTRIBUTE.desc = "StrengthDesc"

--- a/modules/inventory/submodules/storage/config.lua
+++ b/modules/inventory/submodules/storage/config.lua
@@ -1,8 +1,8 @@
 ﻿MODULE.Vehicles = MODULE.Vehicles or {}
 MODULE.StorageDefinitions = {
     ["models/props_junk/wood_crate001a.mdl"] = {
-        name = L("storageWoodCrate"),
-        desc = L("storageWoodCrateDesc"),
+        name = "storageWoodCrate",
+        desc = "storageWoodCrateDesc",
         invType = "GridInv",
         invData = {
             w = 4,
@@ -10,8 +10,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_c17/lockers001a.mdl"] = {
-        name = L("storageLocker"),
-        desc = L("storageLockerDesc"),
+        name = "storageLocker",
+        desc = "storageLockerDesc",
         invType = "GridInv",
         invData = {
             w = 4,
@@ -19,8 +19,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_wasteland/controlroom_storagecloset001a.mdl"] = {
-        name = L("storageMetalCloset"),
-        desc = L("storageMetalClosetDesc"),
+        name = "storageMetalCloset",
+        desc = "storageMetalClosetDesc",
         invType = "GridInv",
         invData = {
             w = 5,
@@ -28,8 +28,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_wasteland/controlroom_filecabinet002a.mdl"] = {
-        name = L("storageFileCabinet"),
-        desc = L("storageFileCabinetDesc"),
+        name = "storageFileCabinet",
+        desc = "storageFileCabinetDesc",
         invType = "GridInv",
         invData = {
             w = 3,
@@ -37,8 +37,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_c17/furniturefridge001a.mdl"] = {
-        name = L("storageRefrigerator"),
-        desc = L("storageRefrigeratorDesc"),
+        name = "storageRefrigerator",
+        desc = "storageRefrigeratorDesc",
         invType = "GridInv",
         invData = {
             w = 3,
@@ -46,8 +46,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_wasteland/kitchen_fridge001a.mdl"] = {
-        name = L("storageLargeRefrigerator"),
-        desc = L("storageLargeRefrigeratorDesc"),
+        name = "storageLargeRefrigerator",
+        desc = "storageLargeRefrigeratorDesc",
         invType = "GridInv",
         invData = {
             w = 4,
@@ -55,8 +55,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/props_junk/trashbin01a.mdl"] = {
-        name = L("storageTrashBin"),
-        desc = L("storageTrashBinDesc"),
+        name = "storageTrashBin",
+        desc = "storageTrashBinDesc",
         invType = "GridInv",
         invData = {
             w = 1,
@@ -64,8 +64,8 @@ MODULE.StorageDefinitions = {
         }
     },
     ["models/items/ammocrate_smg1.mdl"] = {
-        name = L("storageAmmoCrate"),
-        desc = L("storageAmmoCrateDesc"),
+        name = "storageAmmoCrate",
+        desc = "storageAmmoCrateDesc",
         invType = "GridInv",
         invData = {
             w = 5,
@@ -77,8 +77,8 @@ MODULE.StorageDefinitions = {
         end
     },
     vehicle = {
-        name = L("storageVehicle"),
-        desc = L("storageVehicleDesc"),
+        name = "storageVehicle",
+        desc = "storageVehicleDesc",
         invType = "GridInv",
         invData = {
             w = 6,


### PR DESCRIPTION
## Summary
- localize faction and attribute names/desc at load time
- use plain localization keys for staff faction
- use localization keys for attribute definitions
- use localization keys for storage definitions

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_6869fff5d4208327aec187c5f2e48526