### PR TITLE
Add schema preload module loading

### DIFF
--- a/docs/docs/feature_list.md
+++ b/docs/docs/feature_list.md
@@ -749,6 +749,7 @@ Hot-load modules and manage dependencies.
 - Hot-reload plugins without restarting the server
 
 - Ordered search for schema-specific modules
+- Preload modules loaded before framework modules
 
 - Automatically resolves dependencies between modules
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -157,6 +157,7 @@ Factions:  garrysmod/gamemodes/<SchemaName>/schema/factions/
 Classes:   garrysmod/gamemodes/<SchemaName>/schema/classes/
 Items:     garrysmod/gamemodes/<SchemaName>/schema/items/
 Modules:   garrysmod/gamemodes/<SchemaName>/modules/
+Preload:   garrysmod/gamemodes/<SchemaName>/preload/
 ```
 
 ---

--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -93,6 +93,7 @@ Finds and loads every module located in a directory.
 * `directory` (*string*): Path containing module folders or files.
 
 * `group` (*string*): Group identifier such as `"schema"` or `"module"` (default `"module"`).
+* `skip` (*table?, optional*): Module identifiers to skip while loading.
 
 **Realm**
 

--- a/docs/docs/libraries/lia.modularity.md
+++ b/docs/docs/libraries/lia.modularity.md
@@ -8,6 +8,8 @@ This page explains the module-loading system.
 
 The modularity library loads modules contained in the **`modules`** folder, resolves dependencies, and initialises both serverside and clientside components. During the process it fires the `DoModuleIncludes`, `InitializedSchema`, and `InitializedModules` hooks. See [Module Fields](../definitions/module.md) for the callbacks and options a module may define.
 
+Modules placed in a schema's `preload` directory are loaded **before** any framework modules. When a module with the same identifier exists in both `preload` and `lilia/modules`, the version inside `preload` takes priority and the framework copy is skipped.
+
 ---
 
 ### lia.module.load


### PR DESCRIPTION
## Summary
- add empty `preload` folder
- load schema `preload` modules before framework modules
- avoid loading framework modules if overridden in `preload`
- document the new preload directory

## Testing
- `luacheck gamemode/core/libraries/modularity.lua`
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_6871b040afac8327bc77dbacd9f9adb7