### PR TITLE
Add admin panels to documentation

### DIFF
--- a/documentation/docs/definitions/panels.md
+++ b/documentation/docs/definitions/panels.md
@@ -60,6 +60,8 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 | `liaSmallButton` | `DButton` | Compact button for tight layouts. |
 | `liaMiniButton` | `DButton` | Very small button variant. |
 | `liaNoBGButton` | `DButton` | Text-only button with no background. |
+| `DAdminWorldMenu` | `DPanel` | Context panel for admin world actions. |
+| `DAdminMenu` | `DFrame` | Frame for managing admin tabs. |
 
 ---
 
@@ -628,3 +630,27 @@ Tiny button using `liaMiniFont` for dense interfaces.
 **Description:**
 
 Text-only button that still shows the underline animation.
+
+---
+
+### `DAdminWorldMenu`
+
+**Base Panel:**
+
+`DPanel`
+
+**Description:**
+
+Container panel used for context-sensitive admin actions in the world.
+
+---
+
+### `DAdminMenu`
+
+**Base Panel:**
+
+`DFrame`
+
+**Description:**
+
+Main window for the administrator interface. Populates its property sheet from `lia.admin.menu.tabs`.


### PR DESCRIPTION
## Summary
- document `DAdminWorldMenu` and `DAdminMenu` in the panel definitions

## Testing
- `luajit -b gamemode/core/derma/panels/panels.lua /dev/null` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687398fba74883279f600e4055003111