### PR TITLE
Add single quote support for command args

### DIFF
--- a/documentation/documentation/libraries/lia.commands.md
+++ b/documentation/documentation/libraries/lia.commands.md
@@ -98,7 +98,7 @@ end)
 
 **Purpose**
 
-Splits the provided text into arguments, respecting quotes. Quoted sections are treated as single arguments.
+Splits the provided text into arguments, respecting quotes. Sections wrapped in either single (`'`) or double (`"`) quotes are treated as single arguments.
 
 **Parameters**
 
@@ -117,6 +117,9 @@ Splits the provided text into arguments, respecting quotes. Quoted sections are 
 ```lua
 local args = lia.command.extractArgs('/mycommand "quoted arg" anotherArg')
 -- args = { "quoted arg", "anotherArg" }
+
+local args2 = lia.command.extractArgs("/mycommand 'other arg' another")
+-- args2 = { "other arg", "another" }
 ```
 
 ---

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -82,7 +82,7 @@ function lia.command.extractArgs(text)
     for i = 1, #text do
         if i <= skip then continue end
         local c = text:sub(i, i)
-        if c == "\"" then
+        if c == "\"" or c == "'" then
             local match = text:sub(i):match("%b" .. c .. c)
             if match then
                 curString = ""


### PR DESCRIPTION
## Summary
- allow lia.command.extractArgs to parse single-quoted arguments
- document single quote support in commands library

## Testing
- `luacheck gamemode/core/libraries/commands.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_687203a1cdd883279abbfb889b24b752