### PR TITLE
Move DB column migrations to loadTables

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -738,10 +738,6 @@ function GM:InitializedModules()
 end
 
 function GM:LiliaTablesLoaded()
-    local ignore = function() end
-    lia.db.query("ALTER TABLE IF EXISTS lia_players ADD COLUMN _firstJoin DATETIME"):catch(ignore)
-    lia.db.query("ALTER TABLE IF EXISTS lia_players ADD COLUMN _lastJoin DATETIME"):catch(ignore)
-    lia.db.query("ALTER TABLE IF EXISTS lia_items ADD COLUMN _quantity INTEGER"):catch(ignore)
     lia.db.addDatabaseFields()
 end
 

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -295,6 +295,11 @@ end
 
 function lia.db.loadTables()
     local function done()
+        local ignore = function() end
+        lia.db.query("ALTER TABLE IF EXISTS lia_players ADD COLUMN _firstJoin DATETIME"):catch(ignore)
+        lia.db.query("ALTER TABLE IF EXISTS lia_players ADD COLUMN _lastJoin DATETIME"):catch(ignore)
+        lia.db.query("ALTER TABLE IF EXISTS lia_items ADD COLUMN _quantity INTEGER"):catch(ignore)
+        lia.db.addDatabaseFields()
         lia.db.tablesLoaded = true
         hook.Run("LiliaTablesLoaded")
     end


### PR DESCRIPTION
## Summary
- ensure new database columns are added during table creation
- keep `GM:LiliaTablesLoaded` for character field updates only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f40179d0c83279784ec20e23a21c4