### PR TITLE
Fix trunk inventory check

### DIFF
--- a/modules/inventory/submodules/storage/commands.lua
+++ b/modules/inventory/submodules/storage/commands.lua
@@ -52,7 +52,20 @@ lia.command.add("trunk", {
 
             entity.receivers = entity.receivers or {}
             entity.receivers[client] = true
-            lia.inventory.instances[entity:getNetVar("inv")]:sync(client)
+            local invID = entity:getNetVar("inv")
+            local inv = invID and lia.inventory.instances[invID]
+            if not inv then
+                MODULE:InitializeStorage(entity)
+                invID = entity:getNetVar("inv")
+                inv = invID and lia.inventory.instances[invID]
+            end
+            if not inv then
+                client:notifyLocalized("noInventory")
+                client.liaStorageEntity = nil
+                return
+            end
+
+            inv:sync(client)
             net.Start("liaStorageOpen")
             net.WriteBool(true)
             net.WriteEntity(entity)


### PR DESCRIPTION
## Summary
- prevent error when inventory is missing in the `/trunk` command
- initialize vehicle storage when no inventory exists

## Testing
- `luacheck modules/inventory/submodules/storage/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_686f4e535b0883279c73c71f1bfbdfc5