### PR TITLE
Allow addDatabaseFields to rerun

### DIFF
--- a/docs/docs/libraries/lia.database.md
+++ b/docs/docs/libraries/lia.database.md
@@ -371,7 +371,8 @@ end)
 **Purpose**
 
 Ensures every registered character variable has a matching column in the
-`lia_characters` table, adding any that are missing.
+`lia_characters` table, adding any that are missing. It can be invoked
+multiple times; existing columns will be ignored.
 
 **Parameters**
 

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -570,8 +570,7 @@ function lia.db.count(dbTable, condition)
 end
 
 function lia.db.addDatabaseFields()
-    if not DatabaseQueryRan then
-        local typeMap = {
+    local typeMap = {
             string = function(d) return ("%s VARCHAR(%d)"):format(d.field, d.length or 255) end,
             integer = function(d) return ("%s INT"):format(d.field) end,
             float = function(d) return ("%s FLOAT"):format(d.field) end,
@@ -580,36 +579,33 @@ function lia.db.addDatabaseFields()
             text = function(d) return ("%s TEXT"):format(d.field) end
         }
 
-        local dbModule = lia.db.module or "sqlite"
-        local getColumnsQuery = dbModule == "sqlite" and "SELECT sql FROM sqlite_master WHERE type='table' AND name='lia_characters'" or "DESCRIBE lia_characters"
-        lia.db.query(getColumnsQuery, function(results)
-            local existing = {}
-            if results and #results > 0 then
-                if dbModule == "sqlite" then
-                    local createSQL = results[1].sql or ""
-                    for def in createSQL:match("%((.+)%)"):gmatch("([^,]+)") do
-                        local col = def:match("^%s*`?(%w+)`?")
-                        if col then existing[col] = true end
-                    end
-                else
-                    for _, row in ipairs(results) do
-                        existing[row.Field] = true
-                    end
+    local dbModule = lia.db.module or "sqlite"
+    local getColumnsQuery = dbModule == "sqlite" and "SELECT sql FROM sqlite_master WHERE type='table' AND name='lia_characters'" or "DESCRIBE lia_characters"
+    lia.db.query(getColumnsQuery, function(results)
+        local existing = {}
+        if results and #results > 0 then
+            if dbModule == "sqlite" then
+                local createSQL = results[1].sql or ""
+                for def in createSQL:match("%((.+)%)"):gmatch("([^,]+)") do
+                    local col = def:match("^%s*`?(%w+)`?")
+                    if col then existing[col] = true end
+                end
+            else
+                for _, row in ipairs(results) do
+                    existing[row.Field] = true
                 end
             end
+        end
 
-            for _, v in pairs(lia.char.vars) do
-                if v.field and not existing[v.field] and typeMap[v.fieldType] then
-                    local colDef = typeMap[v.fieldType](v)
-                    if v.default ~= nil then colDef = colDef .. " DEFAULT '" .. tostring(v.default) .. "'" end
-                    local alter = ("ALTER TABLE lia_characters ADD COLUMN %s"):format(colDef)
-                    lia.db.query(alter, function() MsgC(Color(83, 143, 239), "[Lilia] ", Color(0, 255, 0), "[Database] ", Color(255, 255, 255), L("addedMissingColumn", v.field) .. "\n") end)
-                end
+        for _, v in pairs(lia.char.vars) do
+            if v.field and not existing[v.field] and typeMap[v.fieldType] then
+                local colDef = typeMap[v.fieldType](v)
+                if v.default ~= nil then colDef = colDef .. " DEFAULT '" .. tostring(v.default) .. "'" end
+                local alter = ("ALTER TABLE lia_characters ADD COLUMN %s"):format(colDef)
+                lia.db.query(alter, function() MsgC(Color(83, 143, 239), "[Lilia] ", Color(0, 255, 0), "[Database] ", Color(255, 255, 255), L("addedMissingColumn", v.field) .. "\n") end)
             end
-        end)
-
-        DatabaseQueryRan = true
-    end
+        end
+    end)
 end
 
 function lia.db.exists(dbTable, condition)


### PR DESCRIPTION
## Summary
- make `lia.db.addDatabaseFields` always check for columns
- update docs for `lia.db.addDatabaseFields`

## Testing
- `luacheck .` *(fails: 10082 warnings / 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f7b6c6f748327b487f3a403fc783c