### PR TITLE
Fix example links in item docs

### DIFF
--- a/docs/docs/definitions/items.md
+++ b/docs/docs/definitions/items.md
@@ -1165,7 +1165,7 @@ end)
 Minimal definitions for each built-in item type are shown below.
 
 
-### [Weapon](#)
+### [Weapon](../../../gamemode/items/weapons/smg1.txt)
 
 ```lua
 ITEM.name = "Sub Machine Gun"
@@ -1175,7 +1175,7 @@ ITEM.weaponCategory = "primary"
 ITEM.isWeapon = true
 ```
 
-### [Ammo](#)
+### [Ammo](../../../gamemode/items/ammo/pistolammo.txt)
 
 ```lua
 ITEM.name = "Pistol Ammo"
@@ -1184,7 +1184,7 @@ ITEM.ammo = "pistol"
 ITEM.ammoAmount = 30
 ```
 
-### [Outfit](#)
+### [Outfit](../../../gamemode/items/outfit/rebel_armor.txt)
 
 ```lua
 ITEM.name = "Combine Armor"
@@ -1194,7 +1194,7 @@ ITEM.replacements = "models/player/combine_soldier.mdl"
 ITEM.newSkin = 1
 ```
 
-### [PAC Outfit](#)
+### [PAC Outfit](../../../gamemode/items/pacoutfit/skullmask.txt)
 
 ```lua
 ITEM.name = "Skull Mask"
@@ -1202,7 +1202,7 @@ ITEM.outfitCategory = "hat"
 ITEM.pacData = { ... }
 ```
 
-### [Aid Item](#)
+### [Aid Item](../../../gamemode/items/aid/bandages.txt)
 
 ```lua
 ITEM.name = "Bandages"
@@ -1210,28 +1210,28 @@ ITEM.model = "models/weapons/w_package.mdl"
 ITEM.health = 50
 ```
 
-### [Book](#)
+### [Book](../../../gamemode/items/books/book.txt)
 
 ```lua
 ITEM.name = "Example"
 ITEM.contents = "<h1>An Example</h1>"
 ```
 
-### [URL Item](https://www.youtube.com/watch?v=9ezbBugUQiQ)
+### [URL Item](../../../gamemode/items/url/hi_barbie.txt)
 
 ```lua
 ITEM.name = "Hi Barbie"
 ITEM.url = "https://www.youtube.com/watch?v=9ezbBugUQiQ"
 ```
 
-### [Entity Spawner](#)
+### [Entity Spawner](../../../gamemode/items/entities/item_suit.txt)
 
 ```lua
 ITEM.name = "Item Suit"
 ITEM.entityid = "item_suit"
 ```
 
-### [Grenade](#)
+### [Grenade](../../../gamemode/items/grenade/weapon_frag.txt)
 
 ```lua
 ITEM.name = "Grenade"
@@ -1239,7 +1239,7 @@ ITEM.class = "weapon_frag"
 ITEM.DropOnDeath = true
 ```
 
-### [Bag](#)
+### [Bag](../../../modules/inventory/items/bags/small.txt)
 
 ```lua
 ITEM.name = "Small Bag"


### PR DESCRIPTION
## Summary
- link example item headings to the matching `.txt` sources

## Testing
- `python3 -m py_compile scripts/reformat_meta.py`


------
https://chatgpt.com/codex/tasks/task_e_686fa4cbf6f08327b5e1be4b21cd8a8d