### PR TITLE
Add scoreboard model customization hook

### DIFF
--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -434,6 +434,35 @@ end)
 
 ---
 
+### ModifyScoreboardModel
+
+**Purpose**
+Allows modules to customize the model entity displayed for scoreboard entries. This can be used to attach props or tweak bodygroups.
+
+**Parameters**
+
+- `entity` (`Entity`): Model entity being shown.
+- `player` (`Player`): Player this entry represents.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+-- Give everyone a cone hat on the scoreboard.
+hook.Add("ModifyScoreboardModel", "ConeHat", function(ent, ply)
+    local hat = ClientsideModel("models/props_junk/TrafficCone001a.mdl")
+    hat:SetParent(ent)
+    hat:AddEffects(EF_BONEMERGE)
+end)
+```
+
+---
+
 ### GetDisplayedDescription
 
 **Purpose**

--- a/gamemode/core/derma/panels/scoreboard.lua
+++ b/gamemode/core/derma/panels/scoreboard.lua
@@ -261,6 +261,8 @@ function PANEL:addPlayer(ply, parent)
         for i in ipairs(ply:GetMaterials()) do
             slot.model.Entity:SetSubMaterial(i - 1, ply:GetSubMaterial(i - 1))
         end
+
+        hook.Run("ModifyScoreboardModel", slot.model.Entity, ply)
     end)
 
     slot.name = vgui.Create("DLabel", slot)
@@ -357,6 +359,7 @@ function PANEL:addPlayer(ply, parent)
                 slot.model.Entity:SetBodygroup(bg.id, ply:GetBodygroup(bg.id))
             end
 
+            hook.Run("ModifyScoreboardModel", slot.model.Entity, ply)
             self.lastModel, self.lastSkin = mdl, sk
         end
 


### PR DESCRIPTION
## Summary
- allow editing scoreboard avatar models
- document `ModifyScoreboardModel` hook

## Testing
- `python3 scripts/reformat_meta.py docs/docs/hooks/gamemode_hooks.md`

------
https://chatgpt.com/codex/tasks/task_e_686dd71754a48327b4a6ad3b8137fe29