### PR TITLE
Fix item load txt error to only fire externally

### DIFF
--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -141,7 +141,10 @@ function lia.item.load(path, baseID, isBaseItem)
         uniqueID = (isBaseItem and "base_" or "") .. uniqueID
         lia.item.register(uniqueID, baseID, isBaseItem, path)
     elseif path:find("%.txt$") then
-        lia.error("[Lilia] " .. L("textFileLuaRequired", path) .. "\n")
+        local formatted = path:gsub("\\", "/"):lower()
+        if not formatted:find("^lilia/") then
+            lia.error("[Lilia] " .. L("textFileLuaRequired", path) .. "\n")
+        end
     else
         lia.error("[Lilia] " .. L("invalidItemNaming", path) .. "\n")
     end


### PR DESCRIPTION
## Summary
- avoid lia.error on `.txt` items if they're within the `lilia` folder

## Testing
- `luacheck gamemode/core/libraries/item.lua --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_686fda8f8fd883278c26898c0b3fc148