### PR TITLE
Format meta docs

### DIFF
--- a/docs/docs/meta/character.md
+++ b/docs/docs/meta/character.md
@@ -10,13 +10,22 @@ The character meta library contains information about a player's current game st
 
 ### tostring
 
-Description: Returns a printable identifier for this character.
-Parameters:
+**Purpose**
+Returns a printable identifier for this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Format "character[id]".
-Example Usage:
+
+**Example**
+
 ```lua
 -- Print a readable identifier when saving debug logs
 print("Active char: " .. char:tostring())
@@ -27,13 +36,22 @@ print("Active char: " .. char:tostring())
 
 ### eq
 
-Description: Compares this character's ID with another object's ID. The argument can be a `Character` instance or any object providing a `getID` method.
-Parameters:
+**Purpose**
+Compares this character's ID with another object's ID. The argument can be a `Character` instance or any object providing a `getID` method.
+
+**Parameters**
+
 - `other` (`Character`): Character or object to compare.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if both share the same ID.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Unlock the door only for its controlling character
 local owner = door:getNetVar("ownChar")
@@ -46,13 +64,22 @@ end
 
 ### getID
 
-Description: Returns the unique database ID for this character.
-Parameters:
+**Purpose**
+Returns the unique database ID for this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Character identifier.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Store the character ID for later reference
 local id = char:getID()
@@ -63,13 +90,22 @@ session.lastCharID = id
 
 ### getPlayer
 
-Description: Returns the player entity currently controlling this character.
-Parameters:
+**Purpose**
+Returns the player entity currently controlling this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - Player|None: Owning player or None.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Notify the controlling player that the character loaded
 local ply = char:getPlayer()
@@ -82,13 +118,22 @@ end
 
 ### getDisplayedName
 
-Description: Returns the character's name as it should be shown to the given player.
-Parameters:
+**Purpose**
+Returns the character's name as it should be shown to the given player.
+
+**Parameters**
+
 - `client` (`Player`): Player requesting the name.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Localized or recognized character name.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Announce the character's name to a viewer
 client:ChatPrint(string.format("You see %s", char:getDisplayedName(client)))
@@ -98,13 +143,22 @@ client:ChatPrint(string.format("You see %s", char:getDisplayedName(client)))
 
 ### hasMoney
 
-Description: Checks if the character has at least the given amount of money.
-Parameters:
+**Purpose**
+Checks if the character has at least the given amount of money.
+
+**Parameters**
+
 - `amount` (`number`): Amount to check for.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the character's funds are sufficient.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Verify the character can pay for an item before buying
 if char:hasMoney(item.price) then
@@ -116,13 +170,22 @@ end
 
 ### getFlags
 
-Description: Retrieves the string of permission flags for this character.
-Parameters:
+**Purpose**
+Retrieves the string of permission flags for this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Concatenated flag characters.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Look for the admin flag on this character
 if char:getFlags():find("A") then
@@ -134,13 +197,22 @@ end
 
 ### hasFlags
 
-Description: Checks if the character possesses any of the specified flags.
-Parameters:
+**Purpose**
+Checks if the character possesses any of the specified flags.
+
+**Parameters**
+
 - `flags` (`string`): String of flag characters to check.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if at least one flag is present.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Allow special command if any required flag is present
 if char:hasFlags("abc") then
@@ -152,13 +224,22 @@ end
 
 ### getItemWeapon
 
-Description: Returns **true** only when the player's active weapon matches an item in their inventory and that item is equipped. The argument defaults to `true` and the method currently only checks for equipped items.
-Parameters:
+**Purpose**
+Returns **true** only when the player's active weapon matches an item in their inventory and that item is equipped. The argument defaults to `true` and the method currently only checks for equipped items.
+
+**Parameters**
+
 - `requireEquip` (`boolean`): Only match equipped items if true.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the active weapon corresponds to an item.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Check if we're using an inventory weapon
 if char:getItemWeapon(true) then
@@ -170,13 +251,22 @@ end
 
 ### getMaxStamina
 
-Description: Returns the maximum stamina value for this character.
-Parameters:
+**Purpose**
+Returns the maximum stamina value for this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Maximum stamina points.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Calculate the proportion of stamina remaining
 local pct = char:getStamina() / char:getMaxStamina()
@@ -186,13 +276,22 @@ local pct = char:getStamina() / char:getMaxStamina()
 
 ### getStamina
 
-Description: Retrieves the character's current stamina value.
-Parameters:
+**Purpose**
+Retrieves the character's current stamina value.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Current stamina.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Display current stamina in the HUD
 local stamina = char:getStamina()
@@ -203,13 +302,22 @@ drawStaminaBar(stamina)
 
 ### hasClassWhitelist
 
-Description: Checks if the character has whitelisted the given class.
-Parameters:
+**Purpose**
+Checks if the character has whitelisted the given class.
+
+**Parameters**
+
 - `class` (`number`): Class index.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the class is whitelisted.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Decide if the player may choose the medic class
 if char:hasClassWhitelist(CLASS_MEDIC) then
@@ -221,13 +329,22 @@ end
 
 ### isFaction
 
-Description: Returns true if the character's faction matches.
-Parameters:
+**Purpose**
+Returns true if the character's faction matches.
+
+**Parameters**
+
 - `faction` (`number`): Faction index.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: Whether the faction matches.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Restrict access to citizens only
 if char:isFaction(FACTION_CITIZEN) then
@@ -239,13 +356,22 @@ end
 
 ### isClass
 
-Description: Returns true if the character's class equals the specified class.
-Parameters:
+**Purpose**
+Returns true if the character's class equals the specified class.
+
+**Parameters**
+
 - `class` (`number`): Class index.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: Whether the classes match.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Provide a bonus if the character is currently an engineer
 if char:isClass(CLASS_ENGINEER) then
@@ -257,16 +383,23 @@ end
 
 ### getAttrib
 
-Description: Retrieves the value of an attribute including boosts.
-Parameters:
+**Purpose**
+Retrieves the value of an attribute including boosts.
+
+**Parameters**
+
 - `key` (`string`): Attribute identifier.
 - `default` (`number`) – Default value when attribute is missing.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-Returns:
+**Returns**
+
 - number: Final attribute value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Calculate damage using the strength attribute
 local strength = char:getAttrib("str", 0)
@@ -277,13 +410,22 @@ dmg = baseDamage + strength * 0.5
 
 ### getBoost
 
-Description: Returns the boost table for the given attribute.
-Parameters:
+**Purpose**
+Returns the boost table for the given attribute.
+
+**Parameters**
+
 - `attribID` (`string`): Attribute identifier.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table|None: Table of boosts or None.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Inspect active boosts on agility
 PrintTable(char:getBoost("agi"))
@@ -293,13 +435,22 @@ PrintTable(char:getBoost("agi"))
 
 ### getBoosts
 
-Description: Retrieves all attribute boosts for this character.
-Parameters:
+**Purpose**
+Retrieves all attribute boosts for this character.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table: Mapping of attribute IDs to boost tables.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Print all attribute boosts for debugging
 for id, data in pairs(char:getBoosts()) do
@@ -311,13 +462,22 @@ end
 
 ### doesRecognize
 
-Description: Determines if this character recognizes another character.
-Parameters:
+**Purpose**
+Determines if this character recognizes another character.
+
+**Parameters**
+
 - `id` (`number|Character`): Character ID or object to check.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if recognized.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Reveal names in chat only if recognized
 if char:doesRecognize(targetChar) then
@@ -329,13 +489,22 @@ end
 
 ### doesFakeRecognize
 
-Description: Checks if the character has a fake recognition entry for another.
-Parameters:
+**Purpose**
+Checks if the character has a fake recognition entry for another.
+
+**Parameters**
+
 - `id` (`number|Character`): Character identifier.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if fake recognized.
-Example Usage:
+
+**Example**
+
 ```lua
 -- See if recognition was forced by a disguise item
 if char:doesFakeRecognize(targetChar) then
@@ -347,16 +516,23 @@ end
 
 ### recognize
 
-Description: Adds another character to this one's recognition list. When a custom `name` is provided that alias will be shown whenever the character is recognized.
-Parameters:
+**Purpose**
+Adds another character to this one's recognition list. When a custom `name` is provided that alias will be shown whenever the character is recognized.
+
+**Parameters**
+
 - `character` (`number|Character`): Character to recognize or its ID.
 - `name` (`string|nil`) – Optional fake name to store.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - boolean: Always true once processed.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Remember the rival using a codename and by ID
 char:recognize(rivalChar:getID(), "Mysterious Stranger")
@@ -366,13 +542,22 @@ char:recognize(rivalChar:getID(), "Mysterious Stranger")
 
 ### WhitelistAllClasses
 
-Description: Grants class whitelist access for every class defined by the schema.
-Parameters:
+**Purpose**
+Grants class whitelist access for every class defined by the schema.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Allow this character to choose any class
 char:WhitelistAllClasses()
@@ -382,13 +567,22 @@ char:WhitelistAllClasses()
 
 ### WhitelistAllFactions
 
-Description: Marks the character as whitelisted for every faction.
-Parameters:
+**Purpose**
+Marks the character as whitelisted for every faction.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Grant access to all factions for testing
 char:WhitelistAllFactions()
@@ -398,13 +592,22 @@ char:WhitelistAllFactions()
 
 ### WhitelistEverything
 
-Description: Convenience wrapper that whitelists the character for all factions and classes.
-Parameters:
+**Purpose**
+Convenience wrapper that whitelists the character for all factions and classes.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Unlock every faction and class
 char:WhitelistEverything()
@@ -414,13 +617,22 @@ char:WhitelistEverything()
 
 ### classWhitelist
 
-Description: Adds the specified class to this character's whitelist.
-Parameters:
+**Purpose**
+Adds the specified class to this character's whitelist.
+
+**Parameters**
+
 - `class` (`number`): Class index to whitelist.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Permit switching to the engineer class
 char:classWhitelist(CLASS_ENGINEER)
@@ -430,13 +642,22 @@ char:classWhitelist(CLASS_ENGINEER)
 
 ### classUnWhitelist
 
-Description: Removes the specified class from the character's whitelist.
-Parameters:
+**Purpose**
+Removes the specified class from the character's whitelist.
+
+**Parameters**
+
 - `class` (`number`): Class index to remove.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Revoke access to the medic class
 char:classUnWhitelist(CLASS_MEDIC)
@@ -446,16 +667,23 @@ char:classUnWhitelist(CLASS_MEDIC)
 
 ### joinClass
 
-Description: Attempts to set the character's current class. When `isForced` is true the normal eligibility checks are skipped.
-Parameters:
+**Purpose**
+Attempts to set the character's current class. When `isForced` is true the normal eligibility checks are skipped.
+
+**Parameters**
+
 - `class` (`number`): Class index to join.
 - `isForced` (`boolean`) – Bypass restrictions when true.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - boolean: True on success, false otherwise.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Force the character into the soldier class
 char:joinClass(CLASS_SOLDIER, true)
@@ -465,13 +693,22 @@ char:joinClass(CLASS_SOLDIER, true)
 
 ### kickClass
 
-Description: Removes the character from their current class, reverting to the default for their faction.
-Parameters:
+**Purpose**
+Removes the character from their current class, reverting to the default for their faction.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Reset the character's class after leaving the group
 char:kickClass()
@@ -481,16 +718,23 @@ char:kickClass()
 
 ### updateAttrib
 
-Description: Increases an attribute by the specified value, clamped to the maximum allowed.
-Parameters:
+**Purpose**
+Increases an attribute by the specified value, clamped to the maximum allowed.
+
+**Parameters**
+
 - `key` (`string`): Attribute identifier.
 - `value` (`number`) – Amount to add.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Award experience toward agility
 char:updateAttrib("agi", 5)
@@ -500,16 +744,23 @@ char:updateAttrib("agi", 5)
 
 ### setAttrib
 
-Description: Directly sets an attribute to the given value.
-Parameters:
+**Purpose**
+Directly sets an attribute to the given value.
+
+**Parameters**
+
 - `key` (`string`): Attribute identifier.
 - `value` (`number`) – New level for the attribute.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Reset strength after an event
 char:setAttrib("str", 10)
@@ -519,19 +770,24 @@ char:setAttrib("str", 10)
 
 ### addBoost
 
-Description: Applies a temporary boost to one of the character's attributes.
-Parameters:
+**Purpose**
+Applies a temporary boost to one of the character's attributes.
+
+**Parameters**
+
 - `boostID` (`string`): Unique identifier for the boost.
 - `attribID` (`string`) – Attribute to modify.
-
-
 - `boostAmount` (`number`) – Amount of the boost.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Grant a strength bonus while an item is equipped
 char:addBoost("powerGloves", "str", 2)
@@ -541,16 +797,23 @@ char:addBoost("powerGloves", "str", 2)
 
 ### removeBoost
 
-Description: Removes a previously applied attribute boost.
-Parameters:
+**Purpose**
+Removes a previously applied attribute boost.
+
+**Parameters**
+
 - `boostID` (`string`): Identifier used when the boost was added.
 - `attribID` (`string`) – Attribute affected by the boost.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Clear the item bonus when unequipped
 char:removeBoost("powerGloves", "str")
@@ -560,13 +823,22 @@ char:removeBoost("powerGloves", "str")
 
 ### setFlags
 
-Description: Replaces the character's flag string with the provided value.
-Parameters:
+**Purpose**
+Replaces the character's flag string with the provided value.
+
+**Parameters**
+
 - `flags` (`string`): New flag characters to assign.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Reset all flags before assigning new ones
 char:setFlags("")
@@ -576,13 +848,22 @@ char:setFlags("")
 
 ### giveFlags
 
-Description: Adds the specified flag characters to the character.
-Parameters:
+**Purpose**
+Adds the specified flag characters to the character.
+
+**Parameters**
+
 - `flags` (`string`): Flags to grant.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Grant temporary admin powers
 char:giveFlags("A")
@@ -592,13 +873,22 @@ char:giveFlags("A")
 
 ### takeFlags
 
-Description: Removes the given flag characters from the character.
-Parameters:
+**Purpose**
+Removes the given flag characters from the character.
+
+**Parameters**
+
 - `flags` (`string`): Flags to revoke.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Strip special permissions when demoted
 char:takeFlags("A")
@@ -608,13 +898,22 @@ char:takeFlags("A")
 
 ### save
 
-Description: Persists the character's current data to the database.
-Parameters:
+**Purpose**
+Persists the character's current data to the database.
+
+**Parameters**
+
 - `callback` (`function|nil`): Optional function run after saving completes.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Save and then notify when finished
 char:save(function() print("character saved") end)
@@ -624,13 +923,22 @@ char:save(function() print("character saved") end)
 
 ### sync
 
-Description: Sends the character's networkable variables to a specific player. Passing `nil` broadcasts the data to everyone. When the receiver is the character's own player, only local variables intended for them are included.
-Parameters:
+**Purpose**
+Sends the character's networkable variables to a specific player. Passing `nil` broadcasts the data to everyone. When the receiver is the character's own player, only local variables intended for them are included.
+
+**Parameters**
+
 - `receiver` (`Player|nil`): Player to receive the data or nil for broadcast.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Send updates only to one player
 char:sync(targetPlayer)
@@ -640,13 +948,22 @@ char:sync(targetPlayer)
 
 ### setup
 
-Description: Sets up the player entity to use this character's model, faction, and inventory data. Use `noNetworking` to skip network updates during initialization.
-Parameters:
+**Purpose**
+Sets up the player entity to use this character's model, faction, and inventory data. Use `noNetworking` to skip network updates during initialization.
+
+**Parameters**
+
 - `noNetworking` (`boolean`): Skip networking inventories and vars when true.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Fully prepare the character after selection
 char:setup()
@@ -656,13 +973,22 @@ char:setup()
 
 ### kick
 
-Description: Forcibly disconnects the player from their character. The player is killed silently and immediately respawns with no character loaded.
-Parameters:
+**Purpose**
+Forcibly disconnects the player from their character. The player is killed silently and immediately respawns with no character loaded.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Eject the player from their character
 char:kick() -- they will respawn without a character
@@ -672,13 +998,22 @@ char:kick() -- they will respawn without a character
 
 ### ban
 
-Description: Marks the character as banned for the given duration, saves the state, and immediately kicks the controlling player. This also triggers the `OnCharPermakilled` hook.
-Parameters:
+**Purpose**
+Marks the character as banned for the given duration, saves the state, and immediately kicks the controlling player. This also triggers the `OnCharPermakilled` hook.
+
+**Parameters**
+
 - `time` (`number|nil`): Ban length in seconds or nil for permanent.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Ban the character for one hour
 char:ban(3600)
@@ -689,13 +1024,22 @@ char:ban(3600)
 
 ### delete
 
-Description: Completely removes the character from the database along with any inventories it owns.
-Parameters:
+**Purpose**
+Completely removes the character from the database along with any inventories it owns.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Permanently remove this character
 char:delete()
@@ -705,13 +1049,22 @@ char:delete()
 
 ### destroy
 
-Description: Removes the character from the server's loaded cache without touching any saved data. Useful after deleting a character or when cleaning up disconnected players.
-Parameters:
+**Purpose**
+Removes the character from the server's loaded cache without touching any saved data. Useful after deleting a character or when cleaning up disconnected players.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Clean up a removed character instance
 char:destroy()
@@ -721,13 +1074,22 @@ char:destroy()
 
 ### giveMoney
 
-Description: Adds the specified amount to the character's wallet by calling the owning player's `addMoney` method.
-Parameters:
+**Purpose**
+Adds the specified amount to the character's wallet by calling the owning player's `addMoney` method.
+
+**Parameters**
+
 - `amount` (`number`): Amount to add to the wallet.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - boolean: False if the owner is missing, otherwise true.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Pay the character for completing a mission
 local reward = 250
@@ -738,13 +1100,22 @@ char:giveMoney(reward)
 
 ### takeMoney
 
-Description: Subtracts the specified amount of money from the character. Internally this calls `giveMoney` with a negative value and logs the deduction.
-Parameters:
+**Purpose**
+Subtracts the specified amount of money from the character. Internally this calls `giveMoney` with a negative value and logs the deduction.
+
+**Parameters**
+
 - `amount` (`number`): Amount to remove.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - boolean: Always true when the deduction occurs.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Deduct a fine from the character
 local fine = 50
@@ -755,13 +1126,22 @@ char:takeMoney(fine)
 
 ### getName
 
-Description: Returns the character's stored name or a default value.
-Parameters:
+**Purpose**
+Returns the character's stored name or a default value.
+
+**Parameters**
+
 - `default` (`any`): Value to return if the name is unset.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Character name or the provided default.
-Example Usage:
+
+**Example**
+
 ```lua
 print("Character name:", char:getName("Unknown"))
 ```
@@ -770,13 +1150,22 @@ print("Character name:", char:getName("Unknown"))
 
 ### setName
 
-Description: Updates the character's name and replicates the change to players.
-Parameters:
+**Purpose**
+Updates the character's name and replicates the change to players.
+
+**Parameters**
+
 - `value` (`string`): New name for the character.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setName("Alyx Vance")
 ```
@@ -785,13 +1174,22 @@ char:setName("Alyx Vance")
 
 ### getDesc
 
-Description: Fetches the character's description text or returns the given default.
-Parameters:
+**Purpose**
+Fetches the character's description text or returns the given default.
+
+**Parameters**
+
 - `default` (`any`): Value to return if no description exists.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Description or fallback value.
-Example Usage:
+
+**Example**
+
 ```lua
 local about = char:getDesc("No bio")
 ```
@@ -800,13 +1198,22 @@ local about = char:getDesc("No bio")
 
 ### setDesc
 
-Description: Assigns a new description for the character.
-Parameters:
+**Purpose**
+Assigns a new description for the character.
+
+**Parameters**
+
 - `value` (`string`): Description text.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setDesc("Hardened wasteland survivor")
 ```
@@ -815,13 +1222,22 @@ char:setDesc("Hardened wasteland survivor")
 
 ### getModel
 
-Description: Retrieves the model path assigned to the character.
-Parameters:
+**Purpose**
+Retrieves the model path assigned to the character.
+
+**Parameters**
+
 - `default` (`any`): Value returned when no model is stored.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - string: Model path or the fallback value.
-Example Usage:
+
+**Example**
+
 ```lua
 local mdl = char:getModel("models/error.mdl")
 ```
@@ -830,13 +1246,22 @@ local mdl = char:getModel("models/error.mdl")
 
 ### setModel
 
-Description: Sets the character's player model and broadcasts the update.
-Parameters:
+**Purpose**
+Sets the character's player model and broadcasts the update.
+
+**Parameters**
+
 - `value` (`string`): Model file path.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setModel("models/alyx.mdl")
 ```
@@ -845,13 +1270,22 @@ char:setModel("models/alyx.mdl")
 
 ### getClass
 
-Description: Returns the class index currently assigned or the supplied default.
-Parameters:
+**Purpose**
+Returns the class index currently assigned or the supplied default.
+
+**Parameters**
+
 - `default` (`any`): Value used when the class is unset.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Class index.
-Example Usage:
+
+**Example**
+
 ```lua
 if char:getClass() == CLASS_ENGINEER then
     print("Engineer present")
@@ -862,13 +1296,22 @@ end
 
 ### setClass
 
-Description: Stores a new class index for the character.
-Parameters:
+**Purpose**
+Stores a new class index for the character.
+
+**Parameters**
+
 - `value` (`number`): Class identifier.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setClass(CLASS_ENGINEER)
 ```
@@ -877,13 +1320,22 @@ char:setClass(CLASS_ENGINEER)
 
 ### getFaction
 
-Description: Gets the faction index of the character or a fallback value.
-Parameters:
+**Purpose**
+Gets the faction index of the character or a fallback value.
+
+**Parameters**
+
 - `default` (`any`): Value to return when unset.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Faction index.
-Example Usage:
+
+**Example**
+
 ```lua
 print("Faction:", char:getFaction())
 ```
@@ -892,13 +1344,22 @@ print("Faction:", char:getFaction())
 
 ### setFaction
 
-Description: Sets the character's faction team.
-Parameters:
+**Purpose**
+Sets the character's faction team.
+
+**Parameters**
+
 - `value` (`number`): Faction identifier.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setFaction(FACTION_CITIZEN)
 ```
@@ -907,13 +1368,22 @@ char:setFaction(FACTION_CITIZEN)
 
 ### getMoney
 
-Description: Retrieves the amount of currency this character holds.
-Parameters:
+**Purpose**
+Retrieves the amount of currency this character holds.
+
+**Parameters**
+
 - `default` (`any`): Value to return when no money value is stored.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Amount of money or default value.
-Example Usage:
+
+**Example**
+
 ```lua
 local cash = char:getMoney(0)
 ```
@@ -922,13 +1392,22 @@ local cash = char:getMoney(0)
 
 ### setMoney
 
-Description: Overwrites the character's stored money total.
-Parameters:
+**Purpose**
+Overwrites the character's stored money total.
+
+**Parameters**
+
 - `value` (`number`): Amount of currency.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setMoney(1000)
 ```
@@ -937,16 +1416,23 @@ char:setMoney(1000)
 
 ### getData
 
-Description: Returns arbitrary data previously stored on the character.
-Parameters:
+**Purpose**
+Returns arbitrary data previously stored on the character.
+
+**Parameters**
+
 - `key` (`string`): Data key.
 - `default` (`any`) – Value to return if the entry is missing.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-Returns:
+**Returns**
+
 - any: Stored value or default.
-Example Usage:
+
+**Example**
+
 ```lua
 local rank = char:getData("rank", "rookie")
 ```
@@ -955,22 +1441,25 @@ local rank = char:getData("rank", "rookie")
 
 ### setData
 
-Description: Writes a data entry on the character and optionally syncs it.
-Parameters:
+**Purpose**
+Writes a data entry on the character and optionally syncs it.
+
+**Parameters**
+
 - `key` (`string`): Data key to modify.
 - `value` (`any`) – New value to store.
-
-
 - `noReplication` (`boolean`) – Suppress network updates.
-
-
 - `receiver` (`Player`) – Optional specific client to send the update to.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setData("rank", "veteran")
 ```
@@ -979,16 +1468,23 @@ char:setData("rank", "veteran")
 
 ### getVar
 
-Description: Fetches a temporary variable from the character.
-Parameters:
+**Purpose**
+Fetches a temporary variable from the character.
+
+**Parameters**
+
 - `key` (`string`): Variable key.
 - `default` (`any`) – Value returned if the variable is absent.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-Returns:
+**Returns**
+
 - any: Variable value or default.
-Example Usage:
+
+**Example**
+
 ```lua
 local mood = char:getVar("mood", "neutral")
 ```
@@ -997,22 +1493,25 @@ local mood = char:getVar("mood", "neutral")
 
 ### setVar
 
-Description: Stores a temporary variable on the character.
-Parameters:
+**Purpose**
+Stores a temporary variable on the character.
+
+**Parameters**
+
 - `key` (`string`): Variable name.
 - `value` (`any`) – Data to store.
-
-
 - `noReplication` (`boolean`) – If true, skip networking the change.
-
-
 - `receiver` (`Player`) – Specific target for the update.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 -- Store a temporary value and send it only to the owner
 char:setVar("mood", "happy", nil, char:getPlayer())
@@ -1022,13 +1521,22 @@ char:setVar("mood", "happy", nil, char:getPlayer())
 
 ### getInv
 
-Description: Retrieves the character's inventory instance.
-Parameters:
+**Purpose**
+Retrieves the character's inventory instance.
+
+**Parameters**
+
 - `index` (`number`): Optional inventory slot index.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table: Inventory object or list of inventories.
-Example Usage:
+
+**Example**
+
 ```lua
 local inv = char:getInv()
 ```
@@ -1037,13 +1545,22 @@ local inv = char:getInv()
 
 ### setInv
 
-Description: Directly sets the character's inventory table.
-Parameters:
+**Purpose**
+Directly sets the character's inventory table.
+
+**Parameters**
+
 - `value` (`table`): Inventory data.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setInv({})
 ```
@@ -1052,13 +1569,22 @@ char:setInv({})
 
 ### getAttribs
 
-Description: Returns the table of raw attribute values for the character.
-Parameters:
+**Purpose**
+Returns the table of raw attribute values for the character.
+
+**Parameters**
+
 - `default` (`any`): Fallback value when no attributes are stored.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table: Attribute values table.
-Example Usage:
+
+**Example**
+
 ```lua
 local stats = char:getAttribs()
 ```
@@ -1067,13 +1593,22 @@ local stats = char:getAttribs()
 
 ### setAttribs
 
-Description: Overwrites the character's attribute table.
-Parameters:
+**Purpose**
+Overwrites the character's attribute table.
+
+**Parameters**
+
 - `value` (`table`): Table of attribute levels.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setAttribs({ strength = 10 })
 ```
@@ -1082,13 +1617,22 @@ char:setAttribs({ strength = 10 })
 
 ### getRecognizedAs
 
-Description: Gets the mapping of disguised names this character uses to recognize others.
-Parameters:
+**Purpose**
+Gets the mapping of disguised names this character uses to recognize others.
+
+**Parameters**
+
 - `default` (`any`): Value to return when no data is stored.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table: Table of ID to alias mappings.
-Example Usage:
+
+**Example**
+
 ```lua
 local aliases = char:getRecognizedAs()
 ```
@@ -1097,13 +1641,24 @@ local aliases = char:getRecognizedAs()
 
 ### setRecognizedAs
 
-Description: Updates the table of fake recognition names for this character.
-Parameters:
+**Purpose**
+Updates the table of fake recognition names for this character.
+
+**Parameters**
+
 - `value` (`table`): Table of ID to alias mappings.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None
-Example Usage:
+
+**Example**
+
 ```lua
 char:setRecognizedAs({ [123] = "Masked Stranger" })
 ```
+
+---

--- a/docs/docs/meta/entity.md
+++ b/docs/docs/meta/entity.md
@@ -12,13 +12,22 @@ The entity meta library extends Garry's Mod entities with helpers for detection,
 
 ### isProp
 
-Description: Returns true if the entity is a physics prop.
-Parameters:
+**Purpose**
+Returns true if the entity is a physics prop.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: Whether the entity is a physics prop.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Apply physics damage only if this is a prop
 if ent:isProp() then
@@ -30,13 +39,22 @@ end
 
 ### isItem
 
-Description: Checks if the entity is an item entity.
-Parameters:
+**Purpose**
+Checks if the entity is an item entity.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the entity represents an item.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Attempt to pick up the entity as an item
 if ent:isItem() then
@@ -48,13 +66,22 @@ end
 
 ### isMoney
 
-Description: Checks if the entity is a money entity.
-Parameters:
+**Purpose**
+Checks if the entity is a money entity.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the entity represents money.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Collect money dropped on the ground
 if ent:isMoney() then
@@ -66,13 +93,22 @@ end
 
 ### isSimfphysCar
 
-Description: Returns true if this entity is recognized as a simfphys or LVS vehicle.
-Parameters:
+**Purpose**
+Returns true if this entity is recognized as a simfphys or LVS vehicle.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if this is a simfphys vehicle.
-Example Usage:
+
+**Example**
+
 ```lua
 if ent:isSimfphysCar() then
     print("Simfphys vehicle detected")
@@ -83,13 +119,22 @@ end
 
 ### isLiliaPersistent
 
-Description: Determines if the entity is persistent in Lilia.
-Parameters:
+**Purpose**
+Determines if the entity is persistent in Lilia.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: Whether the entity should persist.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Save this entity across map resets if persistent
 if ent:isLiliaPersistent() then
@@ -101,16 +146,23 @@ end
 
 ### checkDoorAccess
 
-Description: Checks if a player has the given door access level. Defaults to `DOOR_GUEST` when no access level is provided.
-Parameters:
+**Purpose**
+Checks if a player has the given door access level. Defaults to `DOOR_GUEST` when no access level is provided.
+
+**Parameters**
+
 - `client` (`Player`): The player to check.
 - `access` (`number, optional`) – Door permission level. Defaults to DOOR_GUEST.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-Returns:
+**Returns**
+
 - boolean: True if the player has access.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Block a player from opening the door without access
 if not door:checkDoorAccess(client, DOOR_ACCESS_OPEN) then
@@ -122,13 +174,22 @@ end
 
 ### keysOwn
 
-Description: Assigns vehicle ownership to the given player using CPPI and network variables.
-Parameters:
+**Purpose**
+Assigns vehicle ownership to the given player using CPPI and network variables.
+
+**Parameters**
+
 - `client` (`Player`): Player to set as owner.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Assign ownership when a player buys the vehicle
 car:keysOwn(client)
@@ -138,13 +199,22 @@ car:keysOwn(client)
 
 ### keysLock
 
-Description: Triggers the `lock` input on the entity if it is a vehicle.
-Parameters:
+**Purpose**
+Triggers the `lock` input on the entity if it is a vehicle.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Lock the vehicle after the driver exits
 car:keysLock()
@@ -154,13 +224,22 @@ car:keysLock()
 
 ### keysUnLock
 
-Description: Triggers the `unlock` input on the entity if it is a vehicle.
-Parameters:
+**Purpose**
+Triggers the `unlock` input on the entity if it is a vehicle.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Unlock the vehicle when the owner presses a key
 car:keysUnLock()
@@ -170,13 +249,22 @@ car:keysUnLock()
 
 ### getDoorOwner
 
-Description: Returns the CPPI owner of this vehicle if one is assigned.
-Parameters:
+**Purpose**
+Returns the CPPI owner of this vehicle if one is assigned.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - Player|None: Door owner or None.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Print the name of the door owner when inspecting
 local owner = car:getDoorOwner()
@@ -189,13 +277,22 @@ end
 
 ### isLocked
 
-Description: Reads the locked state previously set with `setLocked`.
-Parameters:
+**Purpose**
+Reads the locked state previously set with `setLocked`.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: Whether the door is locked.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Display a lock icon if the door is networked as locked
 if door:isLocked() then
@@ -207,13 +304,22 @@ end
 
 ### isDoorLocked
 
-Description: Checks the door's internal lock flag (m_bLocked).
-Parameters:
+**Purpose**
+Checks the door's internal lock flag (m_bLocked).
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the door is locked.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Play a sound when trying to open a locked door server-side
 if door:isDoorLocked() then
@@ -225,13 +331,22 @@ end
 
 ### getEntItemDropPos
 
-Description: Calculates a drop position in front of the entity's eyes, using a trace to ensure the point is unobstructed.
-Parameters:
+**Purpose**
+Calculates a drop position in front of the entity's eyes, using a trace to ensure the point is unobstructed.
+
+**Parameters**
+
 - `offset` (`number`): How far forward to trace from the eye position. Defaults to 64.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - Vector, Angle: Drop position and eye angle.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Spawn an item drop in front of the entity's eyes
 local pos, ang = ent:getEntItemDropPos(16)
@@ -242,16 +357,23 @@ lia.item.spawn("item_water", pos, ang)
 
 ### isNearEntity
 
-Description: Checks if another entity of the same class is within the given radius. Optionally matches against a specific entity.
-Parameters:
+**Purpose**
+Checks if another entity of the same class is within the given radius. Optionally matches against a specific entity.
+
+**Parameters**
+
 - `radius` (`number`): Sphere radius in units. Defaults to 96.
 - `otherEntity` (`Entity, optional`) – Specific entity to look for.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-Returns:
+**Returns**
+
 - boolean: True if another entity is within radius.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Prevent building too close to another chest
 if ent:isNearEntity(128, otherChest) then
@@ -263,13 +385,22 @@ end
 
 ### GetCreator
 
-Description: Returns the entity creator player.
-Parameters:
+**Purpose**
+Returns the entity creator player.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - Player|None: Creator player if stored.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Credit the creator when the entity is removed
 local creator = ent:GetCreator()
@@ -282,13 +413,22 @@ end
 
 ### SetCreator
 
-Description: Stores the creator player on the entity.
-Parameters:
+**Purpose**
+Stores the creator player on the entity.
+
+**Parameters**
+
 - `client` (`Player`): Creator of the entity.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Record the spawner for cleanup tracking
 ent:SetCreator(client)
@@ -298,16 +438,23 @@ ent:SetCreator(client)
 
 ### sendNetVar
 
-Description: Sends the specified network variable to clients. This is usually called from `setNetVar`.
-Parameters:
+**Purpose**
+Sends the specified network variable to clients. This is usually called from `setNetVar`.
+
+**Parameters**
+
 - `key` (`string`): Identifier of the variable.
 - `receiver` (`Player|None, optional`) – Player to send to. Broadcasts if omitted.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 ent:sendNetVar("doorState")
 ```
@@ -316,13 +463,22 @@ ent:sendNetVar("doorState")
 
 ### clearNetVars
 
-Description: Clears all network variables on this entity and tells clients to remove them.
-Parameters:
+**Purpose**
+Clears all network variables on this entity and tells clients to remove them.
+
+**Parameters**
+
 - `receiver` (`Player|None, optional`): Receiver to notify. Broadcasts if omitted.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 ent:clearNetVars(client)
 ```
@@ -331,13 +487,22 @@ ent:clearNetVars(client)
 
 ### removeDoorAccessData
 
-Description: Clears the door's saved access table and informs all clients.
-Parameters:
+**Purpose**
+Clears the door's saved access table and informs all clients.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Wipe door permissions during cleanup
 ent:removeDoorAccessData()
@@ -347,13 +512,22 @@ ent:removeDoorAccessData()
 
 ### setLocked
 
-Description: Stores the locked state in a network variable so clients know if the door is secured.
-Parameters:
+**Purpose**
+Stores the locked state in a network variable so clients know if the door is secured.
+
+**Parameters**
+
 - `state` (`boolean`): New locked state.
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Toggle the door lock and play a latch sound for everyone
 door:setLocked(true)
@@ -364,13 +538,22 @@ door:EmitSound("doors/door_latch3.wav")
 
 ### isDoor
 
-Description: Checks the entity's class for common door prefixes to determine if it is a door.
-Parameters:
+**Purpose**
+Checks the entity's class for common door prefixes to determine if it is a door.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - boolean: Whether the entity is a door.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Check if the entity behaves like a door
 local result = ent:isDoor()
@@ -380,13 +563,22 @@ local result = ent:isDoor()
 
 ### getDoorPartner
 
-Description: Returns the door entity linked as this one's partner via `liaPartner`.
-Parameters:
+**Purpose**
+Returns the door entity linked as this one's partner via `liaPartner`.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - Entity|None: The partnered door.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Unlock both doors when opening a double-door setup
 local partner = ent:getDoorPartner()
@@ -399,19 +591,24 @@ end
 
 ### setNetVar
 
-Description: Updates a network variable and sends it to recipients. This will trigger the **NetVarChanged** hook on both server and client.
-Parameters:
+**Purpose**
+Updates a network variable and sends it to recipients. This will trigger the **NetVarChanged** hook on both server and client.
+
+**Parameters**
+
 - `key` (`string`): Variable name.
 - `value` (`any`) – Value to store.
-
-
 - `receiver` (`Player|None, optional`) – Who to send update to. Broadcasts if omitted.
 
+**Realm**
+`Server`
 
-Realm: Server
-Returns:
+**Returns**
+
 - None: This function does not return a value.
-Example Usage:
+
+**Example**
+
 ```lua
 ent:setNetVar("locked", true)
 ```
@@ -420,13 +617,25 @@ ent:setNetVar("locked", true)
 
 ### getNetVar
 
-Description: Retrieves a stored network variable or a default value.
-Parameters:
+**Purpose**
+Retrieves a stored network variable or a default value.
+
+**Parameters**
+
 - `key` (`string`): Variable name.
 - `default` (`any`) – Value returned if variable is nil.
 
+**Realm**
+`Server`
 
-Realm: Server
+**Returns**
+
+- nil
+
+**Example**
+
+
+---
 - Client
 
 
@@ -442,13 +651,22 @@ local result = ent:getNetVar(key, default)
 
 ### isDoor
 
-Description: Client-side door check using class name.
-Parameters:
+**Purpose**
+Client-side door check using class name.
+
+**Parameters**
+
 - None
-Realm: Client
-Returns:
+
+**Realm**
+`Client`
+
+**Returns**
+
 - boolean: True if entity class contains "door".
-Example Usage:
+
+**Example**
+
 ```lua
 -- Determine if this entity's class name contains "door"
 local result = ent:isDoor()
@@ -458,13 +676,22 @@ local result = ent:isDoor()
 
 ### getDoorPartner
 
-Description: Attempts to locate the door partnered with this one by checking its owner or linked prop.
-Parameters:
+**Purpose**
+Attempts to locate the door partnered with this one by checking its owner or linked prop.
+
+**Parameters**
+
 - None
-Realm: Client
-Returns:
+
+**Realm**
+`Client`
+
+**Returns**
+
 - Entity|None: The partner door entity.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Highlight the partner door of the one being looked at
 local partner = ent:getDoorPartner()
@@ -477,16 +704,23 @@ end
 
 ### getNetVar
 
-Description: Retrieves a network variable for this entity on the client.
-Parameters:
+**Purpose**
+Retrieves a network variable for this entity on the client.
+
+**Parameters**
+
 - `key` (`string`): Variable name.
 - `default` (`any`) – Default if not set.
 
+**Realm**
+`Client`
 
-Realm: Client
-Returns:
+**Returns**
+
 - any: Stored value or default.
-Example Usage:
+
+**Example**
+
 ```lua
 -- Access a synced variable on the client side
 local result = ent:getNetVar(key, default)
@@ -496,19 +730,27 @@ local result = ent:getNetVar(key, default)
 
 ### getParts
 
+**Purpose**
+Retrieves the table of PAC3 part identifiers applied to this entity.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: The currently applied part IDs.
+
+**Example**
+
 ```lua
 function ENTITY:getParts()
     -- returns table
 end
 ```
-
-Description: Retrieves the table of PAC3 part identifiers applied to this entity.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- table: The currently applied part IDs.
-Example Usage:
 ```lua
 -- Print all equipped PAC3 parts for a player
 for id in pairs(client:getParts()) do
@@ -520,18 +762,26 @@ end
 
 ### syncParts
 
+**Purpose**
+Broadcasts the entity's PAC3 part list to synchronize with clients.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function ENTITY:syncParts()
 end
 ```
-
-Description: Broadcasts the entity's PAC3 part list to synchronize with clients.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Resend parts when a player respawns
 client:syncParts()
@@ -541,18 +791,26 @@ client:syncParts()
 
 ### addPart
 
+**Purpose**
+Attaches a PAC3 part to this entity and networks the change.
+
+**Parameters**
+
+- `partID` (`string`): Identifier for the PAC3 outfit to add.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function ENTITY:addPart(partID)
 end
 ```
-
-Description: Attaches a PAC3 part to this entity and networks the change.
-Parameters:
-- `partID` (`string`): Identifier for the PAC3 outfit to add.
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Give the player a custom hat part
 client:addPart("hat01")
@@ -562,18 +820,26 @@ client:addPart("hat01")
 
 ### removePart
 
+**Purpose**
+Detaches a PAC3 part from this entity and updates clients.
+
+**Parameters**
+
+- `partID` (`string`): Identifier of the PAC3 outfit to remove.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function ENTITY:removePart(partID)
 end
 ```
-
-Description: Detaches a PAC3 part from this entity and updates clients.
-Parameters:
-- `partID` (`string`): Identifier of the PAC3 outfit to remove.
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Remove the previously equipped hat part
 client:removePart("hat01")
@@ -583,19 +849,29 @@ client:removePart("hat01")
 
 ### resetParts
 
+**Purpose**
+Clears all PAC3 parts from this entity and notifies clients.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function ENTITY:resetParts()
 end
 ```
-
-Description: Clears all PAC3 parts from this entity and notifies clients.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Remove all PAC3 outfits from the player
 client:resetParts()
 ```
+
+---

--- a/docs/docs/meta/gridinv.md
+++ b/docs/docs/meta/gridinv.md
@@ -10,13 +10,21 @@ A `GridInv` instance stores items in a 2D grid, requiring items to fit within it
 
 ### getWidth
 
-Description: Returns the current width of the inventory grid. If no width has been set, the value from `lia.config.invW` is used.
-Parameters:
+**Purpose**
+Returns the current width of the inventory grid. If no width has been set, the value from `lia.config.invW` is used.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Grid width in slots.
-- *Example:**
+
+**Example**
 
 ```lua
 local width = inv:getWidth()
@@ -27,13 +35,21 @@ print("Inventory width:", width)
 
 ### getHeight
 
-Description: Returns the current height of the inventory grid. Defaults to `lia.config.invH` when unset.
-Parameters:
+**Purpose**
+Returns the current height of the inventory grid. Defaults to `lia.config.invH` when unset.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number: Grid height in slots.
-- *Example:**
+
+**Example**
 
 ```lua
 local height = inv:getHeight()
@@ -44,13 +60,21 @@ print("Inventory height:", height)
 
 ### getSize
 
-Description: Returns both grid dimensions at once.
-Parameters:
+**Purpose**
+Returns both grid dimensions at once.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number, number: Width and height in slots.
-- *Example:**
+
+**Example**
 
 ```lua
 local w, h = inv:getSize()
@@ -61,17 +85,23 @@ print(string.format("Size: %dx%d", w, h))
 
 ### canItemFitInInventory
 
-Description: Checks if an item would fit inside the grid bounds when placed at the given coordinates. This does not test collisions with other items.
-Parameters:
+**Purpose**
+Checks if an item would fit inside the grid bounds when placed at the given coordinates. This does not test collisions with other items.
+
+**Parameters**
+
 - `item` (`Item`): Item being tested.
 - `x` (`number`) – X slot position.
-
 - `y` (`number`) – Y slot position.
 
-Realm: Shared
-Returns:
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the entire item lies within the grid.
-- *Example:**
+
+**Example**
 
 ```lua
 if inv:canItemFitInInventory(item, 2, 3) then
@@ -83,13 +113,21 @@ end
 
 ### canAdd
 
-Description: Determines if the inventory is large enough to hold the item's dimensions. Accepts either an Item object or a unique ID.
-Parameters:
+**Purpose**
+Determines if the inventory is large enough to hold the item's dimensions. Accepts either an Item object or a unique ID.
+
+**Parameters**
+
 - `item` (`Item|string`): Item table or unique ID to test.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True when the item size fits inside the grid.
-- *Example:**
+
+**Example**
 
 ```lua
 if inv:canAdd("pistol_ammo") then
@@ -101,19 +139,24 @@ end
 
 ### doesItemOverlapWithOther
 
-Description: Returns whether `testItem` placed at `(x, y)` would overlap the given existing item. Used internally when checking placement validity.
-Parameters:
+**Purpose**
+Returns whether `testItem` placed at `(x, y)` would overlap the given existing item. Used internally when checking placement validity.
+
+**Parameters**
+
 - `testItem` (`Item`): Item being placed.
 - `x` (`number`) – Proposed X slot.
-
 - `y` (`number`) – Proposed Y slot.
-
 - `item` (`Item`) – Existing item inside the inventory.
 
-Realm: Shared
-Returns:
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if the two items intersect.
-- *Example:**
+
+**Example**
 
 ```lua
 for _, existing in pairs(inv:getItems(true)) do
@@ -128,13 +171,21 @@ end
 
 ### doesFitInventory
 
-Description: Checks this inventory and all nested bags to see if the item could be placed somewhere.
-Parameters:
+**Purpose**
+Checks this inventory and all nested bags to see if the item could be placed somewhere.
+
+**Parameters**
+
 - `item` (`Item`): Item to test.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True if a free position exists.
-- *Example:**
+
+**Example**
 
 ```lua
 if inv:doesFitInventory(item) then
@@ -146,19 +197,24 @@ end
 
 ### doesItemFitAtPos
 
-Description: Determines if `testItem` can be placed at `(x, y)` without overlapping existing items and while staying inside the grid.
-Parameters:
+**Purpose**
+Determines if `testItem` can be placed at `(x, y)` without overlapping existing items and while staying inside the grid.
+
+**Parameters**
+
 - `testItem` (`Item`): Item to check.
 - `x` (`number`) – X slot position.
-
 - `y` (`number`) – Y slot position.
 
-Realm: Shared
-Returns:
+**Realm**
+`Shared`
+
+**Returns**
+
 - boolean: True when placement is valid.
 - Item|nil – Conflicting item if placement fails.
 
-- *Example:**
+**Example**
 
 ```lua
 local ok, blocking = inv:doesItemFitAtPos(item, 2, 2)
@@ -171,13 +227,21 @@ end
 
 ### findFreePosition
 
-Description: Searches the grid sequentially for the first open space that can fit the given item.
-Parameters:
+**Purpose**
+Searches the grid sequentially for the first open space that can fit the given item.
+
+**Parameters**
+
 - `item` (`Item`): Item to place.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - number|nil, number|nil: X and Y slot coordinates or nil if none found.
-- *Example:**
+
+**Example**
 
 ```lua
 local x, y = inv:findFreePosition(item)
@@ -190,13 +254,21 @@ end
 
 ### configure
 
-Description: Called when the inventory type registers. On the server it adds default access rules preventing players from placing items that do not fit and restricting access to the owner.
-Parameters:
+**Purpose**
+Called when the inventory type registers. On the server it adds default access rules preventing players from placing items that do not fit and restricting access to the owner.
+
+**Parameters**
+
 - None
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - None: This function does not return a value.
-- *Example:**
+
+**Example**
 
 ```lua
 function MyInv:configure()
@@ -208,13 +280,21 @@ end
 
 ### getItems
 
-Description: Returns a table of items contained in this inventory. When `noRecurse` is false, items inside nested bags are also returned.
-Parameters:
+**Purpose**
+Returns a table of items contained in this inventory. When `noRecurse` is false, items inside nested bags are also returned.
+
+**Parameters**
+
 - `noRecurse` (`boolean`): Skip nested bag contents when true.
-Realm: Shared
-Returns:
+
+**Realm**
+`Shared`
+
+**Returns**
+
 - table: Item table indexed by item ID.
-- *Example:**
+
+**Example**
 
 ```lua
 for id, itm in pairs(inv:getItems()) do
@@ -226,15 +306,22 @@ end
 
 ### setSize
 
-Description: Updates the stored grid dimensions on the server.
-Parameters:
+**Purpose**
+Updates the stored grid dimensions on the server.
+
+**Parameters**
+
 - `w` (`number`): New width in slots.
 - `h` (`number`) – New height in slots.
 
-Realm: Server
-Returns:
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-- *Example:**
+
+**Example**
 
 ```lua
 -- Expand the inventory to 6x4 slots
@@ -245,13 +332,21 @@ inv:setSize(6, 4)
 
 ### wipeItems
 
-Description: Removes all items from the inventory.
-Parameters:
+**Purpose**
+Removes all items from the inventory.
+
+**Parameters**
+
 - None
-Realm: Server
-Returns:
+
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-- *Example:**
+
+**Example**
 
 ```lua
 inv:wipeItems()
@@ -261,15 +356,22 @@ inv:wipeItems()
 
 ### setOwner
 
-Description: Sets the owning character of this inventory. A player value is automatically converted to their character ID. When `fullUpdate` is true the inventory is synced to that owner immediately.
-Parameters:
+**Purpose**
+Sets the owning character of this inventory. A player value is automatically converted to their character ID. When `fullUpdate` is true the inventory is synced to that owner immediately.
+
+**Parameters**
+
 - `owner` (`number|Player`): Character ID or Player to own the inventory.
 - `fullUpdate` (`boolean`) – Send a full sync to the owner.
 
-Realm: Server
-Returns:
+**Realm**
+`Server`
+
+**Returns**
+
 - None: This function does not return a value.
-- *Example:**
+
+**Example**
 
 ```lua
 inv:setOwner(client, true)
@@ -279,17 +381,23 @@ inv:setOwner(client, true)
 
 ### add
 
-Description: Inserts an item into the inventory at the given position. Extra quantity that cannot fit triggers the `OnPlayerLostStackItem` hook.
-Parameters:
+**Purpose**
+Inserts an item into the inventory at the given position. Extra quantity that cannot fit triggers the `OnPlayerLostStackItem` hook.
+
+**Parameters**
+
 - `item` (`Item|string`): Item instance or unique ID to add.
 - `x` (`number`) – X slot, optional.
-
 - `y` (`number`) – Y slot, optional.
 
-Realm: Server
-Returns:
+**Realm**
+`Server`
+
+**Returns**
+
 - Deferred: Resolves with the newly added item(s).
-- *Example:**
+
+**Example**
 
 ```lua
 inv:add("pistol_ammo", 1, 1):next(function(itm)
@@ -301,15 +409,22 @@ end)
 
 ### remove
 
-Description: Removes an item by ID or type. Quantity defaults to `1`.
-Parameters:
+**Purpose**
+Removes an item by ID or type. Quantity defaults to `1`.
+
+**Parameters**
+
 - `itemID` (`number|string`): Item ID or unique ID.
 - `quantity` (`number`) – Amount to remove.
 
-Realm: Server
-Returns:
+**Realm**
+`Server`
+
+**Returns**
+
 - Deferred: Resolves once removal finishes.
-- *Example:**
+
+**Example**
 
 ```lua
 inv:remove("pistol_ammo", 2):next(function()
@@ -321,21 +436,28 @@ end)
 
 ### requestTransfer
 
-Description: Sends a `liaTransferItem` request telling the server to move an item. The server processes this call through the `HandleItemTransferRequest` hook.
-Parameters:
+**Purpose**
+Sends a `liaTransferItem` request telling the server to move an item. The server processes this call through the `HandleItemTransferRequest` hook.
+
+**Parameters**
+
 - `itemID` (`number`): ID of the item to move.
 - `destID` (`number`) – Destination inventory ID.
-
 - `x` (`number`) – Target X slot.
-
 - `y` (`number`) – Target Y slot.
 
-Realm: Client
-Returns:
+**Realm**
+`Client`
+
+**Returns**
+
 - None: This function does not return a value.
-- *Example:**
+
+**Example**
 
 ```lua
 -- Move the item into another inventory
 inv:requestTransfer(id, bag:getID(), 1, 2)
 ```
+
+---

--- a/docs/docs/meta/inventory.md
+++ b/docs/docs/meta/inventory.md
@@ -12,22 +12,28 @@ Inventory meta functions handle transactions, capacity checks, retrieval by slot
 
 ### getData
 
+**Purpose**
+Returns a stored data value for this inventory.
+
+**Parameters**
+
+- `key` (`string`): Data field key.
+- `default` (`any`) – Value if the key does not exist.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- any: Stored value or default.
+
+**Example**
+
 ```lua
 function Inventory:getData(key, default)
     -- return any
 end
 ```
-
-Description: Returns a stored data value for this inventory.
-Parameters:
-- `key` (`string`): Data field key.
-- `default` (`any`) – Value if the key does not exist.
-
-
-Realm: Shared
-Returns:
-- any: Stored value or default.
-Example Usage:
 ```lua
 -- Read how many times the container was opened
 local opens = inv:getData("openCount", 0)
@@ -37,19 +43,27 @@ local opens = inv:getData("openCount", 0)
 
 ### extend
 
+**Purpose**
+Creates a subclass of the inventory meta table with a new class name.
+
+**Parameters**
+
+- `className` (`string`): Name of the subclass meta table.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: The newly derived inventory table.
+
+**Example**
+
 ```lua
 function Inventory:extend(className)
     -- return table
 end
 ```
-
-Description: Creates a subclass of the inventory meta table with a new class name.
-Parameters:
-- `className` (`string`): Name of the subclass meta table.
-Realm: Shared
-Returns:
-- table: The newly derived inventory table.
-Example Usage:
 ```lua
 -- Define a subclass for weapon crates and register it
 local WeaponInv = inv:extend("WeaponInventory")
@@ -68,19 +82,27 @@ WeaponInv:register("weapon_inv")
 
 ### configure
 
+**Purpose**
+Stub for inventory configuration; meant to be overridden.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:configure()
     -- override to customize this inventory type
 end
 ```
-
-Description: Stub for inventory configuration; meant to be overridden.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Called from a subclass to register custom access rules
 function WeaponInv:configure()
@@ -96,22 +118,28 @@ end
 
 ### addDataProxy
 
+**Purpose**
+Adds a proxy function that is called when a data field changes.
+
+**Parameters**
+
+- `key` (`string`): Data field to watch.
+- `onChange` (`function`) – Callback receiving old and new values.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:addDataProxy(key, onChange)
     -- return nil
 end
 ```
-
-Description: Adds a proxy function that is called when a data field changes.
-Parameters:
-- `key` (`string`): Data field to watch.
-- `onChange` (`function`) – Callback receiving old and new values.
-
-
-Realm: Shared
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Track changes to the "locked" data field
 inv:addDataProxy("locked", function(old, new)
@@ -124,22 +152,28 @@ end)
 
 ### getItemsByUniqueID
 
+**Purpose**
+Returns all items in the inventory matching the given unique ID.
+
+**Parameters**
+
+- `uniqueID` (`string`): Item unique identifier.
+- `onlyMain` (`boolean`) – Search only the main item list.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: Table of matching item objects.
+
+**Example**
+
 ```lua
 function Inventory:getItemsByUniqueID(uniqueID, onlyMain)
     -- return table
 end
 ```
-
-Description: Returns all items in the inventory matching the given unique ID.
-Parameters:
-- `uniqueID` (`string`): Item unique identifier.
-- `onlyMain` (`boolean`) – Search only the main item list.
-
-
-Realm: Shared
-Returns:
-- table: Table of matching item objects.
-Example Usage:
 ```lua
 -- Use each ammo box found in the main list
 for _, box in ipairs(inv:getItemsByUniqueID("ammo_box", true)) do
@@ -151,19 +185,27 @@ end
 
 ### register
 
+**Purpose**
+Registers this inventory type with the lia.inventory system.
+
+**Parameters**
+
+- `typeID` (`string`): Unique identifier for this inventory type.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:register(typeID)
     -- persistence setup
 end
 ```
-
-Description: Registers this inventory type with the lia.inventory system.
-Parameters:
-- `typeID` (`string`): Unique identifier for this inventory type.
-Realm: Shared
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Register and then immediately create the inventory type
 WeaponInv:register("weapon_inv")
@@ -174,19 +216,27 @@ local chestInv = WeaponInv:new()
 
 ### new
 
+**Purpose**
+Creates a new inventory of this type.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: New inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:new()
     -- return table
 end
 ```
-
-Description: Creates a new inventory of this type.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- table: New inventory instance.
-Example Usage:
 ```lua
 -- Create an inventory and attach it to a spawned chest entity
 local chest = ents.Create("prop_physics")
@@ -199,19 +249,27 @@ chest.inv = WeaponInv:new()
 
 ### tostring
 
+**Purpose**
+Returns a printable representation of this inventory.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- string: Formatted as "ClassName[id]".
+
+**Example**
+
 ```lua
 function Inventory:tostring()
     -- return string
 end
 ```
-
-Description: Returns a printable representation of this inventory.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- string: Formatted as "ClassName[id]".
-Example Usage:
 ```lua
 -- Print the identifier when debugging
 print("Inventory: " .. inv:tostring())
@@ -221,19 +279,27 @@ print("Inventory: " .. inv:tostring())
 
 ### getType
 
+**Purpose**
+Retrieves the inventory type table from lia.inventory.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: Inventory type definition.
+
+**Example**
+
 ```lua
 function Inventory:getType()
     -- return table
 end
 ```
-
-Description: Retrieves the inventory type table from lia.inventory.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- table: Inventory type definition.
-Example Usage:
 ```lua
 -- Read slot data from the type definition
 local def = inv:getType()
@@ -243,25 +309,29 @@ local def = inv:getType()
 
 ### onDataChanged
 
+**Purpose**
+Called when an inventory data field changes. Executes any registered proxy callbacks for that field.
+
+**Parameters**
+
+- `key` (`string`): Data field key.
+- `oldValue` (`any`) – Previous value.
+- `newValue` (`any`) – Updated value.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:onDataChanged(key, oldValue, newValue)
     -- callback after setData
 end
 ```
-
-Description: Called when an inventory data field changes. Executes any registered proxy callbacks for that field.
-Parameters:
-- `key` (`string`): Data field key.
-- `oldValue` (`any`) – Previous value.
-
-
-- `newValue` (`any`) – Updated value.
-
-
-Realm: Shared
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- React when a data value is updated
 function WeaponInv:onDataChanged(key, old, new)
@@ -273,19 +343,27 @@ end
 
 ### getItems
 
+**Purpose**
+Returns all items stored in this inventory.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: Item instance table indexed by itemID.
+
+**Example**
+
 ```lua
 function Inventory:getItems()
     -- return table
 end
 ```
-
-Description: Returns all items stored in this inventory.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- table: Item instance table indexed by itemID.
-Example Usage:
 ```lua
 -- Sum the weight of all items
 local totalWeight = 0
@@ -299,19 +377,27 @@ print("Weight:", totalWeight)
 
 ### getItemsOfType
 
+**Purpose**
+Collects all items that match the given unique ID.
+
+**Parameters**
+
+- `itemType` (`string`): Item unique identifier.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- table: Array of matching items.
+
+**Example**
+
 ```lua
 function Inventory:getItemsOfType(itemType)
     -- return table
 end
 ```
-
-Description: Collects all items that match the given unique ID.
-Parameters:
-- `itemType` (`string`): Item unique identifier.
-Realm: Shared
-Returns:
-- table: Array of matching items.
-Example Usage:
 ```lua
 -- List all medkits currently in the inventory
 local kits = inv:getItemsOfType("medkit")
@@ -321,19 +407,27 @@ local kits = inv:getItemsOfType("medkit")
 
 ### getFirstItemOfType
 
+**Purpose**
+Retrieves the first item matching the given unique ID.
+
+**Parameters**
+
+- `itemType` (`string`): Item unique identifier.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- Item|None: The first matching item or None.
+
+**Example**
+
 ```lua
 function Inventory:getFirstItemOfType(itemType)
     -- return item
 end
 ```
-
-Description: Retrieves the first item matching the given unique ID.
-Parameters:
-- `itemType` (`string`): Item unique identifier.
-Realm: Shared
-Returns:
-- Item|None: The first matching item or None.
-Example Usage:
 ```lua
 -- Grab the first pistol found in the inventory
 local pistol = inv:getFirstItemOfType("pistol")
@@ -343,19 +437,27 @@ local pistol = inv:getFirstItemOfType("pistol")
 
 ### hasItem
 
+**Purpose**
+Determines whether the inventory contains an item type.
+
+**Parameters**
+
+- `itemType` (`string`): Item unique identifier.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- boolean: True if an item is found.
+
+**Example**
+
 ```lua
 function Inventory:hasItem(itemType)
     -- return boolean
 end
 ```
-
-Description: Determines whether the inventory contains an item type.
-Parameters:
-- `itemType` (`string`): Item unique identifier.
-Realm: Shared
-Returns:
-- boolean: True if an item is found.
-Example Usage:
 ```lua
 -- See if any health potion exists
 if inv:hasItem("health_potion") then
@@ -367,19 +469,27 @@ end
 
 ### getItemCount
 
+**Purpose**
+Counts the total quantity of a specific item type.
+
+**Parameters**
+
+- `itemType` (`string|None`): Item unique ID to count. Counts all if nil.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- number: Sum of quantities.
+
+**Example**
+
 ```lua
 function Inventory:getItemCount(itemType)
     -- return number
 end
 ```
-
-Description: Counts the total quantity of a specific item type.
-Parameters:
-- `itemType` (`string|None`): Item unique ID to count. Counts all if nil.
-Realm: Shared
-Returns:
-- number: Sum of quantities.
-Example Usage:
 ```lua
 -- Count the total number of bullets
 local ammoTotal = inv:getItemCount("bullet")
@@ -390,19 +500,27 @@ print("Ammo remaining:", ammoTotal)
 
 ### getID
 
+**Purpose**
+Returns the unique database ID of this inventory.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- number: Inventory identifier.
+
+**Example**
+
 ```lua
 function Inventory:getID()
     -- return number
 end
 ```
-
-Description: Returns the unique database ID of this inventory.
-Parameters:
-- None
-Realm: Shared
-Returns:
-- number: Inventory identifier.
-Example Usage:
 ```lua
 -- Store the inventory ID on its container entity
 entity:setNetVar("invID", inv:getID())
@@ -412,19 +530,27 @@ entity:setNetVar("invID", inv:getID())
 
 ### eq
 
+**Purpose**
+Compares two inventories by ID for equality.
+
+**Parameters**
+
+- `other` (`Inventory`): Other inventory to compare.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+- boolean: True if both inventories share the same ID.
+
+**Example**
+
 ```lua
 function Inventory:eq(other)
     -- return boolean
 end
 ```
-
-Description: Compares two inventories by ID for equality.
-Parameters:
-- `other` (`Inventory`): Other inventory to compare.
-Realm: Shared
-Returns:
-- boolean: True if both inventories share the same ID.
-Example Usage:
 ```lua
 -- Check if two chests share the same inventory record
 if inv:eq(other) then
@@ -436,22 +562,28 @@ end
 
 ### addItem
 
+**Purpose**
+Inserts an item instance into this inventory and persists it.
+
+**Parameters**
+
+- `item` (`Item`): Item to add.
+- `noReplicate` (`boolean`) – Skip network replication when true.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: The inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:addItem(item, noReplicate)
     -- return self
 end
 ```
-
-Description: Inserts an item instance into this inventory and persists it.
-Parameters:
-- `item` (`Item`): Item to add.
-- `noReplicate` (`boolean`) – Skip network replication when true.
-
-
-Realm: Server
-Returns:
-- table: The inventory instance.
-Example Usage:
 ```lua
 -- Add a looted item to the inventory
 if not inv:hasItem(item.uniqueID) then
@@ -463,19 +595,27 @@ end
 
 ### add
 
+**Purpose**
+Alias for `addItem` that inserts an item into the inventory.
+
+**Parameters**
+
+- `item` (`Item`): Item to add.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: The inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:add(item)
     return self:addItem(item)
 end
 ```
-
-Description: Alias for `addItem` that inserts an item into the inventory.
-Parameters:
-- `item` (`Item`): Item to add.
-Realm: Server
-Returns:
-- table: The inventory instance.
-Example Usage:
 ```lua
 inv:add(item)
 ```
@@ -484,19 +624,27 @@ inv:add(item)
 
 ### syncItemAdded
 
+**Purpose**
+Replicates a newly added item to all clients that can access the inventory.
+
+**Parameters**
+
+- `item` (`Item`): Item instance that was added.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:syncItemAdded(item)
     -- networking
 end
 ```
-
-Description: Replicates a newly added item to all clients that can access the inventory.
-Parameters:
-- `item` (`Item`): Item instance that was added.
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 inv:syncItemAdded(item)
 ```
@@ -505,19 +653,27 @@ inv:syncItemAdded(item)
 
 ### initializeStorage
 
+**Purpose**
+Creates a persistent inventory record in the database using the supplied initial data.
+
+**Parameters**
+
+- `initialData` (`table`): Values to store when creating the inventory.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- Deferred: Resolves with the new inventory ID.
+
+**Example**
+
 ```lua
 function Inventory:initializeStorage(initialData)
     -- return Deferred
 end
 ```
-
-Description: Creates a persistent inventory record in the database using the supplied initial data.
-Parameters:
-- `initialData` (`table`): Values to store when creating the inventory.
-Realm: Server
-Returns:
-- Deferred: Resolves with the new inventory ID.
-Example Usage:
 ```lua
 WeaponInv:initializeStorage({char = charID, locked = true}):next(function(id)
     print("Created inventory", id)
@@ -528,18 +684,26 @@ end)
 
 ### restoreFromStorage
 
+**Purpose**
+Stub called when loading an inventory from custom storage systems.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:restoreFromStorage()
 end
 ```
-
-Description: Stub called when loading an inventory from custom storage systems.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 inv:restoreFromStorage()
 ```
@@ -548,22 +712,28 @@ inv:restoreFromStorage()
 
 ### removeItem
 
+**Purpose**
+Removes an item by ID and optionally deletes it.
+
+**Parameters**
+
+- `itemID` (`number`): Unique item identifier.
+- `preserveItem` (`boolean`) – Keep item in database when true.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- Deferred: Resolves once the item removal completes.
+
+**Example**
+
 ```lua
 function Inventory:removeItem(itemID, preserveItem)
     -- return Deferred
 end
 ```
-
-Description: Removes an item by ID and optionally deletes it.
-Parameters:
-- `itemID` (`number`): Unique item identifier.
-- `preserveItem` (`boolean`) – Keep item in database when true.
-
-
-Realm: Server
-Returns:
-- Deferred: Resolves once the item removal completes.
-Example Usage:
 ```lua
 -- Remove an item but keep it saved for later
 inv:removeItem(itemID, true):next(function()
@@ -575,19 +745,27 @@ end)
 
 ### remove
 
+**Purpose**
+Alias for `removeItem` that removes an item from the inventory.
+
+**Parameters**
+
+- `itemID` (`number`): Unique item identifier.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- Deferred: Resolves once the item is removed.
+
+**Example**
+
 ```lua
 function Inventory:remove(itemID)
     return self:removeItem(itemID)
 end
 ```
-
-Description: Alias for `removeItem` that removes an item from the inventory.
-Parameters:
-- `itemID` (`number`): Unique item identifier.
-Realm: Server
-Returns:
-- Deferred: Resolves once the item is removed.
-Example Usage:
 ```lua
 inv:remove(itemID):next(function()
     print("Removed from the container")
@@ -598,22 +776,28 @@ end)
 
 ### setData
 
+**Purpose**
+Sets a data field on the inventory and replicates the change to clients.
+
+**Parameters**
+
+- `key` (`string`): Data field name.
+- `value` (`any`) – Value to store.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: The inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:setData(key, value)
     -- persistence
 end
 ```
-
-Description: Sets a data field on the inventory and replicates the change to clients.
-Parameters:
-- `key` (`string`): Data field name.
-- `value` (`any`) – Value to store.
-
-
-Realm: Server
-Returns:
-- table: The inventory instance.
-Example Usage:
 ```lua
 inv:setData("locked", true)
 ```
@@ -622,25 +806,29 @@ inv:setData("locked", true)
 
 ### canAccess
 
+**Purpose**
+Evaluates access rules to determine whether an action is permitted.
+
+**Parameters**
+
+- `action` (`string`): Action identifier.
+- `context` (`table|None`) – Additional data such as the client.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- boolean|nil: True, false, or nil if undecided.
+- string|nil – Optional failure reason.
+
+**Example**
+
 ```lua
 function Inventory:canAccess(action, context)
     -- return boolean, reason
 end
 ```
-
-Description: Evaluates access rules to determine whether an action is permitted.
-Parameters:
-- `action` (`string`): Action identifier.
-- `context` (`table|None`) – Additional data such as the client.
-
-
-Realm: Server
-Returns:
-- boolean|nil: True, false, or nil if undecided.
-- string|nil – Optional failure reason.
-
-
-Example Usage:
 ```lua
 local allowed = inv:canAccess("take", {client = ply})
 ```
@@ -649,22 +837,28 @@ local allowed = inv:canAccess("take", {client = ply})
 
 ### addAccessRule
 
+**Purpose**
+Registers a function used by `canAccess` to grant or deny actions.
+
+**Parameters**
+
+- `rule` (`function`): Access rule function.
+- `priority` (`number|None`) – Insertion position for the rule.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: The inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:addAccessRule(rule, priority)
     -- return self
 end
 ```
-
-Description: Registers a function used by `canAccess` to grant or deny actions.
-Parameters:
-- `rule` (`function`): Access rule function.
-- `priority` (`number|None`) – Insertion position for the rule.
-
-
-Realm: Server
-Returns:
-- table: The inventory instance.
-Example Usage:
 ```lua
 inv:addAccessRule(function(inv, action, ctx)
     return ctx.client:IsAdmin()
@@ -675,19 +869,27 @@ end)
 
 ### removeAccessRule
 
+**Purpose**
+Unregisters a previously added access rule.
+
+**Parameters**
+
+- `rule` (`function`): The rule to remove.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: The inventory instance.
+
+**Example**
+
 ```lua
 function Inventory:removeAccessRule(rule)
     -- return self
 end
 ```
-
-Description: Unregisters a previously added access rule.
-Parameters:
-- `rule` (`function`): The rule to remove.
-Realm: Server
-Returns:
-- table: The inventory instance.
-Example Usage:
 ```lua
 inv:removeAccessRule(myRule)
 ```
@@ -696,19 +898,27 @@ inv:removeAccessRule(myRule)
 
 ### getRecipients
 
+**Purpose**
+Returns a list of players that should receive network updates for this inventory.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- table: Array of Player objects.
+
+**Example**
+
 ```lua
 function Inventory:getRecipients()
     -- return table
 end
 ```
-
-Description: Returns a list of players that should receive network updates for this inventory.
-Parameters:
-- None
-Realm: Server
-Returns:
-- table: Array of Player objects.
-Example Usage:
 ```lua
 local receivers = inv:getRecipients()
 ```
@@ -717,18 +927,26 @@ local receivers = inv:getRecipients()
 
 ### onInstanced
 
+**Purpose**
+Called after a new inventory is created in the database.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:onInstanced()
 end
 ```
-
-Description: Called after a new inventory is created in the database.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 function WeaponInv:onInstanced()
     print("Created inventory", self:getID())
@@ -739,18 +957,26 @@ end
 
 ### onLoaded
 
+**Purpose**
+Called after an inventory is loaded from the database.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:onLoaded()
 end
 ```
-
-Description: Called after an inventory is loaded from the database.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 function WeaponInv:onLoaded()
     print("Loaded inventory", self:getID())
@@ -761,19 +987,27 @@ end
 
 ### loadItems
 
+**Purpose**
+Loads all items belonging to this inventory from storage.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- Deferred: Resolves with a table of loaded items.
+
+**Example**
+
 ```lua
 function Inventory:loadItems()
     -- return Deferred
 end
 ```
-
-Description: Loads all items belonging to this inventory from storage.
-Parameters:
-- None
-Realm: Server
-Returns:
-- Deferred: Resolves with a table of loaded items.
-Example Usage:
 ```lua
 inv:loadItems():next(function(items)
     print("Loaded", table.Count(items), "items")
@@ -784,18 +1018,26 @@ end)
 
 ### onItemsLoaded
 
+**Purpose**
+Hook called after `loadItems` finishes loading all items.
+
+**Parameters**
+
+- `items` (`table`): Loaded items indexed by ID.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:onItemsLoaded(items)
 end
 ```
-
-Description: Hook called after `loadItems` finishes loading all items.
-Parameters:
-- `items` (`table`): Loaded items indexed by ID.
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 function WeaponInv:onItemsLoaded(items)
     print("Ready with", #items, "items")
@@ -806,19 +1048,27 @@ end
 
 ### instance
 
+**Purpose**
+Creates and stores a new inventory instance of this type.
+
+**Parameters**
+
+- `initialData` (`table|None`): Data to populate the inventory with.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- Deferred: Resolves with the created inventory.
+
+**Example**
+
 ```lua
 function Inventory:instance(initialData)
     -- return Deferred
 end
 ```
-
-Description: Creates and stores a new inventory instance of this type.
-Parameters:
-- `initialData` (`table|None`): Data to populate the inventory with.
-Realm: Server
-Returns:
-- Deferred: Resolves with the created inventory.
-Example Usage:
 ```lua
 WeaponInv:instance({char = charID}):next(function(inv) end)
 ```
@@ -827,22 +1077,28 @@ WeaponInv:instance({char = charID}):next(function(inv) end)
 
 ### syncData
 
+**Purpose**
+Sends a single data field to clients.
+
+**Parameters**
+
+- `key` (`string`): Field to replicate.
+- `recipients` (`table|None`) – Player recipients.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:syncData(key, recipients)
     -- networking
 end
 ```
-
-Description: Sends a single data field to clients.
-Parameters:
-- `key` (`string`): Field to replicate.
-- `recipients` (`table|None`) – Player recipients.
-
-
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Sync the locked state to nearby players
 inv:syncData("locked", recipients)
@@ -852,19 +1108,27 @@ inv:syncData("locked", recipients)
 
 ### sync
 
+**Purpose**
+Sends the entire inventory and its items to players.
+
+**Parameters**
+
+- `recipients` (`table|None`): Player recipients.
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:sync(recipients)
     -- networking
 end
 ```
-
-Description: Sends the entire inventory and its items to players.
-Parameters:
-- `recipients` (`table|None`): Player recipients.
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Send all items to the owner after they join
 inv:sync({owner})
@@ -874,19 +1138,27 @@ inv:sync({owner})
 
 ### delete
 
+**Purpose**
+Removes this inventory record from the database.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:delete()
     -- persistence
 end
 ```
-
-Description: Removes this inventory record from the database.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Permanently delete a chest inventory on cleanup
 inv:delete()
@@ -897,42 +1169,61 @@ print("Inventory removed from database")
 
 ### destroy
 
+**Purpose**
+Destroys all items and removes network references.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Server`
+
+**Returns**
+
+- None: This function does not return a value.
+
+**Example**
+
 ```lua
 function Inventory:destroy()
     -- cleanup
 end
 ```
-
-Description: Destroys all items and removes network references.
-Parameters:
-- None
-Realm: Server
-Returns:
-- None: This function does not return a value.
-Example Usage:
 ```lua
 -- Clear all items when the container entity is removed
 inv:destroy()
 print("Inventory destroyed")
 ```
 
+---
 ### show
+
+**Purpose**
+Opens the inventory user interface on the client.
+
+**Parameters**
+
+- `parent` (`Panel|None`): Optional parent panel.
+
+**Realm**
+`Client`
+
+**Returns**
+
+- Panel: The created inventory UI panel.
+
+**Example**
 
 ```lua
 function Inventory:show(parent)
     -- returns Panel
 end
 ```
-
-Description: Opens the inventory user interface on the client.
-Parameters:
-- `parent` (`Panel|None`): Optional parent panel.
-Realm: Client
-Returns:
-- Panel: The created inventory UI panel.
-Example Usage:
 ```lua
 inv:show()
 -- or attach to an existing panel
 local ui = inv:show(parentPanel)
 ```
+
+---

--- a/docs/docs/meta/tool.md
+++ b/docs/docs/meta/tool.md
@@ -12,23 +12,21 @@ Tool meta functions track hovered entities, create ghost previews, and wrap comm
 
 ### Create
 
-Description: 
+**Purpose**
 Creates a new tool object with default values.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - table: The newly created tool object.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Create a new tool instance and configure it
@@ -42,23 +40,21 @@ tool.Owner = client -- client that spawned the tool
 
 ### CreateConVars
 
-Description: 
+**Purpose**
 Creates client and server ConVars for this tool.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Ensure console variables exist for configuration
@@ -69,23 +65,21 @@ tool:CreateConVars()
 
 ### GetServerInfo
 
-Description: 
+**Purpose**
 Returns the server ConVar for the given property.
 
-Parameters:
+**Parameters**
 
 - `property` (string): Property name.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - ConVar: The server ConVar object.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Check if the server allows using this tool
@@ -96,23 +90,21 @@ local allow = tool:GetServerInfo("allow_use"):GetBool()
 
 ### BuildConVarList
 
-Description: 
+**Purpose**
 Returns a table of client ConVars prefixed by the tool mode.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - table: Table of convars.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Get a table of client ConVars for networking
@@ -123,23 +115,21 @@ local cvars = tool:BuildConVarList()
 
 ### GetClientInfo
 
-Description: 
+**Purpose**
 Retrieves a client ConVar value as a string.
 
-Parameters:
+**Parameters**
 
 - `property` (string): ConVar name without mode prefix.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - string: The value stored in the ConVar.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Get the client's chosen material from a ConVar
@@ -150,26 +140,22 @@ local mat = tool:GetClientInfo("material")
 
 ### GetClientNumber
 
-Description: 
+**Purpose**
 Retrieves a numeric client ConVar value.
 
-Parameters:
+**Parameters**
 
 - `property` (string): ConVar name without mode prefix.
-
-
 - `default` (number): Value returned if the ConVar doesn't exist.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - number: The numeric value of the ConVar.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Read the numeric power setting with a fallback
@@ -180,23 +166,21 @@ local power = tool:GetClientNumber("power", 10)
 
 ### Allowed
 
-Description: 
+**Purpose**
 Determines whether this tool is allowed to be used.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - boolean: True if the tool is allowed.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Gate tool usage behind an admin check
@@ -209,23 +193,21 @@ end
 
 ### Init
 
-Description: 
+**Purpose**
 Placeholder for tool initialization.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 function TOOL:Init()
@@ -238,23 +220,21 @@ end
 
 ### GetMode
 
-Description: 
+**Purpose**
 Gets the current tool mode string.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - string: Tool mode name.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Retrieve the tool's active mode string
@@ -265,23 +245,21 @@ local result = tool:GetMode()
 
 ### GetSWEP
 
-Description: 
+**Purpose**
 Returns the SWEP associated with this tool.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - SWEP: The tool's weapon entity.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Obtain the weapon entity representing this tool
@@ -292,23 +270,21 @@ local result = tool:GetSWEP()
 
 ### GetOwner
 
-Description: 
+**Purpose**
 Returns the player who owns the associated weapon.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - Player: Owner of the tool.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Reference the player who deployed the tool
@@ -320,23 +296,21 @@ print(owner:Name())
 
 ### GetWeapon
 
-Description: 
+**Purpose**
 Retrieves the weapon entity this tool is attached to.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - Weapon: The weapon object.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Access the underlying weapon object
@@ -347,23 +321,21 @@ local result = tool:GetWeapon()
 
 ### LeftClick
 
-Description: 
+**Purpose**
 Handles the left-click action. Override for custom behavior.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - boolean: False by default.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Example override performing a build action
@@ -377,23 +349,21 @@ end
 
 ### RightClick
 
-Description: 
+**Purpose**
 Handles the right-click action. Override for custom behavior.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - boolean: False by default.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Example override for an alternate action
@@ -407,23 +377,21 @@ end
 
 ### Reload
 
-Description: 
+**Purpose**
 Clears stored objects when the tool reloads.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 function TOOL:Reload()
@@ -436,23 +404,21 @@ end
 
 ### Deploy
 
-Description: 
+**Purpose**
 Called when the tool is equipped. Releases ghost entity.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 function TOOL:Deploy()
@@ -465,23 +431,21 @@ end
 
 ### Holster
 
-Description: 
+**Purpose**
 Called when the tool is holstered. Releases ghost entity.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 function TOOL:Holster()
@@ -494,23 +458,21 @@ end
 
 ### Think
 
-Description: 
+**Purpose**
 Called every tick; releases ghost entities by default.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 function TOOL:Think()
@@ -523,23 +485,21 @@ end
 
 ### CheckObjects
 
-Description: 
+**Purpose**
 Validates stored objects and clears them if invalid.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Validate all stored objects each tick
@@ -550,23 +510,21 @@ local result = tool:CheckObjects()
 
 ### ClearObjects
 
-Description: 
+**Purpose**
 Removes all stored objects from the tool.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Remove any objects the tool is storing
@@ -577,25 +535,25 @@ local result = tool:ClearObjects()
 
 ### ReleaseGhostEntity
 
-Description: 
+**Purpose**
 Removes the ghost entity used for previewing placements.
 
-Parameters:
+**Parameters**
 
 - None
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `None`: This function does not return a value.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Remove the placement preview entity
 local result = tool:ReleaseGhostEntity()
 ```
+
+---

--- a/docs/docs/meta/vector.md
+++ b/docs/docs/meta/vector.md
@@ -31,23 +31,21 @@ end)
 
 ### Center
 
-Description: 
+**Purpose**
 Returns the midpoint between this vector and the supplied vector.
 
-Parameters:
+**Parameters**
 
 - `vec2` (Vector): The vector to average with this vector.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `Vector`: The center point of the two vectors.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Average two vectors to find the midpoint
@@ -61,23 +59,21 @@ print(result)
 
 ### Distance
 
-Description: 
+**Purpose**
 Calculates the distance between this vector and another vector.
 
-Parameters:
+**Parameters**
 
 - `vec2` (Vector): The other vector.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `number`: The distance between the two vectors.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Measure the distance between two points
@@ -91,26 +87,22 @@ print(result)
 
 ### RotateAroundAxis
 
-Description: 
+**Purpose**
 Rotates the vector around an axis by the specified degrees and returns the new vector.
 
-Parameters:
+**Parameters**
 
 - `axis` (Vector): Axis to rotate around.
-
-
 - `degrees` (number): Angle in degrees.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `Vector`: The rotated vector.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Rotate a vector 90 degrees around the Z axis
@@ -123,29 +115,21 @@ print(result)
 
 ### Right
 
-Description: 
-Calculates the cross product of this vector and the provided up reference to
+**Purpose**
+Calculates the cross product of this vector and the provided up reference to derive a right-direction vector. The result is normalized and therefore perpendicular to both input vectors. If this vector has no horizontal component it defaults to `Vector(0, -1, 0)`.
 
-derive a right-direction vector. The result is normalized and therefore
-
-perpendicular to both input vectors. If this vector has no horizontal
-
-component it defaults to `Vector(0, -1, 0)`.
-
-Parameters:
+**Parameters**
 
 * `vUp` (`Vector`, optional) – Up direction to compare against. Defaults to `vector_up`.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `Vector`: The calculated right vector.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Get the right direction vector
@@ -158,31 +142,21 @@ print(result)
 
 ### Up
 
-Description: 
-Uses two cross products to determine an up-direction vector that is
+**Purpose**
+Uses two cross products to determine an up-direction vector that is perpendicular to both this vector and the given up reference. First, the right vector is obtained via `self:Cross(vUp)`, then that right vector is crossed with `self` to yield the final up direction. When this vector lacks a horizontal component the fallback value is `Vector(-self.z, 0, 0)`.
 
-perpendicular to both this vector and the given up reference. First, the right
-
-vector is obtained via `self:Cross(vUp)`, then that right vector is crossed with
-
-`self` to yield the final up direction. When this vector lacks a horizontal
-
-component the fallback value is `Vector(-self.z, 0, 0)`.
-
-Parameters:
+**Parameters**
 
 * `vUp` (`Vector`, optional) – Up direction to compare against. Defaults to `vector_up`.
 
+**Realm**
+`Shared`
 
-Realm: Shared
-
-
-Returns:
+**Returns**
 
 - `Vector`: The calculated up vector.
 
-
-Example Usage:
+**Example**
 
 ```lua
 -- Get the up direction vector
@@ -190,3 +164,5 @@ local forward = Vector(1, 0, 0)
 local result = forward:Up()
 print(result)
 ```
+
+---

--- a/scripts/reformat_meta.py
+++ b/scripts/reformat_meta.py
@@ -1,0 +1,128 @@
+import sys, re
+
+RE_SECTION = re.compile(r'^### ')
+
+files = sys.argv[1:]
+for path in files:
+    lines = open(path).read().splitlines()
+    out = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith('### '):
+            name = line[4:].strip()
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == '':
+                j += 1
+            code_block = []
+            if j < len(lines) and lines[j].startswith('```'):
+                start = j
+                code_block.append(lines[j])
+                j += 1
+                while j < len(lines) and not lines[j].startswith('```'):
+                    code_block.append(lines[j])
+                    j += 1
+                if j < len(lines):
+                    code_block.append(lines[j])
+                    j += 1
+                while j < len(lines) and lines[j].strip() == '':
+                    j += 1
+            if j >= len(lines) or not lines[j].startswith('Description:'):
+                # not a function section, keep as-is
+                out.append(line)
+                i += 1
+                continue
+            out.append(line)
+            i = j
+            # Description
+            desc_lines = []
+            if i < len(lines) and lines[i].startswith('Description:'):
+                desc_line = lines[i][12:].strip()
+                if desc_line:
+                    desc_lines.append(desc_line)
+                i += 1
+                while i < len(lines) and not lines[i].startswith('Parameters:'):
+                    if lines[i].strip():
+                        desc_lines.append(lines[i].strip())
+                    i += 1
+            desc = ' '.join(l.strip() for l in desc_lines).strip()
+            # Parameters
+            params = []
+            if i < len(lines) and lines[i].startswith('Parameters:'):
+                i += 1
+                while i < len(lines) and not lines[i].startswith('Realm:'):
+                    if lines[i].strip():
+                        params.append(lines[i].strip())
+                    i += 1
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            # Realm
+            realm = ''
+            if i < len(lines) and lines[i].startswith('Realm:'):
+                realm = lines[i][6:].strip()
+                i += 1
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            # Returns
+            returns = []
+            if i < len(lines) and lines[i].startswith('Returns:'):
+                i += 1
+                while i < len(lines) and not (lines[i].startswith('Example') or lines[i].startswith('- *Example') or lines[i].startswith('```')):
+                    if lines[i].strip():
+                        returns.append(lines[i].strip())
+                    i += 1
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            # Example
+            example = code_block[:]
+            if i < len(lines) and (lines[i].startswith('Example') or lines[i].startswith('- *Example')):
+                i += 1
+                while i < len(lines) and not lines[i].startswith('```'):
+                    i += 1
+            if i < len(lines) and lines[i].startswith('```'):
+                example.append(lines[i])
+                i += 1
+                while i < len(lines) and not lines[i].startswith('```'):
+                    example.append(lines[i])
+                    i += 1
+                if i < len(lines):
+                    example.append(lines[i])
+                    i += 1
+            # skip trailing blanks
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            # expect ---
+            if i < len(lines) and lines[i].startswith('---'):
+                i += 1
+            # Build new section
+            out.append('')
+            out.append('**Purpose**')
+            out.append(desc)
+            out.append('')
+            out.append('**Parameters**')
+            out.append('')
+            if params:
+                out.extend(params)
+            else:
+                out.append('- None')
+            out.append('')
+            out.append('**Realm**')
+            out.append(f'`{realm}`')
+            out.append('')
+            out.append('**Returns**')
+            out.append('')
+            if returns:
+                out.extend(returns)
+            else:
+                out.append('- nil')
+            out.append('')
+            out.append('**Example**')
+            out.append('')
+            out.extend(example)
+            out.append('')
+            out.append('---')
+        else:
+            out.append(line)
+            i += 1
+    with open(path, 'w') as f:
+        f.write('\n'.join(out) + '\n')


### PR DESCRIPTION
## Summary
- convert character, entity, gridinv, inventory, tool and vector meta docs to use the new function documentation style
- add a helper script to reformat meta documentation

## Testing
- `python3 -m py_compile scripts/reformat_meta.py`

------
https://chatgpt.com/codex/tasks/task_e_686a1e5b16148327a6318b3385cf873d