### PR TITLE
Adjust gamemode docs for moved modules

### DIFF
--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -396,7 +396,7 @@ When loading a module from a directory, Lilia automatically scans for common sub
 A complete example showing common fields in use:
 
 ```lua
--- example/modules/myfeature/module.lua
+-- example/gamemode/modules/myfeature/module.lua
 MODULE.name = "My Feature"
 MODULE.author = "76561198012345678"
 MODULE.discord = "@example"

--- a/documentation/docs/libraries/lia.logger.md
+++ b/documentation/docs/libraries/lia.logger.md
@@ -6,7 +6,7 @@ This page documents logging utilities.
 
 ## Overview
 
-The logger library writes structured log entries to the console and to the `lia_logs` SQL table (gamemode, category, text, character ID, SteamID). Built-in log types live in `modules/administration/submodules/logging/logs.lua`; custom types can be added with `lia.log.addType`.
+The logger library writes structured log entries to the console and to the `lia_logs` SQL table (gamemode, category, text, character ID, SteamID). Built-in log types live in `gamemode/modules/administration/submodules/logging/logs.lua`; custom types can be added with `lia.log.addType`.
 
 Each database row stores the timestamp, SteamID, and (if relevant) character ID so that every entry can be associated with a specific player.
 


### PR DESCRIPTION
## Summary
- fix logger documentation path for built-in log types
- update module.lua example path

## Testing
- `luacheck gamemode`

------
https://chatgpt.com/codex/tasks/task_e_68795c75ed64832782982dbee4aed532