### PR TITLE
Fix docs formatting

### DIFF
--- a/docs/docs/libraries/lia.webimage.md
+++ b/docs/docs/libraries/lia.webimage.md
@@ -141,3 +141,4 @@ Shows a simple window for previewing any image URL. Useful for development.
 test_webimage_menu
 ```
 
+---

--- a/docs/docs/meta/entity.md
+++ b/docs/docs/meta/entity.md
@@ -630,20 +630,37 @@ Retrieves a stored network variable or a default value.
 
 **Returns**
 
-- nil
+- any: Stored value or the provided default.
 
 **Example**
 
+```lua
+local locked = ent:getNetVar("locked", false)
+```
 
 ---
-- Client
 
+### getNetVar
 
-Returns:
+**Purpose**
+Retrieves a network variable for this entity on the client.
+
+**Parameters**
+
+- `key` (`string`): Variable name.
+- `default` (`any`) – Default if not set.
+
+**Realm**
+`Client`
+
+**Returns**
+
 - any: Stored value or default.
-Example Usage:
+
+**Example**
+
 ```lua
--- Retrieve the stored variable or fallback to the default
+-- Access a synced variable on the client side
 local result = ent:getNetVar(key, default)
 ```
 
@@ -700,33 +717,6 @@ if IsValid(partner) then
 end
 ```
 
----
-
-### getNetVar
-
-**Purpose**
-Retrieves a network variable for this entity on the client.
-
-**Parameters**
-
-- `key` (`string`): Variable name.
-- `default` (`any`) – Default if not set.
-
-**Realm**
-`Client`
-
-**Returns**
-
-- any: Stored value or default.
-
-**Example**
-
-```lua
--- Access a synced variable on the client side
-local result = ent:getNetVar(key, default)
-```
-
----
 
 ### getParts
 


### PR DESCRIPTION
## Summary
- add missing closing delimiter to the webimage library page
- fix duplicated/missing content for `getNetVar` in entity meta docs

## Testing
- `python3 scripts/reformat_meta.py docs/docs/meta/entity.md docs/docs/meta/character.md docs/docs/meta/vector.md docs/docs/libraries/lia.webimage.md`

------
https://chatgpt.com/codex/tasks/task_e_686a252630b88327856821bf39f547dd