### PR TITLE
Fix third-person visibility flicker

### DIFF
--- a/gamemode/core/libraries/thirdperson.lua
+++ b/gamemode/core/libraries/thirdperson.lua
@@ -124,6 +124,7 @@ hook.Add("PrePlayerDraw", "liaThirdPersonPrePlayerDraw", function(drawnClient)
     end
 
     local filter = player.GetAll()
+    table.RemoveByValue(filter, drawnClient)
     local visible = false
     for _, boneName in ipairs(ImportantBones) do
         local boneIndex = drawnClient:LookupBone(boneName)


### PR DESCRIPTION
## Summary
- tweak trace filter so the drawn player is not ignored while other players are

## Testing
- `luacheck gamemode/core/libraries/thirdperson.lua`
- `python3 -m pip --version`


------
https://chatgpt.com/codex/tasks/task_e_686e62407d188327b14925102cc6c15c