### PR TITLE
Fix option library docs

### DIFF
--- a/docs/docs/libraries/lia.option.md
+++ b/docs/docs/libraries/lia.option.md
@@ -46,7 +46,7 @@ Registers a configurable option that can be networked.
 
 * `default` (*any*): Default value.
 
-* `callback` (*function*): Runs on change.
+* `callback` (*function | nil*): Runs on change. Optional.
 
 * `data` (*table*): Extra option data.
 


### PR DESCRIPTION
## Summary
- clarify that `callback` is optional in `lia.option.add`

## Testing
- `python3 scripts/reformat_meta.py --help` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d29be848327bac1c2d249d3393a