### PR TITLE
Update library documentation

### DIFF
--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -16,6 +16,12 @@ localized phrases. Loaded phrases are stored in `lia.lang.stored` while display
 
 names are kept in `lia.lang.names`.
 
+### Fields
+
+* **lia.lang.names** (table) – Maps language identifiers to display names.
+* **lia.lang.stored** (table) – Holds phrase tables for each language.
+
+
 ---
 
 ### lia.lang.loadFromDir

--- a/docs/docs/libraries/lia.logger.md
+++ b/docs/docs/libraries/lia.logger.md
@@ -27,6 +27,7 @@ registered with `lia.log.addType`.
   `lia.log.convertToDatabase` is running. The server blocks player connections
 
   during this time.
+* **lia.log.types** (table) – Registry of log types added with `lia.log.addType`.
 
 ---
 

--- a/docs/docs/libraries/lia.markup.md
+++ b/docs/docs/libraries/lia.markup.md
@@ -53,6 +53,11 @@ Constructs an empty markup object. Usually returned by `lia.markup.parse`.
 **Returns**
 
 * `MarkupObject`: Newly constructed object with zero size.
+**Example**
+
+```lua
+local obj = lia.markup.MarkupObject:create()
+```
 
 ### MarkupObject Fields
 


### PR DESCRIPTION
## Summary
- document `lia.lang.names` and `lia.lang.stored` tables
- mention `lia.log.types` registry
- add an example for `MarkupObject:create`

## Testing
- `mkdocs build -f docs/mkdocs.yml` *(fails: command not found)*
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a251a8a488327ab13770a396d01ba