### PR TITLE
Fix config reset on reload

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -368,6 +368,7 @@ end
 function GM:PreCleanupMap()
     lia.shuttingDown = true
     hook.Run("SaveData")
+    lia.config.save()
     hook.Run("PersistenceSave")
 end
 
@@ -381,6 +382,7 @@ function GM:ShutDown()
     if hook.Run("ShouldDataBeSaved") == false then return end
     lia.shuttingDown = true
     hook.Run("SaveData")
+    lia.config.save()
     for _, v in player.Iterator() do
         v:saveLiliaData()
         if v:getChar() then v:getChar():save() end


### PR DESCRIPTION
## Summary
- save config when the map cleans up or server shuts down

## Testing
- `luacheck gamemode/core/hooks/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4819242083279f99f3867412efac