### PR TITLE
Fix command syntax types

### DIFF
--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -261,7 +261,7 @@ lia.command.add("togglelockcharacters", {
     superAdminOnly = true,
     privilege = "Toggle Character Lock",
     desc = "toggleCharLockDesc",
-    syntax = "[boolean Lock]",
+    syntax = "",
     onRun = function()
         local newVal = not GetGlobalBool("characterSwapLock", false)
         SetGlobalBool("characterSwapLock", newVal)
@@ -838,7 +838,7 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = "Manage Items",
     desc = "giveItemDesc",
-    syntax = "[player Player Name] [item Item Name Or ID]",
+    syntax = "[player Player Name] [string Item Name or ID]",
     AdminStick = {
         Name = "adminStickGiveItemName",
         Category = "characterManagement",


### PR DESCRIPTION
## Summary
- update `chargiveitem` syntax to treat second argument as string
- remove unused boolean argument from `togglelockcharacters`

## Testing
- `luarocks install luacheck`
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_686f35fc95308327bf865d08c980f489