### PR TITLE
Improve library docs

### DIFF
--- a/docs/docs/libraries/lia.attributes.md
+++ b/docs/docs/libraries/lia.attributes.md
@@ -22,6 +22,10 @@ invoked automatically when a module is initialized, so most schemas simply place
 
 their attribute files in `schema/attributes/`.
 
+### Fields
+
+* **lia.attribs.list** (table) – Table of attribute definitions indexed by ID.
+
 ---
 
 ### ATTRIBUTE table fields

--- a/docs/docs/libraries/lia.bars.md
+++ b/docs/docs/libraries/lia.bars.md
@@ -10,6 +10,12 @@ The bars library manages health, stamina, and other progress bars displayed on t
 
 Default health, armor and stamina bars are registered automatically when the client loads.
 
+### Fields
+
+* **lia.bar.list** (table) – Active bars sorted by priority.
+* **lia.bar.delta** (table) – Smoothed bar values for transitions.
+* **lia.bar.values** (table) – Last raw values returned by each bar.
+
 ### Bar Table Fields
 
 Each bar returned by `lia.bar.get` or inserted via `lia.bar.add` is a table with the following fields:

--- a/docs/docs/libraries/lia.character.md
+++ b/docs/docs/libraries/lia.character.md
@@ -8,6 +8,13 @@ This page covers utilities for manipulating character data.
 
 The character library handles creation and persistence of player characters. It manages character variables, interacts with the database, and offers helpers for retrieving characters by ID or SteamID. Because these functions directly modify stored data, use them carefully or you may corrupt character information.
 
+### Fields
+
+* **lia.char.loaded** (table) – Active character objects indexed by ID.
+* **lia.char.names** (table) – Map of character IDs to their names.
+* **lia.char.varHooks** (table) – Registered variable change hooks.
+* **lia.char.vars** (table) – Metadata definitions for character variables.
+
 ### lia.char.new
 
 **Description:**

--- a/docs/docs/libraries/lia.workshop.md
+++ b/docs/docs/libraries/lia.workshop.md
@@ -106,7 +106,5 @@ end)
 
 ### Console Commands
 
-`workshop_force_redownload` – clears the local queue and downloads all Workshop items again. Useful if a client
-
-needs to re-fetch content that may have been corrupted.
+`workshop_force_redownload` – clears the local queue and downloads all Workshop items again. Useful if a client needs to re-fetch content that may have been corrupted.
 


### PR DESCRIPTION
## Summary
- fix console command text for workshop docs
- document `lia.attribs.list` in attributes docs
- document bar list tables
- document character library tables

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686a2501f8f48327b736fcb28163ef55