### PR TITLE
Fix meta docs formatting

### DIFF
--- a/docs/docs/meta/gridinv.md
+++ b/docs/docs/meta/gridinv.md
@@ -8,6 +8,7 @@ Grid-based inventories extend the base inventory class with slot-based item plac
 
 A `GridInv` instance stores items in a 2D grid, requiring items to fit within its width and height. It provides logic for finding free positions, transferring items, and updating ownership information.
 
+---
 ### getWidth
 
 **Purpose**

--- a/docs/docs/meta/item.md
+++ b/docs/docs/meta/item.md
@@ -8,6 +8,7 @@ Item objects represent things found in inventories or spawned in the world. This
 
 Item meta functions cover stack counts, categories, weight calculations, and network variables. Items are objects that can exist in inventories or the world, and item instances clone the base properties defined by the item table. These helpers enable consistent interaction across trading, crafting, and interface components.
 
+---
 ### getQuantity
 
 **Purpose**
@@ -1197,3 +1198,5 @@ Processes an interaction action performed by `client` on this item.
 -- Trigger the "use" interaction from code
 item:interact("use", client, nil)
 ```
+
+---


### PR DESCRIPTION
## Summary
- add missing section separators in `gridinv.md` and `item.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a2529fc9c83279f6816445f9f5386