### PR TITLE
Switch docs deploy to modules.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,10 @@ jobs:
           token: ${{ secrets.LiliaGitSecret }}
       - name: Sync docs to site
         run: |
-          rsync -a --delete --exclude '.git*' lilia/documentation/ site/
+          rsync -a --delete --exclude '.git*' --exclude 'modules.md' lilia/documentation/ site/
+      - name: Fetch modules.json
+        run: |
+          curl -L -o site/modules.json https://raw.githubusercontent.com/LiliaFramework/Modules/refs/heads/gh-pages/modules.json
       - name: Generate version.json
         run: |
           cat > site/version.json <<EOF


### PR DESCRIPTION
## Summary
- adjust rsync to exclude `modules.md`
- fetch `modules.json` from Modules repo when deploying pages

## Testing
- `luacheck .` *(fails: 10038 warnings / 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687203ca837483278fa9d097b286318e