### PR TITLE
Add hook for customizing player model on load

### DIFF
--- a/docs/docs/hooks/gamemode_hooks.md
+++ b/docs/docs/hooks/gamemode_hooks.md
@@ -6326,6 +6326,35 @@ end)
 
 ---
 
+### SetupPlayerModel
+
+**Purpose**
+Lets modules modify player models after the base model, skin and bodygroups are applied. The hook is fired serverside when a character loads and clientside when the main menu spawns its preview model.
+
+**Parameters**
+
+- `ent` (`Entity`): Player or menu model entity being initialized.
+- `character` (`table|nil`): Active character table if available.
+
+**Realm**
+`Shared`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+-- Adds extra parts once the player's model is ready
+hook.Add("SetupPlayerModel", "ApplyParts", function(ent, char)
+    if ent.addPart then
+        ent:addPart("custom_hat")
+    end
+end)
+```
+
+---
+
 ### PlayerUseDoor
 
 **Purpose**

--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -502,6 +502,7 @@ function PANEL:updateModelEntity(character)
         local groups = character:getData("groups", {})
         if groups[i] then self.modelEntity:SetBodygroup(i, groups[i]) end
     end
+    hook.Run("SetupPlayerModel", self.modelEntity, character)
 
     local pos, ang = hook.Run("GetMainMenuPosition", character)
     if not pos or not ang then

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -376,6 +376,7 @@ if SERVER then
             end
 
             client:SetSkin(self:getData("skin", 0))
+            hook.Run("SetupPlayerModel", client, self)
             if not noNetworking then
                 for _, v in ipairs(self:getInv(true)) do
                     if istable(v) then v:sync(client) end


### PR DESCRIPTION
## Summary
- allow modules to modify the player entity model when a character is loaded
- invoke `SetupPlayerModel` in the main menu preview panel
- document the new shared hook parameters

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y luarocks`
- `luarocks install luacheck`
- `luacheck .` *(fails: 9881 warnings / 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dd776d26c8327b76af151d6a95f2d