### PR TITLE
Fix trunk command

### DIFF
--- a/modules/inventory/submodules/storage/commands.lua
+++ b/modules/inventory/submodules/storage/commands.lua
@@ -31,7 +31,7 @@ lia.command.add("trunk", {
     desc = "trunkOpenDesc",
     onRun = function(client)
         local entity = client:getTracedEntity()
-        local maxDistance = 110
+        local maxDistance = 128
         local openTime = 0.7
         if not hook.Run("isSuitableForTrunk", entity) then
             client:notifyLocalized("notLookingAtVehicle")
@@ -50,6 +50,7 @@ lia.command.add("trunk", {
                 return
             end
 
+            entity.receivers = entity.receivers or {}
             entity.receivers[client] = true
             lia.inventory.instances[entity:getNetVar("inv")]:sync(client)
             net.Start("liaStorageOpen")


### PR DESCRIPTION
## Summary
- fix `trunk` command's receivers table
- allow using the trunk command from slightly farther away

## Testing
- `luacheck modules/inventory/submodules/storage/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_686f45fe3e7c832788b81ef8489fcd9a