### PR TITLE
Feat/icon16 support

### DIFF
--- a/gamemode/modules/administration/admin.lua
+++ b/gamemode/modules/administration/admin.lua
@@ -1,4 +1,4 @@
-lia.admin = lia.admin or {}
+﻿lia.admin = lia.admin or {}
 lia.admin.groups = lia.admin.groups or {}
 lia.admin.privileges = lia.admin.privileges or {}
 lia.admin.privilegeCategories = lia.admin.privilegeCategories or {}
@@ -14,15 +14,6 @@ lia.admin.DefaultGroups = {
     admin = 2,
     superadmin = 3
 }
-
-hook.Add("GetUsergroupIcon", "liaDefaultGroupIcons", function(groupName)
-    local defaults = {
-        ["user"] = "icon16/user.png",
-        ["admin"] = "icon16/star.png",
-        ["superadmin"] = "icon16/shield.png"
-    }
-    return defaults[tostring(groupName)] or "icon16/user.png"
-end)
 
 local defaultUserTools = {
     remover = true,
@@ -1665,8 +1656,7 @@ else
             privContainer:DockMargin(20, 20, 20, 20)
             privContainer.Paint = function() end
             buildPrivilegeList(privContainer, groupName, groups, editable)
-            local iconPath = hook.Run("GetUsergroupIcon", groupName) or "icon16/user.png"
-            local tabData = tabs:AddTab(groupName, tabPanel, iconPath)
+            local tabData = tabs:AddTab(groupName, tabPanel)
             tabData.groupName = groupName
             return tabData
         end

--- a/gamemode/modules/administration/admin.lua
+++ b/gamemode/modules/administration/admin.lua
@@ -1,4 +1,4 @@
-﻿lia.admin = lia.admin or {}
+lia.admin = lia.admin or {}
 lia.admin.groups = lia.admin.groups or {}
 lia.admin.privileges = lia.admin.privileges or {}
 lia.admin.privilegeCategories = lia.admin.privilegeCategories or {}
@@ -14,6 +14,15 @@ lia.admin.DefaultGroups = {
     admin = 2,
     superadmin = 3
 }
+
+hook.Add("GetUsergroupIcon", "liaDefaultGroupIcons", function(groupName)
+    local defaults = {
+        ["user"] = "icon16/user.png",
+        ["admin"] = "icon16/star.png",
+        ["superadmin"] = "icon16/shield.png"
+    }
+    return defaults[tostring(groupName)] or "icon16/user.png"
+end)
 
 local defaultUserTools = {
     remover = true,
@@ -1656,7 +1665,8 @@ else
             privContainer:DockMargin(20, 20, 20, 20)
             privContainer.Paint = function() end
             buildPrivilegeList(privContainer, groupName, groups, editable)
-            local tabData = tabs:AddTab(groupName, tabPanel)
+            local iconPath = hook.Run("GetUsergroupIcon", groupName) or "icon16/user.png"
+            local tabData = tabs:AddTab(groupName, tabPanel, iconPath)
             tabData.groupName = groupName
             return tabData
         end

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -1,4 +1,4 @@
-lia.chat.register("ic", {
+﻿lia.chat.register("ic", {
     arguments = {
         {
             name = "text",
@@ -225,25 +225,7 @@ lia.chat.register("looc", {
 
         speaker.liaLastLOOC = CurTime()
     end,
-    onChatAdd = function(speaker, text)
-        local iconObj
-        if IsValid(speaker) and speaker:IsPlayer() then
-            local iconPath = hook.Run("GetUsergroupIcon", speaker:GetUserGroup())
-            if iconPath then
-                iconObj = {
-                    GetName = function() return iconPath end,
-                    Width = function() return 16 end,
-                    Height = function() return 16 end
-                }
-            end
-        end
-
-        if iconObj then
-            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", iconObj, " ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
-        else
-            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
-        end
-    end,
+    onChatAdd = function(speaker, text) chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text) end,
     onCanHear = function(speaker, listener)
         if speaker == listener then return true end
         if speaker:EyePos():Distance(listener:EyePos()) <= lia.config.get("TalkRange", 280) then return true end
@@ -376,25 +358,7 @@ lia.chat.register("ooc", {
         speaker.liaLastOOC = CurTime()
     end,
     onCanHear = function() return true end,
-    onChatAdd = function(speaker, text)
-        local iconObj
-        if IsValid(speaker) and speaker:IsPlayer() then
-            local iconPath = hook.Run("GetUsergroupIcon", speaker:GetUserGroup())
-            if iconPath then
-                iconObj = {
-                    GetName = function() return iconPath end,
-                    Width = function() return 16 end,
-                    Height = function() return 16 end
-                }
-            end
-        end
-
-        if iconObj then
-            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", iconObj, " ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
-        else
-            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
-        end
-    end,
+    onChatAdd = function(speaker, text) chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text) end,
     prefix = {"//", "/ooc"},
     noSpaceAfter = true,
     filter = "ooc"

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -1,4 +1,4 @@
-﻿lia.chat.register("ic", {
+lia.chat.register("ic", {
     arguments = {
         {
             name = "text",
@@ -225,7 +225,25 @@ lia.chat.register("looc", {
 
         speaker.liaLastLOOC = CurTime()
     end,
-    onChatAdd = function(speaker, text) chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text) end,
+    onChatAdd = function(speaker, text)
+        local iconObj
+        if IsValid(speaker) and speaker:IsPlayer() then
+            local iconPath = hook.Run("GetUsergroupIcon", speaker:GetUserGroup())
+            if iconPath then
+                iconObj = {
+                    GetName = function() return iconPath end,
+                    Width = function() return 16 end,
+                    Height = function() return 16 end
+                }
+            end
+        end
+
+        if iconObj then
+            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", iconObj, " ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
+        else
+            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), "[" .. L("looc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
+        end
+    end,
     onCanHear = function(speaker, listener)
         if speaker == listener then return true end
         if speaker:EyePos():Distance(listener:EyePos()) <= lia.config.get("TalkRange", 280) then return true end
@@ -358,7 +376,25 @@ lia.chat.register("ooc", {
         speaker.liaLastOOC = CurTime()
     end,
     onCanHear = function() return true end,
-    onChatAdd = function(speaker, text) chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text) end,
+    onChatAdd = function(speaker, text)
+        local iconObj
+        if IsValid(speaker) and speaker:IsPlayer() then
+            local iconPath = hook.Run("GetUsergroupIcon", speaker:GetUserGroup())
+            if iconPath then
+                iconObj = {
+                    GetName = function() return iconPath end,
+                    Width = function() return 16 end,
+                    Height = function() return 16 end
+                }
+            end
+        end
+
+        if iconObj then
+            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", iconObj, " ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
+        else
+            chat.AddText((lia.color.theme and lia.color.theme.text) or Color(210, 235, 235), " [" .. L("ooc") .. "] ", (lia.color.theme and lia.color.theme.chat) or Color(255, 239, 150), speaker:Name(), ": " .. text)
+        end
+    end,
     prefix = {"//", "/ooc"},
     noSpaceAfter = true,
     filter = "ooc"


### PR DESCRIPTION
This PR introduces native support for displaying icon16 rank icons next to player names in Out-of-Character (OOC) and Local OOC (LOOC) chat, as well as beside usergroup names within the F1 Permissions menu.

To keep the framework modular and extensible, this implementation utilizes a new GetUsergroupIcon hook, allowing custom schemas to easily override and supply their own icons for custom ranks.

Changes Proposed
New Hook (GetUsergroupIcon): Added a default hook in the administration module that returns native icon16 fallback icons for the base usergroups (user: user.png, admin: star.png, superadmin: shield.png).
F1 Permissions UI: Updated the tabs:AddTab() UI builder within admin.lua to dynamically retrieve the group's icon via the hook and draw it to the left of the tab name.
Chatbox Module Integration: Modified the onChatAdd callback for both the ooc and looc chat classes in shared.lua. They now retrieve the speaker's rank icon via the hook and inject it as a native markup object into chat.AddText().