### PR TITLE
Fix null entity error in permaprops

### DIFF
--- a/gamemode/core/libraries/compatibility/permaprops.lua
+++ b/gamemode/core/libraries/compatibility/permaprops.lua
@@ -5,8 +5,12 @@ local radiusSqr = 16
 local lastSaver
 hook.Add("CanTool", "liaPermaProps", function(client, _, tool)
     local entity = client:getTracedEntity()
+    if not IsValid(entity) then
+        return
+    end
+
     local entClass = entity:GetClass()
-    if IsValid(entity) and tool == "permaprops" and hook.Run("CanPersistEntity", entity) ~= false and (string.StartWith(entClass, "lia_") or entity:isLiliaPersistent() or entity:CreatedByMap()) then
+    if tool == "permaprops" and hook.Run("CanPersistEntity", entity) ~= false and (string.StartWith(entClass, "lia_") or entity:isLiliaPersistent() or entity:CreatedByMap()) then
         client:notifyLocalized("toolCantUseEntity", tool)
         return false
     end


### PR DESCRIPTION
## Summary
- ensure `CanTool` handler checks entity validity before calling `GetClass`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dfe3c5af48327a471ba48b44bb506