### PR TITLE
Fix util canFit docs

### DIFF
--- a/docs/docs/libraries/lia.util.md
+++ b/docs/docs/libraries/lia.util.md
@@ -318,9 +318,9 @@ Checks if a hull fits at a position without intersecting obstacles.
 
 * `pos` (*Vector*): Test position.
 
-* `mins` (*Vector*): Hull mins (default `Vector(-16, -16, 0)`).
+* `mins` (*Vector*): Hull mins (default `Vector(16, 16, 0)`).
 
-* `maxs` (*Vector*): Hull maxs (default `Vector(16, 16, 72)`).
+* `maxs` (*Vector*): Hull maxs (default same as `mins`).
 
 * `filter` (*table | Entity | function*): Trace filter.
 


### PR DESCRIPTION
## Summary
- correct default parameter descriptions for `lia.util.canFit`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b2d24e758832799631037be3aace6