### PR TITLE
Fix localization setup

### DIFF
--- a/docs/docs/libraries/lia.languages.md
+++ b/docs/docs/libraries/lia.languages.md
@@ -92,7 +92,7 @@ Returns the translated phrase for a key in the active language, using `string.fo
 **Example**
 
 ```lua
-print(L("Show All"))
+print(L("vendorShowAll"))
 ```
 
 ---

--- a/gamemode/core/libraries/languages.lua
+++ b/gamemode/core/libraries/languages.lua
@@ -1,4 +1,4 @@
-﻿lia.lang = lia.lang or {}
+lia.lang = lia.lang or {}
 lia.lang.names = lia.lang.names or {}
 lia.lang.stored = lia.lang.stored or {}
 function lia.lang.loadFromDir(directory)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1,4 +1,4 @@
-﻿NAME = "English"
+NAME = "English"
 LANGUAGE = {
     mustProvideString = "Must Provide a String",
     use = "Use",


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM from localization loader and English strings
- use a valid translation key in `lia.languages` docs

## Testing
- `python3 - <<'EOF'
import re
used=set()
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686fa7074e708327909826e35b9ef63f