### PR TITLE
Fix lia.bar.drawBar width doc

### DIFF
--- a/docs/docs/libraries/lia.bars.md
+++ b/docs/docs/libraries/lia.bars.md
@@ -123,7 +123,7 @@ Draws a single horizontal bar at the specified screen coordinates, filling it pr
 
 * `y` (*number*): The y-coordinate of the bar’s top-left corner.
 
-* `w` (*number*): Total width of the bar (including padding).
+* `w` (*number*): Width of the bar's fill area (padding of 3px is added on each side).
 
 * `h` (*number*): Total height of the bar.
 


### PR DESCRIPTION
## Summary
- clarify that `w` in `lia.bar.drawBar` is the width of the fill area and padding is added automatically

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d6d8d88832786ae75af54803a05