### PR TITLE
Fix faction/class data in argument prompt

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -341,13 +341,13 @@ else
                 ctrl = vgui.Create("DComboBox", panel)
                 ctrl:SetValue(L("selectFactionPrompt"))
                 for _, fac in ipairs(lia.faction.indices) do
-                    ctrl:AddChoice(L(fac.name), fac.index)
+                    ctrl:AddChoice(L(fac.name), string.format("\"%s\"", fac.uniqueID))
                 end
             elseif fieldType == "class" then
                 ctrl = vgui.Create("DComboBox", panel)
                 ctrl:SetValue(L("selectClassPrompt"))
-                for id, class in pairs(lia.class.list) do
-                    ctrl:AddChoice(L(class.name), id)
+                for _, class in pairs(lia.class.list) do
+                    ctrl:AddChoice(L(class.name), string.format("\"%s\"", class.uniqueID))
                 end
             elseif fieldType == "text" or fieldType == "number" then
                 ctrl = vgui.Create("DTextEntry", panel)


### PR DESCRIPTION
## Summary
- send faction and class as quoted `uniqueID`s when collecting command arguments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a2383cbd883278de155a2db0a9298