### PR TITLE
Fix derma preview translation formatting

### DIFF
--- a/gamemode/core/derma/skin.lua
+++ b/gamemode/core/derma/skin.lua
@@ -406,12 +406,12 @@ concommand.Add("open_derma_preview", function()
         list:SetTall(80)
         list:EnableVerticalScrollbar()
         list:SetPadding(5)
-        for i = 1, 10 do
-            local item = vgui.Create("DLabel")
-            item:SetText(string.format(L("itemLabel"), i))
-            item:SizeToContents()
-            list:AddItem(item)
-        end
+            for i = 1, 10 do
+                local item = vgui.Create("DLabel")
+                item:SetText(L("itemLabel", i))
+                item:SizeToContents()
+                list:AddItem(item)
+            end
         return list
     end)
 
@@ -438,7 +438,7 @@ concommand.Add("open_derma_preview", function()
         subScroll:SetTall(100)
         for i = 1, 20 do
             local line = subScroll:Add("DLabel")
-            line:SetText(string.format(L("lineLabel"), i))
+            line:SetText(L("lineLabel", i))
             line:Dock(TOP)
             line:DockMargin(0, 0, 0, 5)
         end


### PR DESCRIPTION
## Summary
- fix translation formatting in `skin.lua` so preview uses L function correctly

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_686dcd2414c88327b5edf4b21fb9dde4