### PR TITLE
Fix inventory cleanup parameter in docs

### DIFF
--- a/docs/docs/libraries/lia.inventory.md
+++ b/docs/docs/libraries/lia.inventory.md
@@ -227,7 +227,7 @@ Destroys every inventory associated with a character.
 
 **Parameters**
 
-* `character` (*Player*): Character entity or table.
+* `character` (*table*): Character object (e.g. from `client:getChar()`).
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- correct the parameter type for `cleanUpForCharacter`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d4a624083278f783234ef10d39b