### PR TITLE
Add missing library field docs

### DIFF
--- a/docs/docs/libraries/lia.classes.md
+++ b/docs/docs/libraries/lia.classes.md
@@ -10,6 +10,12 @@ The classes library loads Lua definitions that describe player classes. Classes 
 
 See [Class Fields](../definitions/class.md) for configurable `CLASS` properties and [Class Hooks](../hooks/class_hooks.md) for customization callbacks.
 
+### Fields
+
+* **lia.class.list** (table) – Holds all loaded class tables indexed by number.
+
+---
+
 ### lia.class.loadFromDir
 
 **Description:**

--- a/docs/docs/libraries/lia.color.md
+++ b/docs/docs/libraries/lia.color.md
@@ -8,6 +8,10 @@ This page lists helper functions for working with colors.
 
 The color library centralizes color utilities used throughout the UI. You can register reusable colors, adjust their channels to create variants, and fetch the main palette from the configuration. Many common color names are pre-registered and can be used with the global `Color()` function. Custom registrations are stored in `lia.color.stored`.
 
+### Fields
+
+* **lia.color.stored** (table) – Table of named colors referenced by `Color(name)`.
+
 ---
 
 ### lia.color.register
@@ -115,5 +119,19 @@ Builds a UI palette derived from the config's base color.
     local colors = lia.color.ReturnMainAdjustedColors()
     surface.SetDrawColor(colors.background)
 ```
+
+### Color(name)
+
+The global `Color()` function is overridden to accept a registered color name.
+Passing a string will look up the color in `lia.color.stored` and return a
+`Color` object. Unrecognized names default to white.
+
+**Realm:**
+
+* Shared
+
+**Returns:**
+
+* Color – The color object matching the name.
 
 

--- a/docs/docs/libraries/lia.commands.md
+++ b/docs/docs/libraries/lia.commands.md
@@ -8,6 +8,12 @@ This page documents command registration and execution.
 
 The commands library registers console and chat commands. It parses arguments, checks permissions, and routes the handlers for execution. Commands can be run via slash chat or the console and may be restricted to specific usergroups through a CAMI-compliant admin mod.
 
+### Fields
+
+* **lia.command.list** (table) – Lookup table of registered commands by name.
+
+---
+
 ### lia.command.add
 
 **Description:**

--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -8,6 +8,11 @@ This page explains how to add and access configuration settings.
 
 The config library stores server configuration values with descriptions and default settings. It also provides callbacks when values change so modules can react to new options.
 
+### Fields
+
+* **lia.config.stored** (table) – Table of registered configuration entries.
+* **lia.config.isConverting** (boolean) – Set while `lia.config.convertToDatabase` runs.
+
 ---
 
 ### lia.config.add

--- a/docs/docs/libraries/lia.darkrp.md
+++ b/docs/docs/libraries/lia.darkrp.md
@@ -16,6 +16,11 @@ global `DarkRP` table. A simplified `RPExtraTeams` table is created as well,
 
 mapping each faction to its team index for compatibility.
 
+### Fields
+
+* **DarkRP** (table) – Global table mirroring these helpers for compatibility.
+* **RPExtraTeams** (table) – List of factions indexed by team for DarkRP addons.
+
 ---
 
 

--- a/docs/docs/libraries/lia.data.md
+++ b/docs/docs/libraries/lia.data.md
@@ -8,6 +8,11 @@ This page describes persistent data storage helpers.
 
 The data library stores key/value pairs in the `lia_data` database table. Values are cached in memory inside `lia.data.stored` for quick access.
 
+### Fields
+
+* **lia.data.stored** (table) – Cached data loaded from the database.
+* **lia.data.isConverting** (boolean) – True while `lia.data.convertToDatabase` is running.
+
 ---
 
 


### PR DESCRIPTION
## Summary
- document global registries for classes, colors, commands, configs, DarkRP, and data libraries
- clarify that `Color()` accepts named colors

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_686a25079f1083279d4d1324fc1572d3