### PR TITLE
Add flag for class invitations

### DIFF
--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -29,6 +29,7 @@ lia.flag.add("r", L("flagSpawnRagdolls"))
 lia.flag.add("e", L("flagSpawnProps"))
 lia.flag.add("n", L("flagSpawnNpcs"))
 lia.flag.add("Z", L("flagInviteToYourFaction"))
+lia.flag.add("X", L("flagInviteToYourClass"))
 lia.flag.add("p", L("flagPhysgun"), function(client, isGiven)
     if isGiven then
         client:Give("weapon_physgun")

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -355,6 +355,7 @@ LANGUAGE = {
     flagSpawnProps = "Gives Access to spawning props.",
     flagSpawnNpcs = "Gives Access to spawning NPCs.",
     flagInviteToYourFaction = "Gives Access to inviting to your faction.",
+    flagInviteToYourClass = "Gives Access to inviting to your class.",
     flagPhysgun = "Gives Access to Physgun.",
     flagToolgun = "Gives Access to Toolgun",
     classNoInfo = "Class information not found.",

--- a/modules/interactionmenu/libraries/shared.lua
+++ b/modules/interactionmenu/libraries/shared.lua
@@ -61,6 +61,7 @@ AddInteraction(L("inviteToClass"), {
         local cChar = client:getChar()
         local tChar = target:getChar()
         if not cChar or not tChar then return false end
+        if cChar:hasFlags("X") then return true end
         if cChar:getFaction() ~= tChar:getFaction() then return false end
         return hook.Run("CanInviteToClass", client, target) ~= false
     end,


### PR DESCRIPTION
## Summary
- create `flagInviteToYourClass` language entry
- register new `X` flag
- allow anyone with this flag to invite others to their class

## Testing
- `luacheck modules/interactionmenu/libraries/shared.lua gamemode/core/libraries/flags.lua gamemode/languages/english.lua --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_686f2a74eef883278fc92865b451e2ba