### PR TITLE
Fix docs for lia.darkrp.notify parameters

### DIFF
--- a/docs/docs/libraries/lia.darkrp.md
+++ b/docs/docs/libraries/lia.darkrp.md
@@ -79,11 +79,15 @@ local spawn = lia.darkrp.findEmptyPos(ply:GetPos(), { ply }, 128, 16, Vector(0, 
 
 **Purpose**
 
-Sends a notification to the specified client. The second and third parameters exist only for DarkRP compatibility and are ignored.
+Sends a notification to the specified client. The second and third parameters mirror the DarkRP API but are ignored by this implementation.
 
 **Parameters**
 
 * `client` (*Player*): Player to receive the message.
+
+* `type` (*number*): DarkRP notification type. *Ignored.*
+
+* `length` (*number*): Display time in seconds. *Ignored.*
 
 * `message` (*string*): Text of the notification.
 


### PR DESCRIPTION
## Summary
- document the `type` and `length` parameters for `lia.darkrp.notify` to match the Lua implementation

## Testing
- `python3 scripts/reformat_meta.py`

------
https://chatgpt.com/codex/tasks/task_e_686b2d58c08483279793c4b811d46141