### PR TITLE
Fix missing closing sections in hook docs

### DIFF
--- a/docs/docs/hooks/class_hooks.md
+++ b/docs/docs/hooks/class_hooks.md
@@ -51,6 +51,8 @@ function CLASS:OnCanBe(client)
     return false
 end
 ```
+
+---
 ---
 
 
@@ -203,3 +205,4 @@ function CLASS:OnTransferred(client, oldClass)
     char:setData("previousClass", oldClass)
 end
 ```
+---

--- a/docs/docs/hooks/faction_hooks.md
+++ b/docs/docs/hooks/faction_hooks.md
@@ -195,3 +195,4 @@ function FACTION:OnCheckLimitReached(character, client)
     return lia.faction.getPlayerCount(self.index) >= maxMembers
 end
 ```
+---


### PR DESCRIPTION
## Summary
- add missing closing separators for class and faction hook docs

## Testing
- `python scripts/reformat_meta.py --help` *(fails: FileNotFoundError --help)*

------
https://chatgpt.com/codex/tasks/task_e_686a24f94ad88327b9e19a953b14cf5a