### PR TITLE
Move recognition data to new character var

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -378,6 +378,13 @@ lia.char.registerVar("attribs", {
     shouldDisplay = function() return table.Count(lia.attribs.list) > 0 end
 })
 
+lia.char.registerVar("recognition", {
+    field = "recognition",
+    default = "",
+    isLocal = true,
+    noDisplay = true
+})
+
 lia.char.registerVar("RecognizedAs", {
     field = "recognized_as",
     default = {},
@@ -451,6 +458,7 @@ if SERVER then
             _steamID = data.steamID,
             _faction = data.faction or L("unknown"),
             _money = data.money,
+            recognition = data.recognition or "",
             recognized_as = "",
             _data = data.data
         }, function(_, charID)
@@ -515,6 +523,11 @@ if SERVER then
                     end
                 end
 
+                if charData.data and charData.data.rgn then
+                    charData.recognition = charData.data.rgn
+                    charData.data.rgn = nil
+                end
+
                 if not lia.faction.teams[charData.faction] then
                     local defaultFaction
                     for _, fac in pairs(lia.faction.teams) do
@@ -539,6 +552,9 @@ if SERVER then
 
                 characters[#characters + 1] = charId
                 local character = lia.char.new(charData, charId, client)
+                if charData.recognition then
+                    lia.char.setCharData(charId, "rgn", nil)
+                end
                 hook.Run("CharRestored", character)
                 character.vars.inv = {}
                 lia.inventory.loadAllFromCharID(charId):next(function(inventories)

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -330,6 +330,7 @@ function lia.db.loadTables()
                 _data VARCHAR,
                 _money VARCHAR,
                 _faction VARCHAR,
+                recognition TEXT NOT NULL DEFAULT '',
                 recognized_as TEXT NOT NULL DEFAULT ''
             );
 
@@ -407,6 +408,7 @@ function lia.db.loadTables()
                 `_data` VARCHAR(1024) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `_money` INT(10) UNSIGNED NULL DEFAULT '0',
                 `_faction` VARCHAR(255) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+                `recognition` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 `recognized_as` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_id`)
             );

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -138,13 +138,13 @@ if SERVER then
             id = character:getID()
         end
 
-        local recognized = self:getData("rgn", "")
+        local recognized = self:getRecognition()
         local nameList = self:getRecognizedAs()
         if name ~= nil then
             nameList[id] = name
             self:setRecognizedAs(nameList)
         else
-            self:setData("rgn", recognized .. "," .. id .. ",")
+            self:setRecognition(recognized .. "," .. id .. ",")
         end
         return true
     end

--- a/modules/recognition/libraries/shared.lua
+++ b/modules/recognition/libraries/shared.lua
@@ -8,7 +8,7 @@ end
 function MODULE:isCharRecognized(character, id)
     if not lia.config.get("RecognitionEnabled", true) then return true end
     local client = character:getPlayer()
-    local recognized = character:getData("rgn", "")
+    local recognized = character:getRecognition()
     local other = lia.char.loaded[id]
     local otherclient = other and other:getPlayer()
     if not IsValid(otherclient) then return false end


### PR DESCRIPTION
## Summary
- register new `recognition` character variable
- store recognition information in its own column
- migrate `rgn` data to the new variable when characters load
- update recognition checks to use the new variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f2d7ec25483278cca601590bbd2ec