### PR TITLE
Fix shadowed variable in keybind.lua

### DIFF
--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -428,9 +428,9 @@ lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
         local mdl = parent:Add("liaModelPanel")
         mdl:SetScaledSize(sizeX, sizeY)
         mdl:SetFOV(35)
-        local function getModel(mdl)
-            if isstring(mdl) then return mdl end
-            if istable(mdl) then
+        local function getModel(model)
+            if isstring(model) then return model end
+            if istable(model) then
                 local models = {}
                 local function gather(tbl)
                     for _, v in pairs(tbl) do
@@ -442,7 +442,7 @@ lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
                     end
                 end
 
-                gather(mdl)
+                gather(model)
                 if #models > 0 then return models[math.random(#models)] end
             end
         end


### PR DESCRIPTION
## Summary
- fix variable shadowing in `createModelPanel` helper

## Testing
- `luacheck gamemode/core/libraries/keybind.lua --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 21 errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687088e0c4808327ad1e0ec33840e0b8