### PR TITLE
Move compatibility log types

### DIFF
--- a/gamemode/core/libraries/compatibility/advdupe.lua
+++ b/gamemode/core/libraries/compatibility/advdupe.lua
@@ -1,4 +1,16 @@
-﻿local function CheckDuplicationScale(client, entities)
+if SERVER and not lia.log.types["dupeCrashAttempt"] then
+    lia.log.addType(
+        "dupeCrashAttempt",
+        function(client)
+            local name = IsValid(client) and client:Name() or L("unknown")
+            local steamID = IsValid(client) and client:SteamID64() or L("na")
+            return string.format("Player '%s' [%s] attempted to duplicate oversized entities.", name, steamID)
+        end,
+        "Security"
+    )
+end
+
+local function CheckDuplicationScale(client, entities)
     entities = entities or {}
     for _, ent in pairs(entities) do
         if ent.ModelScale and ent.ModelScale > 10 then

--- a/gamemode/core/libraries/compatibility/advdupe2.lua
+++ b/gamemode/core/libraries/compatibility/advdupe2.lua
@@ -1,4 +1,16 @@
-﻿local function CheckDuplicationScale(client, entities)
+if SERVER and not lia.log.types["dupeCrashAttempt"] then
+    lia.log.addType(
+        "dupeCrashAttempt",
+        function(client)
+            local name = IsValid(client) and client:Name() or L("unknown")
+            local steamID = IsValid(client) and client:SteamID64() or L("na")
+            return string.format("Player '%s' [%s] attempted to duplicate oversized entities.", name, steamID)
+        end,
+        "Security"
+    )
+end
+
+local function CheckDuplicationScale(client, entities)
     entities = entities or {}
     for _, ent in pairs(entities) do
         if ent.ModelScale and ent.ModelScale > 10 then

--- a/gamemode/core/libraries/compatibility/permaprops.lua
+++ b/gamemode/core/libraries/compatibility/permaprops.lua
@@ -1,3 +1,24 @@
+if SERVER then
+    if not lia.log.types["permaPropSaved"] then
+        lia.log.addType(
+            "permaPropSaved",
+            function(client, class, model, pos)
+                return string.format("%s perma-propped %s (%s) at %s", client:Name(), class, model, pos)
+            end,
+            "PermaProps"
+        )
+    end
+    if not lia.log.types["permaPropOverlap"] then
+        lia.log.addType(
+            "permaPropOverlap",
+            function(_, pos, other)
+                return string.format("Perma-prop spawned at %s overlapping prop at %s.", pos, other)
+            end,
+            "PermaProps"
+        )
+    end
+end
+
 hook.Add("CanTool", "liaPermaProps", function(client, _, tool)
     local entity = client:getTracedEntity()
     local entClass = entity:GetClass()

--- a/gamemode/core/libraries/compatibility/vjbase.lua
+++ b/gamemode/core/libraries/compatibility/vjbase.lua
@@ -1,4 +1,14 @@
-﻿local exploitable_nets = {"VJSay", "vj_fireplace_turnon1", "vj_npcmover_sv_create", "vj_npcmover_sv_startmove", "vj_npcmover_removesingle", "vj_npcmover_removeall", "vj_npcspawner_sv_create", "vj_npcrelationship_sr_leftclick", "vj_testentity_runtextsd", "vj_fireplace_turnon2",}
+if SERVER and not lia.log.types["unprotectedVJNetCall"] then
+    lia.log.addType(
+        "unprotectedVJNetCall",
+        function(client, netMessage)
+            return string.format("%s triggered unprotected net message '%s'", client:Name(), netMessage)
+        end,
+        "VJ Base"
+    )
+end
+
+local exploitable_nets = {"VJSay", "vj_fireplace_turnon1", "vj_npcmover_sv_create", "vj_npcmover_sv_startmove", "vj_npcmover_removesingle", "vj_npcmover_removeall", "vj_npcspawner_sv_create", "vj_npcrelationship_sr_leftclick", "vj_testentity_runtextsd", "vj_fireplace_turnon2",}
 local function handle_exploitable_net(client, name)
     if not IsValid(client) or not client:IsPlayer() then return end
     client:ChatPrint(L("unauthorizedNetMessage", name))

--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -244,14 +244,6 @@
         end,
         category = "Connections"
     },
-    ["dupeCrashAttempt"] = {
-        func = function(client)
-            local name = IsValid(client) and client:Name() or L("unknown")
-            local steamID = IsValid(client) and client:SteamID64() or L("na")
-            return string.format("Player '%s' [%s] attempted to duplicate oversized entities.", name, steamID)
-        end,
-        category = "Security"
-    },
     ["doorSetClass"] = {
         func = function(client, door, className) return string.format("%s set door class to %s on door %s.", client:Name(), className, door:GetClass()) end,
         category = "Doors"
@@ -741,19 +733,5 @@
             return string.format("Admin '%s' closed a ticket for %s. Total claims: %d.", client:Name(), requester, count or 0)
         end,
         category = "Tickets"
-    },
-    ["unprotectedVJNetCall"] = {
-        func = function(client, netMessage) return string.format("%s triggered unprotected net message '%s'", client:Name(), netMessage) end,
-        category = "VJ Base"
-    },
-    ["permaPropSaved"] = {
-        func = function(client, class, model, pos)
-            return string.format("%s perma-propped %s (%s) at %s", client:Name(), class, model, pos)
-        end,
-        category = "PermaProps"
-    },
-    ["permaPropOverlap"] = {
-        func = function(_, pos, other) return string.format("Perma-prop spawned at %s overlapping prop at %s.", pos, other) end,
-        category = "PermaProps"
     },
 }


### PR DESCRIPTION
## Summary
- shift compatibility log type definitions out of the logging module
- register log types inside their respective compatibility files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a3a727830832786cf4fa97d6e86b1