### PR TITLE
Add physgun and vehicle logs

### DIFF
--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -84,6 +84,36 @@
         end,
         category = "SWEP"
     },
+    ["physgunPickup"] = {
+        func = function(client, class, model)
+            return string.format("Player '%s' picked up '%s' (%s) with the physgun.", client:Name(), class, model)
+        end,
+        category = "Physgun"
+    },
+    ["physgunDrop"] = {
+        func = function(client, class, model)
+            return string.format("Player '%s' dropped '%s' (%s) with the physgun.", client:Name(), class, model)
+        end,
+        category = "Physgun"
+    },
+    ["physgunFreeze"] = {
+        func = function(client, class, model)
+            return string.format("Player '%s' froze '%s' (%s) with the physgun.", client:Name(), class, model)
+        end,
+        category = "Physgun"
+    },
+    ["vehicleEnter"] = {
+        func = function(client, class, model)
+            return string.format("Player '%s' entered vehicle '%s' (%s).", client:Name(), class, model)
+        end,
+        category = "Vehicles"
+    },
+    ["vehicleExit"] = {
+        func = function(client, class, model)
+            return string.format("Player '%s' left vehicle '%s' (%s).", client:Name(), class, model)
+        end,
+        category = "Vehicles"
+    },
     ["chat"] = {
         func = function(client, chatType, message)
             return string.format("(%s) %s said: '%s'", chatType, client:Name(), message)

--- a/modules/protection/libraries/server.lua
+++ b/modules/protection/libraries/server.lua
@@ -102,7 +102,7 @@ function MODULE:PlayerSay(client, message)
     end
 end
 
-function MODULE:PlayerLeaveVehicle(_, entity)
+function MODULE:PlayerLeaveVehicle(client, entity)
     if entity:GetClass() == "prop_vehicle_prisoner_pod" then
         local sName = "PodFix_" .. entity:EntIndex()
         hook.Add("Think", sName, function()
@@ -118,6 +118,7 @@ function MODULE:PlayerLeaveVehicle(_, entity)
             end
         end)
     end
+    lia.log.add(client, "vehicleExit", entity:GetClass(), entity:GetModel())
 end
 
 function MODULE:OnEntityCreated(entity)
@@ -165,16 +166,23 @@ function MODULE:ShouldCollide(ent1, ent2)
     return true
 end
 
-function MODULE:PlayerEnteredVehicle(_, entity)
+function MODULE:PlayerEnteredVehicle(client, entity)
     if entity:GetClass() == "prop_vehicle_prisoner_pod" then entity:RemoveEFlags(EFL_NO_THINK_FUNCTION) end
+    lia.log.add(client, "vehicleEnter", entity:GetClass(), entity:GetModel())
 end
 
-function MODULE:OnPhysgunPickup(_, entity)
+function MODULE:OnPhysgunPickup(client, entity)
     if (entity:isProp() or entity:isItem()) and entity:GetCollisionGroup() == COLLISION_GROUP_NONE then entity:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR) end
+    lia.log.add(client, "physgunPickup", entity:GetClass(), entity:GetModel())
 end
 
-function MODULE:PhysgunDrop(_, entity)
-    if entity:isProp() and entity:isItem() then timer.Simple(5, function() if IsValid(entity) and entity:GetCollisionGroup() == COLLISION_GROUP_PASSABLE_DOOR then entity:SetCollisionGroup(COLLISION_GROUP_NONE) end end) end
+function MODULE:PhysgunDrop(client, entity)
+    if entity:isProp() and entity:isItem() then
+        timer.Simple(5, function()
+            if IsValid(entity) and entity:GetCollisionGroup() == COLLISION_GROUP_PASSABLE_DOOR then entity:SetCollisionGroup(COLLISION_GROUP_NONE) end
+        end)
+    end
+    lia.log.add(client, "physgunDrop", entity:GetClass(), entity:GetModel())
 end
 
 function MODULE:OnPhysgunFreeze(_, physObj, entity, client)
@@ -200,6 +208,7 @@ function MODULE:OnPhysgunFreeze(_, physObj, entity, client)
     else
         entity:SetCollisionGroup(COLLISION_GROUP_NONE)
     end
+    lia.log.add(client, "physgunFreeze", entity:GetClass(), entity:GetModel())
     return true
 end
 


### PR DESCRIPTION
## Summary
- log physgun interactions and vehicle entry/exit with model details
- record these events in the logger library

## Testing
- `luacheck modules/administration/submodules/logging/logs.lua modules/protection/libraries/server.lua --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`
- `luacheck . --exclude-files luacheck/** --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686a224aebac8327a3052208b9e16993