### PR TITLE
Update invitation controls

### DIFF
--- a/documentation/docs/definitions/class.md
+++ b/documentation/docs/definitions/class.md
@@ -44,7 +44,8 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `index` | `number` | `auto` | Unique team index assigned at registration. |
 | `uniqueID` | `string` | `filename` | Optional identifier; defaults to the file name when omitted. |
 | `commands` | `table` | `{}` | Command names members may always use. |
-| `inviter` | `boolean` | `false` | Allows members of this class to invite others to join it. |
+| `canInviteToFaction` | `boolean` | `false` | Allows members of this class to invite players to their faction. |
+| `canInviteToClass4` | `boolean` | `false` | Allows members of this class to invite others to their class. |
 
 ---
 
@@ -620,7 +621,25 @@ CLASS.commands = {
 }
 ```
 
-#### `inviter`
+#### `canInviteToFaction`
+
+**Type:**
+
+`boolean`
+
+**Description:**
+
+Whether members of this class can invite players to join their faction.
+
+**Example Usage:**
+
+```lua
+CLASS.canInviteToFaction = true
+```
+
+---
+
+#### `canInviteToClass4`
 
 **Type:**
 
@@ -633,7 +652,7 @@ Whether members of this class can invite players to join this class.
 **Example Usage:**
 
 ```lua
-CLASS.inviter = true
+CLASS.canInviteToClass4 = true
 ```
 
 ---
@@ -683,7 +702,8 @@ CLASS.bloodcolor = BLOOD_COLOR_RED
 CLASS.commands = {
     plytransfer = true
 }
-CLASS.inviter = true
+CLASS.canInviteToFaction = true
+CLASS.canInviteToClass4 = true
 ```
 
 

--- a/documentation/docs/definitions/faction.md
+++ b/documentation/docs/definitions/faction.md
@@ -48,7 +48,6 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `isGloballyRecognized` | `boolean` | `false` | Everyone automatically recognizes this faction.
 | `ScoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 | `commands` | `table` | `{}` | Command names members may always use. |
-| `inviter` | `boolean` | `false` | Allows members of this faction to invite players to it. |
 
 ---
 
@@ -658,23 +657,6 @@ FACTION.commands = {
 }
 ```
 
-#### `inviter`
-
-**Type:**
-
-`boolean`
-
-**Description:**
-
-Whether members of this faction can invite players to join the faction.
-
-**Example Usage:**
-
-```lua
-FACTION.inviter = true
-```
-
----
 
 ## Example Faction Definition
 
@@ -692,7 +674,6 @@ FACTION.models = {
 FACTION.prefix = "[CIT]"
 FACTION.weapons = {"weapon_radio"}
 FACTION.items = {"water"}
-FACTION.inviter = true
 FACTION.pay = 20
 FACTION.payTimer = 1800
 FACTION.health = 100

--- a/modules/interactionmenu/libraries/shared.lua
+++ b/modules/interactionmenu/libraries/shared.lua
@@ -63,7 +63,7 @@ AddInteraction(L("inviteToClass"), {
         if not cChar or not tChar then return false end
         if cChar:hasFlags("X") then return true end
         local classData = lia.class.list[cChar:getClass()]
-        if classData and classData.inviter then return true end
+        if classData and classData.canInviteToClass4 then return true end
         if cChar:getFaction() ~= tChar:getFaction() then return false end
         return hook.Run("CanInviteToClass", client, target) ~= false
     end,
@@ -222,8 +222,8 @@ AddInteraction(L("inviteToFaction"), {
         local tChar = target:getChar()
         if not cChar or not tChar then return false end
         if cChar:hasFlags("Z") then return true end
-        local factionData = lia.faction.indices[cChar:getFaction()]
-        if factionData and factionData.inviter then return true end
+        local classData = lia.class.list[cChar:getClass()]
+        if classData and classData.canInviteToFaction then return true end
         return hook.Run("CanInviteToFaction", client, target) ~= false and cChar:getFaction() ~= tChar:getFaction()
     end,
     onRun = function(client, target)


### PR DESCRIPTION
## Summary
- drop deprecated `inviter` field from faction and class docs
- add `canInviteToFaction` and `canInviteToClass4` to class docs
- adjust invite logic to use the new class fields

## Testing
- `luacheck modules/interactionmenu/libraries/shared.lua --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity`

------
https://chatgpt.com/codex/tasks/task_e_68724ebff27c8327b8bc97df3f5b19ab