### PR TITLE
Update color docs

### DIFF
--- a/docs/docs/libraries/lia.color.md
+++ b/docs/docs/libraries/lia.color.md
@@ -20,7 +20,7 @@ Registers a named color for later lookup or use with `Color(name)`.
 
 * `name` (*string*): Key used to reference the color.
 
-* `color` (*Color | table*): Color object or `{ r, g, b }` table.
+* `color` (*Color | table*): Color object or `{ r, g, b }` table with the channel values in order.
 
 **Realm**
 
@@ -111,6 +111,7 @@ The global `Color()` function is overridden to accept a registered color name. P
 **Parameters**
 
 * `name` (*string*): Registered color name.
+* `alpha` (*number | nil*): Optional alpha override when creating the color. Defaults to `255` if omitted.
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- document optional alpha parameter for `Color(name)`
- clarify `lia.color.register` table format

## Testing
- `luacheck gamemode/core/libraries/color.lua docs/docs/libraries/lia.color.md --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`


------
https://chatgpt.com/codex/tasks/task_e_686b2d6323308327a89ed1725aeaadfd