### PR TITLE
Fix command prefix detection overriding commands as OOC

### DIFF
--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -17,7 +17,7 @@ function lia.chat.register(chatType, data)
                 lookup[prefix] = true
             end
             local noSlash = prefix:gsub("^/", "")
-            if noSlash ~= "" and not lookup[noSlash] then
+            if noSlash ~= "" and not lookup[noSlash] and noSlash:sub(1, 1) ~= "/" then
                 processed[#processed + 1] = noSlash
                 lookup[noSlash] = true
             end


### PR DESCRIPTION
## Summary
- prevent `lia.chat.register` from turning `//` into a single slash prefix
- this stops chat commands from being interpreted as out-of-character

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 0 warnings / 21 errors in 247 files)*

------
https://chatgpt.com/codex/tasks/task_e_686f493fd7448327b45a2bd7b954199f