### PR TITLE
Improve module disabled message

### DIFF
--- a/documentation/documentation/definitions/module.md
+++ b/documentation/documentation/definitions/module.md
@@ -251,6 +251,8 @@ Controls whether the module loads. Can be a static boolean or a function returni
 When the function form is used, it may optionally return a second string
 explaining why the module is disabled. This message is displayed through
 `lia.bootstrap` when the loader skips the module.
+When a module is disabled or skipped, you will see a console message in the format:
+`[Lilia] [Bootstrap] [Module Disabled/Skipped] <reason>`.
 
 **Example Usage:**
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -93,7 +93,7 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
         lia.include(path, "shared")
     else
         if not file.Exists(coreFile, "LUA") then
-            lia.bootstrap("Module", L("moduleSkipMissing", uniqueID, lowerVar))
+            lia.bootstrap("Module Skipped", L("moduleSkipMissing", uniqueID, lowerVar))
             _G[variable] = prev
             return
         end
@@ -110,9 +110,9 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
 
     if uniqueID ~= "schema" and not enabled then
         if disableReason then
-            lia.bootstrap("Module", disableReason)
+            lia.bootstrap("Module Disabled", disableReason)
         else
-            lia.bootstrap("Module", L("moduleDisabled", MODULE.name))
+            lia.bootstrap("Module Disabled", L("moduleDisabled", MODULE.name))
         end
         _G[variable] = prev
         return


### PR DESCRIPTION
## Summary
- clarify bootstrap output when modules are disabled or skipped
- document bootstrap format for skipped modules

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720382e41083278a5addb5015977fa