### PR TITLE
Fix config sync on server reload

### DIFF
--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -528,6 +528,9 @@ end
 
 function GM:OnReloaded()
     lia.config.load()
+    if SERVER then
+        lia.config.send()
+    end
     lia.module.initialize()
     lia.faction.formatModelData()
     if CLIENT then
@@ -550,5 +553,4 @@ if #loadedCompatibility > 0 then
         L("compatibilityLoadedMultiple", table.concat(loadedCompatibility, ", "))
     lia.bootstrap("Compatibility", message)
 end
-
 if game.IsDedicated() then concommand.Remove("gm_save") end


### PR DESCRIPTION
## Summary
- send configuration data to all clients after server reload so they stay in sync

## Testing
- `luacheck gamemode/modules modules scripts`

------
https://chatgpt.com/codex/tasks/task_e_686e4a11f988832784d4f1d8de537b0d