### PR TITLE
Fix flag commands category

### DIFF
--- a/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/modules/administration/submodules/adminstick/libraries/client.lua
@@ -320,7 +320,8 @@ end
 local function IncludeFlagManagement(tgt, menu, stores)
     local cl = LocalPlayer()
     if not cl:hasPrivilege("Commands - Manage Flags") then return end
-    local fm = GetOrCreateSubMenu(menu, "flagsManagement", stores)
+    local charMenu = GetOrCreateSubMenu(menu, "characterManagement", stores)
+    local fm = GetOrCreateSubMenu(charMenu, "flagsManagement", stores)
     local give = GetOrCreateSubMenu(fm, "giveFlagsMenu", stores)
     local take = GetOrCreateSubMenu(fm, "takeFlagsMenu", stores)
     local toGive, toTake = {}, {}

--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -349,7 +349,7 @@ lia.command.add("flaggiveall", {
     AdminStick = {
         Name = "adminStickGiveAllFlagsName",
         Category = "characterManagement",
-        SubCategory = "adminStickSubCategorySetInfos",
+        SubCategory = "flagsManagement",
         Icon = "icon16/flag_blue.png"
     },
     onRun = function(client, arguments)
@@ -377,7 +377,7 @@ lia.command.add("flagtakeall", {
     AdminStick = {
         Name = "adminStickTakeAllFlagsName",
         Category = "characterManagement",
-        SubCategory = "adminStickSubCategorySetInfos",
+        SubCategory = "flagsManagement",
         Icon = "icon16/flag_green.png"
     },
     onRun = function(client, arguments)


### PR DESCRIPTION
## Summary
- move flag management submenu under Character Management
- keep `flaggiveall` and `flagtakeall` in the nested menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686dd8d4b7288327b6dc17de32f8553d