### PR TITLE
Fix missing localization key

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -861,6 +861,7 @@ LANGUAGE = {
     clearChatCommandDesc = "Clears chat for all players.",
     teleportedToEntity = "Teleported to entity: %s",
     youAreDead = "You are dead!",
+    youAreRagdolled = "You are ragdolled!",
     cannotSwitchInVehicle = "You cannot switch characters while in a vehicle or sitting!",
     pressInstructions = "Press A/D to rotate | W/S to move camera vertically | Press SPACE to exit",
     entities = "Entities",


### PR DESCRIPTION
## Summary
- define missing `youAreRagdolled` localization key in English table

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a0c8bb07c8327847cabc2b4ff6799