### PR TITLE
Fix config sync

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -70,7 +70,7 @@ function lia.config.load()
     if SERVER then
         lia.db.waitForTablesToLoad():next(function()
             local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-            lia.db.select({"_key", "_value"}, "config", "_schema = " .. lia.db.convertDataType(schema)):next(function(res)
+            lia.db.select({"_key", "_value"}, "lia_config", "_schema = " .. lia.db.convertDataType(schema)):next(function(res)
                 local rows = res.results or {}
                 local existing = {}
                 if #rows == 0 then
@@ -106,7 +106,7 @@ function lia.config.load()
 
                 local finalize = function() hook.Run("InitializedConfig") end
                 if #inserts > 0 then
-                    lia.db.bulkInsert("config", inserts):next(finalize)
+                    lia.db.bulkInsert("lia_config", inserts):next(finalize)
                 else
                     finalize()
                 end

--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -514,11 +514,11 @@ end
 local hasInitializedModules = false
 function GM:Initialize()
     if engine.ActiveGamemode() == "lilia" then lia.error(L("noSchemaLoaded")) end
-    lia.config.load()
     if not hasInitializedModules then
         lia.module.initialize()
         hasInitializedModules = true
     end
+    lia.config.load()
 
     if CLIENT then
         lia.option.load()
@@ -527,8 +527,8 @@ function GM:Initialize()
 end
 
 function GM:OnReloaded()
-    lia.config.load()
     lia.module.initialize()
+    lia.config.load()
     lia.faction.formatModelData()
     if SERVER then
         lia.config.send()
@@ -550,5 +550,4 @@ if #loadedCompatibility > 0 then
     local message = #loadedCompatibility == 1 and L("compatibilityLoadedSingle", loadedCompatibility[1]) or L("compatibilityLoadedMultiple", table.concat(loadedCompatibility, ", "))
     lia.bootstrap("Compatibility", message)
 end
-
 if game.IsDedicated() then concommand.Remove("gm_save") end


### PR DESCRIPTION
## Summary
- load modules before loading config so module configs sync correctly
- sync config table name to `lia_config` so cfg changes persist

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e54ff967083278e5d0f7ab287e405