### PR TITLE
Fix keybind documentation

### DIFF
--- a/docs/docs/libraries/lia.keybind.md
+++ b/docs/docs/libraries/lia.keybind.md
@@ -89,7 +89,7 @@ print("Inventory key:", input.GetKeyName(invKey))
 
 **Purpose**
 
-Writes all current keybinds to `data/lilia/keybinds/<gamemode>/<server-ip>.json`.
+Writes all current keybinds to `data/lilia/keybinds/<gamemode>/<server-ip>.txt` (stored as JSON).
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- clarify file extension used when saving keybinds

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d418b9083279507c7e432eb3955