### PR TITLE
Fix whitelist data retrieval

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -481,7 +481,10 @@ if SERVER then
 
     function playerMeta:getLiliaData(key, default)
         local data = self.liaData and self.liaData[key]
-        return data and default or data
+        if data == nil then
+            return default
+        end
+        return data
     end
 
     playerMeta.getData = playerMeta.getLiliaData


### PR DESCRIPTION
## Summary
- fix return value of `getLiliaData`

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dccee9cb08327b049cd8b12161918