### PR TITLE
Add inviter permissions to factions and classes

### DIFF
--- a/documentation/docs/definitions/class.md
+++ b/documentation/docs/definitions/class.md
@@ -44,6 +44,7 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `index` | `number` | `auto` | Unique team index assigned at registration. |
 | `uniqueID` | `string` | `filename` | Optional identifier; defaults to the file name when omitted. |
 | `commands` | `table` | `{}` | Command names members may always use. |
+| `inviter` | `boolean` | `false` | Allows members of this class to invite others to join it. |
 
 ---
 
@@ -619,6 +620,22 @@ CLASS.commands = {
 }
 ```
 
+#### `inviter`
+
+**Type:**
+
+`boolean`
+
+**Description:**
+
+Whether members of this class can invite players to join this class.
+
+**Example Usage:**
+
+```lua
+CLASS.inviter = true
+```
+
 ---
 
 ## Complete Example
@@ -666,6 +683,7 @@ CLASS.bloodcolor = BLOOD_COLOR_RED
 CLASS.commands = {
     plytransfer = true
 }
+CLASS.inviter = true
 ```
 
 

--- a/documentation/docs/definitions/faction.md
+++ b/documentation/docs/definitions/faction.md
@@ -48,6 +48,7 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `isGloballyRecognized` | `boolean` | `false` | Everyone automatically recognizes this faction.
 | `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 | `commands` | `table` | `{}` | Command names members may always use. |
+| `inviter` | `boolean` | `false` | Allows members of this faction to invite players to it. |
 
 ---
 
@@ -657,6 +658,22 @@ FACTION.commands = {
 }
 ```
 
+#### `inviter`
+
+**Type:**
+
+`boolean`
+
+**Description:**
+
+Whether members of this faction can invite players to join the faction.
+
+**Example Usage:**
+
+```lua
+FACTION.inviter = true
+```
+
 ---
 
 ## Example Faction Definition
@@ -675,6 +692,7 @@ FACTION.models = {
 FACTION.prefix = "[CIT]"
 FACTION.weapons = {"weapon_radio"}
 FACTION.items = {"water"}
+FACTION.inviter = true
 FACTION.pay = 20
 FACTION.payTimer = 1800
 FACTION.health = 100

--- a/modules/interactionmenu/libraries/shared.lua
+++ b/modules/interactionmenu/libraries/shared.lua
@@ -62,6 +62,8 @@ AddInteraction(L("inviteToClass"), {
         local tChar = target:getChar()
         if not cChar or not tChar then return false end
         if cChar:hasFlags("X") then return true end
+        local classData = lia.class.list[cChar:getClass()]
+        if classData and classData.inviter then return true end
         if cChar:getFaction() ~= tChar:getFaction() then return false end
         return hook.Run("CanInviteToClass", client, target) ~= false
     end,
@@ -220,6 +222,8 @@ AddInteraction(L("inviteToFaction"), {
         local tChar = target:getChar()
         if not cChar or not tChar then return false end
         if cChar:hasFlags("Z") then return true end
+        local factionData = lia.faction.indices[cChar:getFaction()]
+        if factionData and factionData.inviter then return true end
         return hook.Run("CanInviteToFaction", client, target) ~= false and cChar:getFaction() ~= tChar:getFaction()
     end,
     onRun = function(client, target)


### PR DESCRIPTION
## Summary
- allow classes or factions to mark members as inviters
- document `CLASS.inviter` and `FACTION.inviter`

## Testing
- `luacheck modules/interactionmenu/libraries/shared.lua`

------
https://chatgpt.com/codex/tasks/task_e_68721d64d81883279dfbcbb858ae0a91