### PR TITLE
Add module disable reason support

### DIFF
--- a/documentation/documentation/documentation/definitions/module.md
+++ b/documentation/documentation/documentation/definitions/module.md
@@ -248,6 +248,9 @@ MODULE.Dependencies = {
 **Description:**
 
 Controls whether the module loads. Can be a static boolean or a function returning a boolean.
+When the function form is used, it may optionally return a second string
+explaining why the module is disabled. This message is displayed through
+`lia.bootstrap` when the loader skips the module.
 
 **Example Usage:**
 
@@ -258,6 +261,11 @@ MODULE.enabled = true
 -- Or evaluate a configuration value
 MODULE.enabled = function()
     return lia.config.get("EnableMyModule", true)
+end
+
+-- Provide a custom disable reason
+MODULE.enabled = function()
+    return false, "Disabled Temporarily"
 end
 ```
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -102,15 +102,19 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
         lia.include(coreFile, "shared")
     end
 
-    local enabled
+    local enabled, disableReason
     if isfunction(MODULE.enabled) then
-        enabled = MODULE.enabled()
+        enabled, disableReason = MODULE.enabled()
     else
         enabled = MODULE.enabled
     end
 
     if uniqueID ~= "schema" and not enabled then
-        lia.bootstrap("Module", L("moduleDisabled", MODULE.name))
+        if disableReason then
+            lia.bootstrap("Module", disableReason)
+        else
+            lia.bootstrap("Module", L("moduleDisabled", MODULE.name))
+        end
         lia.module.list[uniqueID] = nil
         _G[variable] = prev
         return


### PR DESCRIPTION
## Summary
- allow `MODULE.enabled` functions to return a disable reason
- document the new `enabled` behaviour

## Testing
- `luacheck .` *(fails: 10041 warnings / 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871fa1b72688327a624e0778f9eef20