### PR TITLE
Fix chat format localization

### DIFF
--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -30,10 +30,10 @@ function lia.chat.register(chatType, data)
     end
 
     data.color = data.color or Color(242, 230, 160)
-    data.format = data.format and L(data.format) or "%s: \"%s\""
+    data.format = data.format or "%s: \"%s\""
     data.onChatAdd = data.onChatAdd or function(speaker, text, anonymous)
         local name = anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, chatType) or IsValid(speaker) and speaker:Name() or "Console"
-        chat.AddText(lia.chat.timestamp(false), data.color, string.format(data.format, name, text))
+        chat.AddText(lia.chat.timestamp(false), data.color, L(data.format, name, text))
     end
 
     if CLIENT and data.prefix then


### PR DESCRIPTION
## Summary
- avoid calling `L` on unformatted chat format strings
- use `L` with parameters when rendering chat messages

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a20a861c0832796a4a9025b6c5c71