### PR TITLE
Fix config docs

### DIFF
--- a/docs/docs/libraries/lia.config.md
+++ b/docs/docs/libraries/lia.config.md
@@ -14,7 +14,7 @@ The config library stores server configuration values with descriptions and defa
 
 **Purpose**
 
-Registers a new config option with the given key, display name, default value, and optional callback or data.
+Registers a new config option with the given key, display name, default value, and optional callback. A data table describing the option is **required**.
 
 **Parameters**
 
@@ -26,7 +26,7 @@ Registers a new config option with the given key, display name, default value, a
 
 * `callback` (*function*): Function run when the value changes. *Optional*.
 
-* `data` (*table*): Additional fields such as `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`.
+* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`.
 
 **Realm**
 
@@ -290,6 +290,7 @@ Migrates legacy config files from `data/lilia` into the `lia_config` SQL table. 
 **Parameters**
 
 * `changeMap` (*boolean*): Whether to reload the map after conversion completes.
+* `data` (*table*): Legacy config key-value pairs to import. Defaults to reading from disk. *Optional*.
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- clarify that `lia.config.add` requires a data table
- document the optional `data` parameter for `lia.config.convertToDatabase`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2d5e81f08327a1c8e1231f08e88f