### PR TITLE
Update faction doc for default class parameter

### DIFF
--- a/docs/docs/libraries/lia.factions.md
+++ b/docs/docs/libraries/lia.factions.md
@@ -321,7 +321,7 @@ Finds the first class marked as default for the given faction.
 
 **Parameters**
 
-* `id` (*string*): Faction unique ID.
+* `id` (*number*): Faction index.
 
 **Realm**
 
@@ -334,7 +334,7 @@ Finds the first class marked as default for the given faction.
 **Example**
 
 ```lua
-local defaultClass = lia.faction.getDefaultClass("citizen")
+local defaultClass = lia.faction.getDefaultClass(FACTION_CITIZEN)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix the parameter type for `lia.faction.getDefaultClass`
- update the example to use the faction index constant

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2d517ac083278c607df9d007b399