### PR TITLE
Add missing player meta docs

### DIFF
--- a/docs/docs/meta/player.md
+++ b/docs/docs/meta/player.md
@@ -702,6 +702,56 @@ Returns a hull trace in front of the player.
 local tr = player:getTrace(48)
 
 ```
+### GetEyeTrace
+
+**Purpose**
+
+Returns an eye trace from the player's view position. On the client this result is cached each frame.
+
+**Parameters**
+
+* `distance` (number|nil): Trace length in units, defaults to 32768.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+* table: Trace result.
+
+**Example**
+
+```lua
+local tr = player:GetEyeTrace(128)
+print("Hit entity:", tr.Entity)
+```
+---
+
+### GetEyeTraceNoCursor
+
+**Purpose**
+
+Performs an eye trace using the player's view angles instead of the cursor direction.
+
+**Parameters**
+
+* `distance` (number|nil): Trace length in units, defaults to 32768.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+* table: Trace result.
+
+**Example**
+
+```lua
+local tr = player:GetEyeTraceNoCursor()
+if tr.Hit then
+    print("Hit:", tr.Entity)
+end
+```
 ---
 
 ### getEyeEnt
@@ -2426,6 +2476,30 @@ player:setLocalVar("health", 75)
 ```
 ---
 
+### getLocalVar
+
+**Purpose**
+
+Retrieves a networked local variable stored on the player.
+
+**Parameters**
+
+* `key` (string): Variable name.
+* `default` (any): Value returned if not set.
+
+**Realm**
+`Shared`
+
+**Returns**
+
+* any: Stored value or default.
+
+**Example**
+
+```lua
+local stamina = player:getLocalVar("stamina", 0)
+```
+---
 ### getPlayTime
 
 **Purpose**


### PR DESCRIPTION
## Summary
- document `GetEyeTrace`, `GetEyeTraceNoCursor`, and `getLocalVar`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a252cf1c88327ada09003ab9e9a95